### PR TITLE
Support serving static files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = "1.0.117"
 mime = "0.3.17"
 owning_ref = "0.4.1"
 hyper-util = { features = ["tokio"], version = "0.1.3" }
+tokio-util = { features = ["io"], version = "0.7.11" }
 
 [dependencies.codegen]
 package = "via-codegen"

--- a/crates/via-router/src/iter.rs
+++ b/crates/via-router/src/iter.rs
@@ -128,6 +128,9 @@ impl<'a, 'b, T: Default> Iterator for Visit<'a, 'b, T> {
         }
 
         let Visit { node, path, .. } = self;
+        // Rather than returning early if there are no more path segments, we
+        // must provide a default value to support resolving immediate children
+        // of the root node.
         let (start, value) = path.next().unwrap_or((0, ""));
         let next = node.find(value)?;
 

--- a/crates/via-router/src/iter.rs
+++ b/crates/via-router/src/iter.rs
@@ -128,7 +128,7 @@ impl<'a, 'b, T: Default> Iterator for Visit<'a, 'b, T> {
         }
 
         let Visit { node, path, .. } = self;
-        let (start, value) = path.next()?;
+        let (start, value) = path.next().unwrap_or((0, ""));
         let next = node.find(value)?;
 
         *node = next;

--- a/crates/via-router/src/lib.rs
+++ b/crates/via-router/src/lib.rs
@@ -21,6 +21,13 @@ impl<'a, T: Default> Location<'a, T> {
         let mut segments = Path::segments(path);
         Location(self.0.insert(&mut segments))
     }
+
+    pub fn param(&self) -> Option<&'static str> {
+        match self.0.pattern {
+            Pattern::CatchAll(param) | Pattern::Dynamic(param) => Some(param),
+            _ => None,
+        }
+    }
 }
 
 impl<'a, T: Default> Deref for Location<'a, T> {

--- a/crates/via-serve-static/Cargo.toml
+++ b/crates/via-serve-static/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "via-serve-static"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+mime_guess = "2.0.4"
+tokio = { version = "1.37.0", features = ["fs"] }
+via = { path = "../.." }

--- a/crates/via-serve-static/src/lib.rs
+++ b/crates/via-serve-static/src/lib.rs
@@ -1,0 +1,97 @@
+use std::path::{Component, Path, PathBuf};
+use tokio::fs::{self, File};
+use via::prelude::*;
+
+pub struct ServeStatic {
+    root: PathBuf,
+}
+
+#[service]
+impl ServeStatic {
+    pub fn new<T>(path: T) -> Result<ServeStatic>
+    where
+        Error: From<T::Error>,
+        T: TryInto<PathBuf>,
+    {
+        let mut root = path.try_into()?;
+
+        if root.is_relative() {
+            root = normalize_path(&std::env::current_dir()?.join(root));
+        }
+
+        Ok(ServeStatic { root })
+    }
+
+    #[endpoint(GET, "/*path")]
+    async fn serve(&self, path: String, context: Context, next: Next) -> Result {
+        let absolute_path = self.root.join(path.trim_start_matches('/'));
+        let file_path = resolve_file_path(&absolute_path).await?;
+        let mut response = match try_open_file(&file_path).await? {
+            Some(file) => file.respond()?,
+            None => return next.call(context).await,
+        };
+
+        response.headers_mut().insert(
+            "Content-Type",
+            mime_guess::from_path(&file_path)
+                .first_or_octet_stream()
+                .to_string()
+                .parse()?,
+        );
+
+        Ok(response)
+    }
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut components = path.components().peekable();
+    let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek().cloned() {
+        components.next();
+        PathBuf::from(c.as_os_str())
+    } else {
+        PathBuf::new()
+    };
+
+    for component in components {
+        match component {
+            Component::Prefix(..) => unreachable!(),
+            Component::RootDir => {
+                ret.push(component.as_os_str());
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                ret.pop();
+            }
+            Component::Normal(c) => {
+                ret.push(c);
+            }
+        }
+    }
+    ret
+}
+
+async fn resolve_file_path(path: &Path) -> Result<PathBuf> {
+    let mut file_path = path.to_path_buf();
+
+    if file_path.is_dir() {
+        file_path = file_path.join("index.html");
+        if !fs::try_exists(&file_path).await? {
+            file_path = file_path.with_extension("htm");
+        }
+    }
+
+    Ok(file_path)
+}
+
+async fn try_open_file(path: &Path) -> Result<Option<File>> {
+    use std::io::ErrorKind;
+
+    match File::open(&path).await {
+        Ok(file) => Ok(Some(file)),
+        Err(error) => match error.kind() {
+            ErrorKind::PermissionDenied => Err(Error::from(error).status(403)),
+            ErrorKind::NotFound => Ok(None),
+            _ => Err(error.into()),
+        },
+    }
+}

--- a/crates/via-serve-static/src/lib.rs
+++ b/crates/via-serve-static/src/lib.rs
@@ -1,108 +1,25 @@
-use std::path::{Component, Path, PathBuf};
+use mime_guess::Mime;
+use std::{
+    fs::Metadata,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 use tokio::fs::{self, File};
-use via::{prelude::*, routing::Location};
+use via::{http::Method, prelude::*, routing::Location, BoxFuture};
 
 pub struct ServeStatic<'a> {
+    fall_through: bool,
     location: Location<'a>,
 }
 
-struct StaticServer {
+struct ServerConfig {
+    fall_through: bool,
     path_param: &'static str,
     public_dir: PathBuf,
 }
 
-impl<'a> ServeStatic<'a> {
-    pub fn new(location: Location<'a>) -> Self {
-        ServeStatic { location }
-    }
-
-    pub fn serve<T>(mut self, public_dir: T) -> Result<()>
-    where
-        Error: From<T::Error>,
-        T: TryInto<PathBuf>,
-    {
-        let mut public_dir = public_dir.try_into()?;
-        let path_param = match self.location.param() {
-            Some(param) => param,
-            None => via::bail!("location is missing path parameter"),
-        };
-
-        if public_dir.is_relative() {
-            let current_dir = std::env::current_dir()?;
-            public_dir = normalize_path(&current_dir.join(public_dir));
-        }
-
-        self.location.include(StaticServer {
-            path_param,
-            public_dir,
-        });
-
-        Ok(())
-    }
-}
-
-impl Middleware for StaticServer {
-    fn call(&self, context: Context, next: Next) -> via::BoxFuture<Result> {
-        let path_param = self.path_param;
-        let public_dir = self.public_dir.clone();
-
-        Box::pin(async move {
-            let path_param_value = context.params().get::<String>(path_param)?;
-            let absolute_path = public_dir.join(path_param_value.trim_start_matches('/'));
-            let file_path = resolve_file_path(&absolute_path).await?;
-            let file = match try_open_file(&file_path).await? {
-                Some(file) => file,
-                None => return next.call(context).await,
-            };
-
-            file.respond()?.with_header(
-                "Content-Type",
-                mime_guess::from_path(&file_path)
-                    .first_or_octet_stream()
-                    .to_string(),
-            )
-        })
-    }
-}
-
-fn normalize_path(path: &Path) -> PathBuf {
-    let mut components = path.components().peekable();
-    let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek().cloned() {
-        components.next();
-        PathBuf::from(c.as_os_str())
-    } else {
-        PathBuf::new()
-    };
-
-    for component in components {
-        match component {
-            Component::Prefix(..) => unreachable!(),
-            Component::RootDir => {
-                ret.push(component.as_os_str());
-            }
-            Component::CurDir => {}
-            Component::ParentDir => {
-                ret.pop();
-            }
-            Component::Normal(c) => {
-                ret.push(c);
-            }
-        }
-    }
-    ret
-}
-
-async fn resolve_file_path(path: &Path) -> Result<PathBuf> {
-    let mut file_path = path.to_path_buf();
-
-    if file_path.is_dir() {
-        file_path = file_path.join("index.html");
-        if !fs::try_exists(&file_path).await? {
-            file_path = file_path.with_extension("htm");
-        }
-    }
-
-    Ok(file_path)
+struct StaticServer {
+    config: Arc<ServerConfig>,
 }
 
 async fn try_open_file(path: &Path) -> Result<Option<File>> {
@@ -115,5 +32,164 @@ async fn try_open_file(path: &Path) -> Result<Option<File>> {
             ErrorKind::NotFound => Ok(None),
             _ => Err(error.into()),
         },
+    }
+}
+
+async fn try_read_metadata(path: &Path) -> Result<Option<Metadata>> {
+    use std::io::ErrorKind;
+
+    match fs::metadata(path).await {
+        Ok(file) => Ok(Some(file)),
+        Err(error) => match error.kind() {
+            ErrorKind::PermissionDenied => Err(Error::from(error).status(403)),
+            ErrorKind::NotFound => Ok(None),
+            _ => Err(error.into()),
+        },
+    }
+}
+
+impl<'a> ServeStatic<'a> {
+    /// Returns a builder struct used to configure the static server middleware. The location
+    /// provided must have a path parameter.
+    pub fn new(location: Location<'a>) -> Self {
+        ServeStatic {
+            fall_through: true,
+            location,
+        }
+    }
+
+    /// Configures whether or not to fall through to the next middleware if a file
+    /// is not found or if the request is made with unsupported HTTP method. The
+    /// default value is `true`.
+    pub fn fall_through(mut self, fall_through: bool) -> Self {
+        self.fall_through = fall_through;
+        self
+    }
+
+    /// Attempts to add the static server middleware at the provided `location`. If
+    /// the provided `public_dir` is a relative path, it will be resolved relative to
+    /// the current working directory. If the `public_dir` is not a directory or the
+    /// `location` does not have a path parameter, an error will be returned.
+    pub fn serve<T>(mut self, public_dir: T) -> Result<()>
+    where
+        Error: From<T::Error>,
+        T: TryInto<PathBuf>,
+    {
+        let mut public_dir: PathBuf = public_dir.try_into()?;
+        let fall_through = self.fall_through;
+        let path_param = match self.location.param() {
+            Some(param) => param,
+            None => via::bail!("location is missing path parameter"),
+        };
+
+        if public_dir.is_relative() {
+            let current_dir = std::env::current_dir()?;
+            public_dir = current_dir.join(public_dir).canonicalize()?;
+        }
+
+        self.location.include(StaticServer {
+            config: Arc::new(ServerConfig {
+                fall_through,
+                path_param,
+                public_dir,
+            }),
+        });
+
+        Ok(())
+    }
+}
+
+impl StaticServer {
+    /// Returns an absolute path based on the relative path extracted from the
+    /// path parameter.
+    fn expand_path(&self, path: &str) -> PathBuf {
+        self.config.public_dir.join(path.trim_start_matches('/'))
+    }
+
+    /// Extracts the value of the path parameter from the context.
+    fn extract_path_param(&self, context: &Context) -> Result<String> {
+        Ok(context.params().get(self.config.path_param)?)
+    }
+
+    /// Either falls through to the next middleware or returns a 404 response
+    /// depending on the value of the `fall_through` field in the configuration.
+    async fn handle_not_found(&self, context: Context, next: Next) -> Result {
+        if self.config.fall_through {
+            next.call(context).await
+        } else {
+            "Not Found".with_status(404)
+        }
+    }
+
+    /// Locates the file based on the path parameter extracted from the context.
+    /// If the path parameter is a directory, it will attempt to locate an index
+    /// file.
+    async fn locate_file(&self, context: &Context) -> Result<(Mime, PathBuf)> {
+        let path_param_value = self.extract_path_param(&context)?;
+        let mut file_path = self.expand_path(&path_param_value);
+
+        if file_path.is_dir() {
+            file_path = file_path.join("index.html");
+            // Eagerly determine whether or not index.html exists in order to
+            // support the alternative index.htm extension.
+            if !fs::try_exists(&file_path).await? {
+                file_path = file_path.with_extension("htm");
+            }
+        }
+
+        Ok((
+            mime_guess::from_path(&file_path).first_or_octet_stream(),
+            file_path,
+        ))
+    }
+
+    async fn respond_to_get_request(&self, context: Context, next: Next) -> Result {
+        let (mime_type, file_path) = self.locate_file(&context).await?;
+        let file = match try_open_file(&file_path).await? {
+            Some(file) => file,
+            None => return self.handle_not_found(context, next).await,
+        };
+
+        file.with_header("Content-Type", mime_type.to_string())
+    }
+
+    async fn respond_to_head_request(&self, context: Context, next: Next) -> Result {
+        let (mime_type, file_path) = self.locate_file(&context).await?;
+        let metadata = match try_read_metadata(&file_path).await? {
+            Some(metadata) => metadata,
+            None => return self.handle_not_found(context, next).await,
+        };
+
+        Response::empty()
+            .with_header("Content-Type", mime_type.to_string())
+            .with_header("Content-Length", metadata.len().to_string())
+    }
+}
+
+impl Clone for StaticServer {
+    fn clone(&self) -> Self {
+        StaticServer {
+            config: Arc::clone(&self.config),
+        }
+    }
+}
+
+impl Middleware for StaticServer {
+    fn call(&self, context: Context, next: Next) -> BoxFuture<Result> {
+        let middleware = StaticServer {
+            config: Arc::clone(&self.config),
+        };
+
+        Box::pin(async move {
+            if context.method() == Method::GET {
+                middleware.respond_to_get_request(context, next).await
+            } else if context.method() == Method::HEAD {
+                middleware.respond_to_head_request(context, next).await
+            } else if middleware.config.fall_through {
+                next.call(context).await
+            } else {
+                "Method Not Allowed".with_status(405)
+            }
+        })
     }
 }

--- a/docs/examples/advanced-blog/src/services/api/error.rs
+++ b/docs/examples/advanced-blog/src/services/api/error.rs
@@ -21,7 +21,7 @@ fn catch(error: Error) -> Result {
             let status = u16::from(DatabaseErrorCode { kind });
             Err(error.status(status).json())
         }
-        Some(DieselError::NotFound) => Document::new(()).status(404).respond(),
+        Some(DieselError::NotFound) => Document::new(()).with_status(404).respond(),
         Some(_) | None => Err(error.json()),
     }
 }

--- a/docs/examples/advanced-blog/src/services/api/users.rs
+++ b/docs/examples/advanced-blog/src/services/api/users.rs
@@ -31,7 +31,7 @@ impl UserService {
 
     #[endpoint(PATCH, "/")]
     async fn update(&self, id: i32, mut context: Context) -> Result<impl Respond> {
-        let body: Document<ChangeSet> = context.read().json().await?;
+        let _body: Document<ChangeSet> = context.read().json().await?;
         Ok(format!("Update User: {}", id))
     }
 

--- a/docs/examples/hello-world/Cargo.toml
+++ b/docs/examples/hello-world/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2021"
 [dependencies]
 tokio = { features = ["full"], version = "1.37.0" }
 via = { path = "../../.." }
+via-serve-static = { path = "../../../crates/via-serve-static" }

--- a/docs/examples/hello-world/public/index.html
+++ b/docs/examples/hello-world/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Hello, world!</title>
+    </head>
+    <body>
+        <h1>Hello, world!</h1>
+    </body>
+</html>

--- a/docs/examples/hello-world/src/main.rs
+++ b/docs/examples/hello-world/src/main.rs
@@ -1,4 +1,5 @@
 use via::prelude::*;
+use via_serve_static::ServeStatic;
 
 struct Routes;
 
@@ -23,7 +24,7 @@ impl Routes {
     }
 }
 
-async fn logger(context: Context, next: Next) -> Result<impl Respond> {
+async fn logger(context: Context, next: Next) -> Result {
     let path = context.uri().path().to_string();
     let method = context.method().clone();
 
@@ -43,7 +44,9 @@ async fn main() -> Result<()> {
     let mut app = via::new();
 
     app.include(logger);
+
     app.delegate(Routes);
+    app.delegate(ServeStatic::new("./public")?);
 
     app.listen(("0.0.0.0", 8080)).await
 }

--- a/docs/examples/macro-free/src/main.rs
+++ b/docs/examples/macro-free/src/main.rs
@@ -5,10 +5,13 @@ async fn main() -> Result<()> {
     let mut app = via::new();
 
     app.include(logger);
-    app.at("/hello/:name").get(|context: Context, _| async move {
-        let name = context.params().get::<String>("name")?;
-        Ok::<_, Error>(format!("Hello, {}", name))
-    });
+    app.at("/hello/:name")
+        .get(|context: Context, _| async move {
+            let name = context.params().get::<String>("name")?;
+            Ok::<_, Error>(format!("Hello, {}", name))
+        });
+
+    println!("PARAM: {:#?}", app.at("/*path").param());
 
     app.listen(("0.0.0.0", 8080)).await
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,7 @@ use std::{
     fmt::{self, Debug, Display, Formatter},
 };
 
+pub type AnyError = Box<dyn StdError + Send + Sync + 'static>;
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 pub type Source = (dyn StdError + 'static);
 
@@ -17,7 +18,7 @@ pub trait ResultExt<T> {
 #[derive(Debug)]
 pub struct Error {
     format: Option<Format>,
-    source: Box<dyn StdError + Send>,
+    source: AnyError,
     status: u16,
 }
 
@@ -102,7 +103,7 @@ impl Display for Error {
 
 impl<T> From<T> for Error
 where
-    T: StdError + Send + 'static,
+    T: StdError + Send + Sync + 'static,
 {
     fn from(value: T) -> Self {
         Error {
@@ -110,6 +111,12 @@ where
             source: Box::new(value),
             status: 500,
         }
+    }
+}
+
+impl From<Error> for AnyError {
+    fn from(error: Error) -> Self {
+        error.source
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -48,6 +48,12 @@ fn respond(error: Error) -> Result<Response> {
     Ok(response)
 }
 
+impl Bail {
+    pub fn new(message: String) -> Bail {
+        Bail { message }
+    }
+}
+
 impl Debug for Bail {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         Debug::fmt(&self.message, f)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,8 +118,6 @@ impl Application {
                 }
             });
         }
-
-        // Ok(server.with_graceful_shutdown(ctrlc).await?)
     }
 
     fn call(&self, request: HttpRequest) -> CallFuture {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,7 @@
 #[macro_export]
 macro_rules! bail {
     ($($tokens:tt)+) => {
-        Err($crate::error::Bail {
-            message: format!($($tokens)+)
-        })?
+        Err($crate::error::Bail::new(format!($($tokens)+)))?
     };
 }
 

--- a/src/middleware/handler.rs
+++ b/src/middleware/handler.rs
@@ -35,7 +35,7 @@ impl Next {
         if let Some(middleware) = self.stack.pop_front() {
             middleware.call(context, self)
         } else {
-            Box::pin(async { "Not Found".status(404).respond() })
+            Box::pin(async { "Not Found".with_status(404).respond() })
         }
     }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,7 +1,9 @@
-use super::{Application, CallFuture, HttpRequest, HttpResponse};
 use futures::future::{ready, Ready};
 use hyper::service::Service as HyperService;
 use std::{convert, sync::Arc};
+
+use super::{Application, CallFuture, HttpRequest, HttpResponse};
+use crate::{Error, Result};
 
 pub struct MakeService {
     service: Service,
@@ -20,8 +22,8 @@ impl From<Application> for MakeService {
 }
 
 impl<T> HyperService<T> for MakeService {
-    type Error = crate::Error;
-    type Future = Ready<crate::Result<Self::Response>>;
+    type Error = Error;
+    type Future = Ready<Result<Self::Response>>;
     type Response = Service;
 
     fn call(&self, _: T) -> Self::Future {

--- a/src/service.rs
+++ b/src/service.rs
@@ -3,8 +3,6 @@ use futures::future::{ready, Ready};
 use hyper::service::Service as HyperService;
 use std::{convert, sync::Arc};
 
-type Result<T = ()> = crate::Result<T, convert::Infallible>;
-
 pub struct MakeService {
     service: Service,
 }
@@ -22,8 +20,8 @@ impl From<Application> for MakeService {
 }
 
 impl<T> HyperService<T> for MakeService {
-    type Error = convert::Infallible;
-    type Future = Ready<Result<Self::Response>>;
+    type Error = crate::Error;
+    type Future = Ready<crate::Result<Self::Response>>;
     type Response = Service;
 
     fn call(&self, _: T) -> Self::Future {


### PR DESCRIPTION
Adds support for serving static files with the `via-serve-static` crate by making the following changes:

- Adds a `Body` enum to support streaming responses.
- Adds a `param` method to `Location` to enable middleware authors to use dynamic path parameters without having use macros.
- Implements `Respond` for `tokio::fs::File`. A similar approach can be used  in the future if we need to implement respond for other types that implement `AsyncRead`.
- Creates a `via-serve-static` crate with the actual implementation of the static file server.
 