### PR TITLE
feat: support streaming request bodies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ default = []
 serde = ["dep:serde", "dep:serde_json"]
 
 [dependencies]
-bytes = "1.7.0"
+bytes = "1.7"
 futures-util = { version = "0.3", default-features = false }
 http = "1"
 hyper-util = { version = "0.1", features = ["tokio"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ serde = ["dep:serde", "dep:serde_json"]
 
 [dependencies]
 bytes = "1.7"
-futures-util = { version = "0.3", default-features = false }
+futures-core = { version = "0.3", default-features = false }
 http = "1"
 hyper-util = { version = "0.1", features = ["tokio"] }
 percent-encoding = "2.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,9 @@ default = []
 serde = ["dep:serde", "dep:serde_json"]
 
 [dependencies]
+bytes = "1.7.0"
 futures-util = { version = "0.3", default-features = false }
 http = "1"
-http-body = "1"
-http-body-util = "0.1"
 hyper-util = { version = "0.1", features = ["tokio"] }
 percent-encoding = "2.3"
 tokio = "1"

--- a/crates/via-serve-static/Cargo.toml
+++ b/crates/via-serve-static/Cargo.toml
@@ -12,7 +12,7 @@ etag-sha256 = ["dep:sha2"]
 
 [dependencies]
 bitflags = "2.6"
-futures-util = { version = "0.3", default-features = false }
+futures-core = { version = "0.3", default-features = false }
 httpdate = "1.0"
 md-5 = { version = "0.10", optional = true }
 mime_guess = "2.0"

--- a/crates/via-serve-static/src/respond.rs
+++ b/crates/via-serve-static/src/respond.rs
@@ -114,7 +114,7 @@ fn build_path_from_request<State>(
     request: &Request<State>,
     config: &ServerConfig,
 ) -> Result<PathBuf> {
-    let path_param = request.param(&config.path_param).required()?;
+    let path_param = request.param(config.path_param).required()?;
     Ok(config.public_dir.join(path_param.trim_end_matches('/')))
 }
 

--- a/crates/via-serve-static/src/stream_file.rs
+++ b/crates/via-serve-static/src/stream_file.rs
@@ -1,4 +1,4 @@
-use futures_util::Stream;
+use futures_core::Stream;
 use std::{
     fs::File,
     io::{self, Read},

--- a/docs/examples/blog-api/src/api/posts.rs
+++ b/docs/examples/blog-api/src/api/posts.rs
@@ -15,7 +15,7 @@ pub async fn index(request: Request, _: Next) -> Result<Response> {
 }
 
 pub async fn create(mut request: Request, _: Next) -> Result<Response> {
-    let body: Payload<NewPost> = request.take_body()?.into_json().await?;
+    let body: Payload<NewPost> = request.take_body()?.read_json().await?;
     let post = body.data.insert(&request.state().pool).await?;
 
     Response::json(&Payload::new(post)).finish()
@@ -30,7 +30,7 @@ pub async fn show(request: Request, _: Next) -> Result<Response> {
 
 pub async fn update(mut request: Request, _: Next) -> Result<Response> {
     let id = request.param("id").parse::<i32>()?;
-    let body: Payload<ChangeSet> = request.take_body()?.into_json().await?;
+    let body: Payload<ChangeSet> = request.take_body()?.read_json().await?;
     let post = body.data.apply(&request.state().pool, id).await?;
 
     Response::json(&Payload::new(post)).finish()

--- a/docs/examples/blog-api/src/api/posts.rs
+++ b/docs/examples/blog-api/src/api/posts.rs
@@ -15,7 +15,7 @@ pub async fn index(request: Request, _: Next) -> Result<Response> {
 }
 
 pub async fn create(mut request: Request, _: Next) -> Result<Response> {
-    let body: Payload<NewPost> = request.body_mut().into_json().await?;
+    let body: Payload<NewPost> = request.take_body()?.into_json().await?;
     let post = body.data.insert(&request.state().pool).await?;
 
     Response::json(&Payload::new(post)).finish()
@@ -30,7 +30,7 @@ pub async fn show(request: Request, _: Next) -> Result<Response> {
 
 pub async fn update(mut request: Request, _: Next) -> Result<Response> {
     let id = request.param("id").parse::<i32>()?;
-    let body: Payload<ChangeSet> = request.body_mut().into_json().await?;
+    let body: Payload<ChangeSet> = request.take_body()?.into_json().await?;
     let post = body.data.apply(&request.state().pool, id).await?;
 
     Response::json(&Payload::new(post)).finish()

--- a/docs/examples/blog-api/src/api/posts.rs
+++ b/docs/examples/blog-api/src/api/posts.rs
@@ -15,7 +15,7 @@ pub async fn index(request: Request, _: Next) -> Result<Response> {
 }
 
 pub async fn create(mut request: Request, _: Next) -> Result<Response> {
-    let body: Payload<NewPost> = request.body_mut().read_to_json().await?;
+    let body: Payload<NewPost> = request.body_mut().into_json().await?;
     let post = body.data.insert(&request.state().pool).await?;
 
     Response::json(&Payload::new(post)).finish()
@@ -30,7 +30,7 @@ pub async fn show(request: Request, _: Next) -> Result<Response> {
 
 pub async fn update(mut request: Request, _: Next) -> Result<Response> {
     let id = request.param("id").parse::<i32>()?;
-    let body: Payload<ChangeSet> = request.body_mut().read_to_json().await?;
+    let body: Payload<ChangeSet> = request.body_mut().into_json().await?;
     let post = body.data.apply(&request.state().pool, id).await?;
 
     Response::json(&Payload::new(post)).finish()

--- a/docs/examples/blog-api/src/api/posts.rs
+++ b/docs/examples/blog-api/src/api/posts.rs
@@ -15,7 +15,7 @@ pub async fn index(request: Request, _: Next) -> Result<Response> {
 }
 
 pub async fn create(mut request: Request, _: Next) -> Result<Response> {
-    let body: Payload<NewPost> = request.body_mut().read_json().await?;
+    let body: Payload<NewPost> = request.body_mut().read_to_json().await?;
     let post = body.data.insert(&request.state().pool).await?;
 
     Response::json(&Payload::new(post)).finish()
@@ -30,7 +30,7 @@ pub async fn show(request: Request, _: Next) -> Result<Response> {
 
 pub async fn update(mut request: Request, _: Next) -> Result<Response> {
     let id = request.param("id").parse::<i32>()?;
-    let body: Payload<ChangeSet> = request.body_mut().read_json().await?;
+    let body: Payload<ChangeSet> = request.body_mut().read_to_json().await?;
     let post = body.data.apply(&request.state().pool, id).await?;
 
     Response::json(&Payload::new(post)).finish()

--- a/docs/examples/blog-api/src/api/users.rs
+++ b/docs/examples/blog-api/src/api/users.rs
@@ -10,7 +10,7 @@ pub async fn index(request: Request, _: Next) -> Result<Response> {
 }
 
 pub async fn create(mut request: Request, _: Next) -> Result<Response> {
-    let body: Payload<NewUser> = request.take_body()?.into_json().await?;
+    let body: Payload<NewUser> = request.take_body()?.read_json().await?;
     let user = body.data.insert(&request.state().pool).await?;
 
     Response::json(&Payload::new(user)).finish()
@@ -25,7 +25,7 @@ pub async fn show(request: Request, _: Next) -> Result<Response> {
 
 pub async fn update(mut request: Request, _: Next) -> Result<Response> {
     let id = request.param("id").parse::<i32>()?;
-    let body: Payload<ChangeSet> = request.take_body()?.into_json().await?;
+    let body: Payload<ChangeSet> = request.take_body()?.read_json().await?;
     let user = body.data.apply(&request.state().pool, id).await?;
 
     Response::json(&Payload::new(user)).finish()

--- a/docs/examples/blog-api/src/api/users.rs
+++ b/docs/examples/blog-api/src/api/users.rs
@@ -10,7 +10,7 @@ pub async fn index(request: Request, _: Next) -> Result<Response> {
 }
 
 pub async fn create(mut request: Request, _: Next) -> Result<Response> {
-    let body: Payload<NewUser> = request.body_mut().read_json().await?;
+    let body: Payload<NewUser> = request.body_mut().read_to_json().await?;
     let user = body.data.insert(&request.state().pool).await?;
 
     Response::json(&Payload::new(user)).finish()
@@ -25,7 +25,7 @@ pub async fn show(request: Request, _: Next) -> Result<Response> {
 
 pub async fn update(mut request: Request, _: Next) -> Result<Response> {
     let id = request.param("id").parse::<i32>()?;
-    let body: Payload<ChangeSet> = request.body_mut().read_json().await?;
+    let body: Payload<ChangeSet> = request.body_mut().read_to_json().await?;
     let user = body.data.apply(&request.state().pool, id).await?;
 
     Response::json(&Payload::new(user)).finish()

--- a/docs/examples/blog-api/src/api/users.rs
+++ b/docs/examples/blog-api/src/api/users.rs
@@ -10,7 +10,7 @@ pub async fn index(request: Request, _: Next) -> Result<Response> {
 }
 
 pub async fn create(mut request: Request, _: Next) -> Result<Response> {
-    let body: Payload<NewUser> = request.body_mut().read_to_json().await?;
+    let body: Payload<NewUser> = request.body_mut().into_json().await?;
     let user = body.data.insert(&request.state().pool).await?;
 
     Response::json(&Payload::new(user)).finish()
@@ -25,7 +25,7 @@ pub async fn show(request: Request, _: Next) -> Result<Response> {
 
 pub async fn update(mut request: Request, _: Next) -> Result<Response> {
     let id = request.param("id").parse::<i32>()?;
-    let body: Payload<ChangeSet> = request.body_mut().read_to_json().await?;
+    let body: Payload<ChangeSet> = request.body_mut().into_json().await?;
     let user = body.data.apply(&request.state().pool, id).await?;
 
     Response::json(&Payload::new(user)).finish()

--- a/docs/examples/blog-api/src/api/users.rs
+++ b/docs/examples/blog-api/src/api/users.rs
@@ -10,7 +10,7 @@ pub async fn index(request: Request, _: Next) -> Result<Response> {
 }
 
 pub async fn create(mut request: Request, _: Next) -> Result<Response> {
-    let body: Payload<NewUser> = request.body_mut().into_json().await?;
+    let body: Payload<NewUser> = request.take_body()?.into_json().await?;
     let user = body.data.insert(&request.state().pool).await?;
 
     Response::json(&Payload::new(user)).finish()
@@ -25,7 +25,7 @@ pub async fn show(request: Request, _: Next) -> Result<Response> {
 
 pub async fn update(mut request: Request, _: Next) -> Result<Response> {
     let id = request.param("id").parse::<i32>()?;
-    let body: Payload<ChangeSet> = request.body_mut().into_json().await?;
+    let body: Payload<ChangeSet> = request.take_body()?.into_json().await?;
     let user = body.data.apply(&request.state().pool, id).await?;
 
     Response::json(&Payload::new(user)).finish()

--- a/docs/examples/echo-server/src/main.rs
+++ b/docs/examples/echo-server/src/main.rs
@@ -2,7 +2,7 @@ use via::{http::header, Event, Next, Request, Response, Result};
 
 async fn echo(mut request: Request, _: Next) -> Result<Response> {
     // Get a stream of bytes from the request body.
-    let body_stream = request.body_mut().into_stream()?;
+    let body_stream = request.take_body()?.into_stream();
     // Optionally get the Content-Type header from the request.
     let content_type = request
         .headers()

--- a/docs/examples/echo-server/src/main.rs
+++ b/docs/examples/echo-server/src/main.rs
@@ -2,7 +2,7 @@ use via::{http::header, Event, Next, Request, Response, Result};
 
 async fn echo(mut request: Request, _: Next) -> Result<Response> {
     // Get a stream of bytes from the request body.
-    let body_stream = request.body_mut().to_stream()?;
+    let body_stream = request.body_mut().into_stream()?;
     // Optionally get the Content-Type header from the request.
     let content_type = request
         .headers()

--- a/docs/examples/hello-world/src/main.rs
+++ b/docs/examples/hello-world/src/main.rs
@@ -1,6 +1,6 @@
-use via::{Event, Next, Request, Response, Result};
+use via::{Event, Next, Request, Result};
 
-async fn hello(request: Request, _: Next) -> Result<Response> {
+async fn hello(request: Request, _: Next) -> Result<String> {
     // Get a reference to the path parameter `name` from the request uri.
     let name = request.param("name").required()?;
     //                               ^^^^^^^^
@@ -14,7 +14,7 @@ async fn hello(request: Request, _: Next) -> Result<Response> {
 
     // Send a plain text response with a greeting that includes the name from
     // the request's uri path.
-    Response::text(format!("Hello, {}!", name)).finish()
+    Ok(format!("Hello, {}!", name))
 }
 
 #[tokio::main]

--- a/docs/examples/shared-state/src/main.rs
+++ b/docs/examples/shared-state/src/main.rs
@@ -2,47 +2,86 @@ use std::sync::{
     atomic::{AtomicU32, Ordering},
     Arc,
 };
-use via::{Error, Event, Response, Result};
+use via::{http::StatusCode, Event, Response, Result};
 
+// Define a type alias for the `via::Request` to include the `Counter` state.
+// This is a convenience to avoid having to write out the full type signature.
 type Request = via::Request<Counter>;
+
+// Define a type alias for the `via::Next` to include the `Counter` state. This
+// is a convenience to avoid having to write out the full type signature.
 type Next = via::Next<Counter>;
 
+/// A struct of containing the shared state for the application. This struct
+/// will be made available to all middleware functions and responders by
+/// calling the `state` method on the `Request` struct.
 struct Counter {
+    /// The number of responses that had a status code in the 1XX-3XX range.
     sucesses: Arc<AtomicU32>,
+
+    /// The number of responses that had a status code in the 4XX-5XX range.
     errors: Arc<AtomicU32>,
+}
+
+// Define a helper function to check if a status code is in the 4XX-5XX range.
+fn status_is_error(status: StatusCode) -> bool {
+    status.is_client_error() || status.is_server_error()
+}
+
+/// A middleware function that will either increment the `successes` or
+/// `errors` field of the `Counter` state based on the response status.
+async fn counter(request: Request, next: Next) -> Result<Response> {
+    // Clone the `Counter` state by incrementing the reference count of the
+    // outer `Arc`. This will allow us to modify the `state` after we pass
+    // ownership of `request` to the `next` middleware.
+    let state = Arc::clone(request.state());
+    // Call the next middleware in the app and await the response.
+    let response = next.call(request).await?;
+
+    if status_is_error(response.status()) {
+        // The status is in the 4XX-5XX range. Increment the `errors` field.
+        state.errors.fetch_add(1, Ordering::Relaxed);
+    } else {
+        // The status is in the 1XX-3XX range. Increment the `successes` field.
+        state.sucesses.fetch_add(1, Ordering::Relaxed);
+    }
+
+    Ok(response)
+}
+
+/// A responder that will return the total number of `successes` and `errors`
+/// in the `Counter` state.
+async fn totals(request: Request, _: Next) -> Result<String> {
+    // Get a reference to the `Counter` state from the request. We don't need
+    // to clone the state since we are consuming the request rather than
+    // passing it as an argument to `next.call`.
+    let state = request.state();
+    // Load the current value of `errors` from the atomic integer.
+    let errors = state.errors.load(Ordering::Relaxed);
+    // Load the current value of `successes` from the atomic integer.
+    let successes = state.sucesses.load(Ordering::Relaxed);
+
+    // Return a string with the total number of `errors` and `successes`.
+    Ok(format!("Errors: {}\nSucesses: {}", errors, successes))
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Create a new application with a `Counter` as state.
     let mut app = via::app(Counter {
         errors: Arc::new(AtomicU32::new(0)),
         sucesses: Arc::new(AtomicU32::new(0)),
     });
 
-    app.include(|request: Request, next: Next| async {
-        let state = Arc::clone(request.state());
-        let response = next.call(request).await?;
+    // Add the `counter` middleware to the application. Since we are not
+    // specifying an endpoint with the `at` method, this middleware will
+    // be applied to all requests.
+    app.include(counter);
 
-        if response.status().is_success() {
-            state.sucesses.fetch_add(1, Ordering::Relaxed);
-        } else {
-            state.errors.fetch_add(1, Ordering::Relaxed);
-        }
+    // Add the `totals` responder to the endpoint GET /totals.
+    app.at("/totals").respond(via::get(totals));
 
-        Ok::<_, Error>(response)
-    });
-
-    app.at("/counter").respond(via::get(|request: Request, _: Next| async move {
-        let state = request.state();
-        let body = format!(
-            "Errors: {}\nSucesses: {}",
-            state.errors.load(Ordering::Relaxed),
-            state.sucesses.load(Ordering::Relaxed)
-        );
-
-        Response::text(body).finish()
-    }));
-
+    // Start the server.
     app.listen(("127.0.0.1", 8080), |event| match event {
         Event::ConnectionError(error) | Event::UncaughtError(error) => {
             eprintln!("Error: {}", error);

--- a/src/middleware/middleware.rs
+++ b/src/middleware/middleware.rs
@@ -1,7 +1,7 @@
 use std::{future::Future, pin::Pin, sync::Arc};
 
 use super::Next;
-use crate::{Request, Response, Result};
+use crate::{response::IntoResponse, Request, Response, Result};
 
 pub(crate) type ArcMiddleware<State> = Arc<dyn Middleware<State>>;
 pub type BoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send + 'static>>;
@@ -13,9 +13,11 @@ pub trait Middleware<State>: Send + Sync + 'static {
 impl<State, T, F> Middleware<State> for T
 where
     T: Fn(Request<State>, Next<State>) -> F + Send + Sync + 'static,
-    F: Future<Output = Result<Response>> + Send + 'static,
+    F: Future + Send + 'static,
+    F::Output: IntoResponse,
 {
     fn call(&self, request: Request<State>, next: Next<State>) -> BoxFuture<Result<Response>> {
-        Box::pin(self(request, next))
+        let future = self(request, next);
+        Box::pin(async { future.await.into_response() })
     }
 }

--- a/src/request/body.rs
+++ b/src/request/body.rs
@@ -1,4 +1,4 @@
-use bytes::{BufMut, Bytes, BytesMut};
+use bytes::Bytes;
 use futures_core::Stream;
 use hyper::body::{Body as BodyTrait, Incoming};
 use std::{
@@ -9,52 +9,57 @@ use std::{
 
 use crate::{Error, Result};
 
+const MAX_BUFFER_SIZE: usize = isize::MAX as usize;
+
 #[derive(Debug)]
 pub struct Body {
-    inner: Option<Box<Incoming>>,
+    inner: Box<Incoming>,
     len: Option<usize>,
 }
 
 #[must_use = "streams do nothing unless polled"]
 pub struct BodyStream {
-    body: Box<Incoming>,
+    body: Pin<Box<Incoming>>,
 }
 
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct ReadIntoBytes {
-    buffer: BytesMut,
+    buffer: Vec<u8>,
     stream: BodyStream,
 }
 
 /// Conditionally reserves `additional` capacity for `bytes` if the current
 /// capacity is less than additional. Returns an error if `capacity + additional`
-/// would overflow `usize`.
-fn try_reserve(bytes: &mut BytesMut, additional: usize) -> Result<()> {
+/// would overflow `isize`.
+fn try_reserve(bytes: &mut Vec<u8>, additional: usize) -> Result<()> {
     let capacity = bytes.capacity();
 
-    if capacity < additional && capacity.checked_add(additional).is_some() {
-        bytes.reserve(additional);
+    if capacity >= additional {
+        // The buffer has enough capacity. Return without reallocating.
         return Ok(());
     }
 
-    Err(Error::new(
-        "failed to reserve enough capacity for the next frame.".to_owned(),
-    ))
+    match capacity.checked_add(additional) {
+        Some(total) if total <= MAX_BUFFER_SIZE => {
+            bytes.reserve(additional);
+            Ok(())
+        }
+        _ => Err(Error::new(
+            "failed to reserve enough capacity for the next frame.".to_owned(),
+        )),
+    }
 }
 
 impl Body {
-    pub async fn into_bytes(&mut self) -> Result<Bytes> {
-        let stream = self.into_stream()?;
+    pub async fn into_bytes(self) -> Result<Vec<u8>> {
+        let buffer = self.len.map(Vec::with_capacity).unwrap_or_default();
+        let stream = self.into_stream();
 
-        if let Some(capacity) = self.len {
-            ReadIntoBytes::with_capacity(stream, capacity).await
-        } else {
-            ReadIntoBytes::new(stream).await
-        }
+        (ReadIntoBytes { buffer, stream }).await
     }
 
     #[cfg(feature = "serde")]
-    pub async fn into_json<T>(&mut self) -> Result<T>
+    pub async fn into_json<T>(self) -> Result<T>
     where
         T: serde::de::DeserializeOwned,
     {
@@ -69,15 +74,16 @@ impl Body {
         })
     }
 
-    pub async fn into_string(&mut self) -> Result<String> {
+    pub async fn into_string(self) -> Result<String> {
         let buffer = self.into_bytes().await?;
-        Ok(String::from_utf8(Vec::from(buffer))?)
+        let string = String::from_utf8(buffer)?;
+
+        Ok(string)
     }
 
-    pub fn into_stream(&mut self) -> Result<BodyStream> {
-        match self.inner.take() {
-            Some(incoming) => Ok(BodyStream::new(incoming)),
-            None => Err(Error::new("body has already been read".to_owned())),
+    pub fn into_stream(self) -> BodyStream {
+        BodyStream {
+            body: Box::into_pin(self.inner),
         }
     }
 }
@@ -85,30 +91,15 @@ impl Body {
 impl Body {
     pub(crate) fn new(incoming: Incoming) -> Self {
         Self {
-            inner: Some(Box::new(incoming)),
+            inner: Box::new(incoming),
             len: None,
         }
     }
 
     pub(crate) fn with_len(incoming: Incoming, len: usize) -> Self {
         Self {
-            inner: Some(Box::new(incoming)),
+            inner: Box::new(incoming),
             len: Some(len),
-        }
-    }
-}
-
-impl BodyStream {
-    fn new(body: Box<Incoming>) -> Self {
-        Self { body }
-    }
-
-    fn project(self: Pin<&mut Self>) -> Pin<&mut Incoming> {
-        // Safety:
-        // The `body` field is never moved out of `BodyStream`.
-        unsafe {
-            let this = self.get_unchecked_mut();
-            Pin::new_unchecked(&mut this.body)
         }
     }
 }
@@ -118,74 +109,44 @@ impl Stream for BodyStream {
 
     fn poll_next(mut self: Pin<&mut Self>, context: &mut Context) -> Poll<Option<Self::Item>> {
         loop {
-            return match self.as_mut().project().poll_frame(context) {
+            match self.body.as_mut().poll_frame(context) {
                 // A frame was read from the body.
                 Poll::Ready(Some(Ok(frame))) => {
                     if let Ok(bytes) = frame.into_data() {
                         // The frame is a data frame.
-                        Poll::Ready(Some(Ok(bytes)))
-                    } else {
-                        // The frame is not a data frame.
-                        continue;
+                        return Poll::Ready(Some(Ok(bytes)));
                     }
                 }
                 // An Error occurred when reading the next frame.
                 Poll::Ready(Some(Err(error))) => {
                     let error = Error::from(error);
-                    Poll::Ready(Some(Err(error)))
+                    return Poll::Ready(Some(Err(error)));
                 }
                 // We have read all the frames from the body.
                 Poll::Ready(None) => {
                     // No more frames.
-                    Poll::Ready(None)
+                    return Poll::Ready(None);
                 }
                 // The body is not ready to yield a frame.
                 Poll::Pending => {
                     // Wait for the next frame.
-                    Poll::Pending
+                    return Poll::Pending;
                 }
             };
         }
     }
 }
 
-impl ReadIntoBytes {
-    fn new(stream: BodyStream) -> Self {
-        Self {
-            buffer: BytesMut::new(),
-            stream,
-        }
-    }
-
-    fn with_capacity(stream: BodyStream, capacity: usize) -> Self {
-        Self {
-            buffer: BytesMut::with_capacity(capacity),
-            stream,
-        }
-    }
-
-    fn project(self: Pin<&mut Self>) -> (Pin<&mut BodyStream>, Pin<&mut BytesMut>) {
-        // Safety:
-        // The `stream` and `buffer` fields are never moved out of
-        // `ReadIntoBytes`.
-        unsafe {
-            let this = self.get_unchecked_mut();
-            let stream = Pin::new_unchecked(&mut this.stream);
-            let buffer = Pin::new_unchecked(&mut this.buffer);
-
-            (stream, buffer)
-        }
-    }
-}
-
 impl Future for ReadIntoBytes {
-    type Output = Result<Bytes>;
+    type Output = Result<Vec<u8>>;
 
-    fn poll(mut self: Pin<&mut Self>, context: &mut Context) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, context: &mut Context) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        let buffer = &mut this.buffer;
+        let mut stream = Pin::new(&mut this.stream);
+
         loop {
-            let (stream, mut buffer) = self.as_mut().project();
-
-            return match stream.poll_next(context) {
+            match stream.as_mut().poll_next(context) {
                 // A frame was read from the stream.
                 Poll::Ready(Some(Ok(frame))) => {
                     let frame_len = frame.len();
@@ -193,7 +154,7 @@ impl Future for ReadIntoBytes {
                     // Attempt to reserve enough capacity for the frame in the
                     // buffer if the current capacity is less than the frame
                     // length.
-                    if let Err(error) = try_reserve(&mut buffer, frame_len) {
+                    if let Err(error) = try_reserve(buffer, frame_len) {
                         // Zero out the buffer.
                         buffer.fill(0);
                         // Return the error.
@@ -201,29 +162,26 @@ impl Future for ReadIntoBytes {
                     }
 
                     // Write the frame into the buffer.
-                    buffer.put(frame);
-
-                    // Continue reading the stream.
-                    continue;
+                    buffer.extend_from_slice(&frame);
                 }
                 // An Error occurred in the underlying stream.
                 Poll::Ready(Some(Err(error))) => {
                     // Zero out the buffer.
                     buffer.fill(0);
                     // Return the error and stop reading the stream.
-                    Poll::Ready(Err(error))
+                    return Poll::Ready(Err(error));
                 }
                 // We have read all the bytes from the stream.
                 Poll::Ready(None) => {
-                    // Copy the bytes into a new, immutable buffer.
-                    let bytes = buffer.split().freeze();
-                    // Return the immutable copy of the bytes in buffer.
-                    Poll::Ready(Ok(bytes))
+                    // Take ownership of the buffer.
+                    let buffer = std::mem::take(buffer);
+                    // Return the owned buffer.
+                    return Poll::Ready(Ok(buffer));
                 }
                 // The stream is not ready to yield a frame.
                 Poll::Pending => {
                     // Wait for the next frame.
-                    Poll::Pending
+                    return Poll::Pending;
                 }
             };
         }

--- a/src/request/body.rs
+++ b/src/request/body.rs
@@ -179,7 +179,6 @@ impl Future for ReadToBytes {
                     buffer.put(frame);
                 }
                 Poll::Ready(Some(Err(error))) => {
-                    let error = Error::from(error);
                     return Poll::Ready(Err(error));
                 }
                 Poll::Ready(None) => {

--- a/src/request/body.rs
+++ b/src/request/body.rs
@@ -1,57 +1,204 @@
-use http_body_util::{BodyExt, Empty};
-use hyper::body::{Buf, Incoming};
-use std::io::Read;
+use bytes::{BufMut, Bytes, BytesMut};
+use futures_util::Stream;
+use hyper::body::{Body as BodyTrait, Incoming};
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
 
-use crate::Result;
+use crate::{Error, Result};
 
 #[derive(Debug)]
 pub struct Body {
-    inner: Option<Box<Incoming>>,
+    inner: Option<Pin<Box<Incoming>>>,
+    len: Option<usize>,
+}
+
+#[derive(Debug)]
+pub struct BodyStream {
+    body: Pin<Box<Incoming>>,
+}
+
+#[derive(Debug)]
+pub struct ReadToBytes {
+    buffer: Option<BytesMut>,
+    stream: BodyStream,
 }
 
 impl Body {
-    pub async fn read_bytes(&mut self) -> Result<Vec<u8>> {
-        let buf = self.aggregate().await?;
-        let mut bytes = Vec::with_capacity(buf.remaining());
+    pub async fn read_to_bytes(&mut self) -> Result<Bytes> {
+        let stream = self.to_stream()?;
 
-        buf.reader().read_to_end(&mut bytes)?;
-        Ok(bytes)
-    }
-
-    pub async fn read_text(&mut self) -> Result<String> {
-        let bytes = self.read_bytes().await?;
-        Ok(String::from_utf8(bytes)?)
+        if let Some(capacity) = self.len {
+            ReadToBytes::with_capacity(stream, capacity).await
+        } else {
+            ReadToBytes::new(stream).await
+        }
     }
 
     #[cfg(feature = "serde")]
-    pub async fn read_json<T>(&mut self) -> Result<T>
+    pub async fn read_to_json<T>(&mut self) -> Result<T>
     where
         T: serde::de::DeserializeOwned,
     {
         use crate::{http::StatusCode, Error};
 
-        let reader = self.aggregate().await?.reader();
+        let buffer = self.read_to_bytes().await?;
 
-        serde_json::from_reader(reader).map_err(|source| {
+        serde_json::from_slice(&buffer).map_err(|source| {
             let mut error = Error::from(source);
             *error.status_mut() = StatusCode::BAD_REQUEST;
             error
         })
+    }
+
+    pub async fn read_to_string(&mut self) -> Result<String> {
+        let buffer = self.read_to_bytes().await?;
+        Ok(String::from_utf8(Vec::from(buffer))?)
+    }
+
+    pub fn to_stream(&mut self) -> Result<BodyStream> {
+        match self.inner.take() {
+            Some(body) => Ok(BodyStream::new(body)),
+            None => Err(Error::new("body has already been read".to_owned())),
+        }
     }
 }
 
 impl Body {
     pub(crate) fn new(inner: Incoming) -> Self {
         Self {
-            inner: Some(Box::new(inner)),
+            inner: Some(Box::pin(inner)),
+            len: None,
         }
     }
 
-    async fn aggregate(&mut self) -> Result<impl Buf> {
-        if let Some(value) = self.inner.take() {
-            Ok(value.collect().await?.aggregate())
-        } else {
-            Ok(Empty::new().collect().await?.aggregate())
+    pub(crate) fn with_len(inner: Incoming, len: usize) -> Self {
+        Self {
+            inner: Some(Box::pin(inner)),
+            len: Some(len),
+        }
+    }
+}
+
+impl BodyStream {
+    fn new(body: Pin<Box<Incoming>>) -> Self {
+        Self { body }
+    }
+
+    fn project(self: Pin<&mut Self>) -> Pin<&mut Incoming> {
+        // Safety: `body` is never moved after being pinned.
+        unsafe {
+            let this = self.get_unchecked_mut();
+            Pin::new_unchecked(&mut this.body)
+        }
+    }
+}
+
+impl Stream for BodyStream {
+    type Item = Result<Bytes>;
+
+    fn poll_next(mut self: Pin<&mut Self>, context: &mut Context) -> Poll<Option<Self::Item>> {
+        loop {
+            match self.as_mut().project().poll_frame(context) {
+                Poll::Ready(Some(Ok(frame))) if frame.is_data() => {
+                    let bytes = frame.into_data().unwrap();
+                    return Poll::Ready(Some(Ok(bytes)));
+                }
+                Poll::Ready(Some(Err(error))) => {
+                    let error = Error::from(error);
+                    return Poll::Ready(Some(Err(error)));
+                }
+                Poll::Ready(Some(Ok(_))) => {
+                    // Skip trailers.
+                    continue;
+                }
+                Poll::Ready(None) => {
+                    // No more frames.
+                    return Poll::Ready(None);
+                }
+                Poll::Pending => {
+                    // Wait for the next frame.
+                    return Poll::Pending;
+                }
+            }
+        }
+    }
+}
+
+impl ReadToBytes {
+    fn new(stream: BodyStream) -> Self {
+        Self {
+            buffer: Some(BytesMut::new()),
+            stream,
+        }
+    }
+
+    fn with_capacity(stream: BodyStream, capacity: usize) -> Self {
+        Self {
+            buffer: Some(BytesMut::with_capacity(capacity)),
+            stream,
+        }
+    }
+
+    fn project(self: Pin<&mut Self>) -> (Pin<&mut BodyStream>, Pin<&mut Option<BytesMut>>) {
+        unsafe {
+            let this = self.get_unchecked_mut();
+            let stream = Pin::new_unchecked(&mut this.stream);
+            let buffer = Pin::new_unchecked(&mut this.buffer);
+
+            (stream, buffer)
+        }
+    }
+}
+
+impl Future for ReadToBytes {
+    type Output = Result<Bytes>;
+
+    fn poll(mut self: Pin<&mut Self>, context: &mut Context) -> Poll<Self::Output> {
+        loop {
+            let (stream, option) = self.as_mut().project();
+
+            match stream.poll_next(context) {
+                Poll::Ready(Some(Ok(frame))) => {
+                    let frame_len = frame.len();
+                    let buffer = match option.get_mut() {
+                        Some(buffer) => buffer,
+                        None => {
+                            return Poll::Ready(Err(Error::new(
+                                "buffer has already been taken".to_owned(),
+                            )));
+                        }
+                    };
+
+                    if buffer.capacity() < frame_len {
+                        buffer.reserve(frame_len);
+                    }
+
+                    buffer.put(frame);
+                }
+                Poll::Ready(Some(Err(error))) => {
+                    let error = Error::from(error);
+                    return Poll::Ready(Err(error));
+                }
+                Poll::Ready(None) => {
+                    let bytes = match option.get_mut().take() {
+                        Some(buffer) => buffer.freeze(),
+                        None => {
+                            return Poll::Ready(Err(Error::new(
+                                "buffer has already been taken".to_owned(),
+                            )));
+                        }
+                    };
+
+                    return Poll::Ready(Ok(bytes));
+                }
+                Poll::Pending => {
+                    // Wait for the next frame.
+                    return Poll::Pending;
+                }
+            }
         }
     }
 }

--- a/src/request/body.rs
+++ b/src/request/body.rs
@@ -193,8 +193,8 @@ impl Future for ReadIntoBytes {
                     // buffer if the current capacity is less than the frame
                     // length.
                     if let Err(error) = try_reserve(&mut buffer, frame_len) {
-                        // Clear the buffer.
-                        buffer.clear();
+                        // Zero out the buffer.
+                        buffer.fill(0);
                         // Return the error.
                         return Poll::Ready(Err(error));
                     }
@@ -207,8 +207,8 @@ impl Future for ReadIntoBytes {
                 }
                 // An Error occurred in the underlying stream.
                 Poll::Ready(Some(Err(error))) => {
-                    // Clear the buffer.
-                    buffer.clear();
+                    // Zero out the buffer.
+                    buffer.fill(0);
                     // Return the error and stop reading the stream.
                     Poll::Ready(Err(error))
                 }

--- a/src/request/body.rs
+++ b/src/request/body.rs
@@ -1,5 +1,5 @@
 use bytes::{BufMut, Bytes, BytesMut};
-use futures_util::Stream;
+use futures_core::Stream;
 use hyper::body::{Body as BodyTrait, Incoming};
 use std::{
     future::Future,

--- a/src/request/body.rs
+++ b/src/request/body.rs
@@ -166,7 +166,8 @@ impl ReadIntoBytes {
 
     fn project(self: Pin<&mut Self>) -> (Pin<&mut BodyStream>, Pin<&mut BytesMut>) {
         // Safety:
-        // The `stream` and `buffer` fields are never moved out of `ReadToBytes`.
+        // The `stream` and `buffer` fields are never moved out of
+        // `ReadIntoBytes`.
         unsafe {
             let this = self.get_unchecked_mut();
             let stream = Pin::new_unchecked(&mut this.stream);

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -7,7 +7,7 @@ mod request;
 use query_parser::parse_query_params;
 
 pub use self::{
-    body::Body,
+    body::{Body, BodyStream},
     path_param::PathParam,
     query_param::{QueryParamValue, QueryParamValues, QueryParamValuesIter},
     request::Request,

--- a/src/response/body.rs
+++ b/src/response/body.rs
@@ -206,9 +206,9 @@ impl BodyTrait for Body {
                 // many bytes to copy from the buffer into the data frame.
                 let len = buffer.len();
 
-                // Check if the buffer has any data. If it doesn't, return
-                // `Poll::Ready(None)` to signal that the stream has ended.
+                // Check if the buffer has any data.
                 if len == 0 {
+                    // The buffer is empty. Signal that the stream has ended.
                     return Poll::Ready(None);
                 }
 

--- a/src/response/body.rs
+++ b/src/response/body.rs
@@ -206,9 +206,9 @@ where
     fn project(self: Pin<&mut Self>) -> Pin<&mut T> {
         // Safety:
         // This block is necessary because we need to project the inner stream
-        // through the outer pinned reference. The `unsafe` block ensures that
-        // we can safely create a new `Pin` to the inner stream without
-        // violating the guarantees of the `Pin` API.
+        // through the outer pinned reference. We don't know if `T` is `Unpin`
+        // so we need to use `unsafe` to create the pinned reference with
+        // `Pin::new_unchecked`.
         unsafe {
             // Get a mutable reference to `self`.
             let this = self.get_unchecked_mut();

--- a/src/response/body.rs
+++ b/src/response/body.rs
@@ -258,14 +258,14 @@ impl BodyTrait for Body {
 
                 // Attempt to cast the lower bound to a `u64`. If the cast fails,
                 // do not set the lower bound of the size hint.
-                if let Some(value) = u64::try_from(lower).ok() {
+                if let Ok(value) = u64::try_from(lower) {
                     size_hint.set_lower(value);
                 }
 
                 // Check if the upper bound is `Some`. If it is, attempt to cast
                 // it to a `u64`. If the cast fails or the upper bound is `None`,
                 // do not set the upper bound of the size hint.
-                if let Some(value) = upper.and_then(|value| u64::try_from(value).ok()) {
+                if let Some(Ok(value)) = upper.map(u64::try_from) {
                     size_hint.set_upper(value);
                 }
 

--- a/src/response/body.rs
+++ b/src/response/body.rs
@@ -171,10 +171,7 @@ impl BodyTrait for Body {
     }
 
     fn is_end_stream(&self) -> bool {
-        match &self.kind {
-            BodyKind::Buffer(None) => true,
-            _ => false,
-        }
+        matches!(self.kind, BodyKind::Buffer(None))
     }
 
     fn size_hint(&self) -> SizeHint {

--- a/src/response/into_response.rs
+++ b/src/response/into_response.rs
@@ -1,0 +1,58 @@
+use super::{Response, ResponseBuilder};
+use crate::{Error, Result};
+
+pub trait IntoResponse {
+    fn into_response(self) -> Result<Response>;
+}
+
+impl IntoResponse for () {
+    fn into_response(self) -> Result<Response> {
+        Ok(Response::new())
+    }
+}
+
+impl IntoResponse for Vec<u8> {
+    fn into_response(self) -> Result<Response> {
+        Response::builder().body(self).finish()
+    }
+}
+
+impl IntoResponse for &'static [u8] {
+    fn into_response(self) -> Result<Response> {
+        Response::builder().body(self).finish()
+    }
+}
+
+impl IntoResponse for String {
+    fn into_response(self) -> Result<Response> {
+        Response::text(self).finish()
+    }
+}
+
+impl IntoResponse for &'static str {
+    fn into_response(self) -> Result<Response> {
+        Response::text(self).finish()
+    }
+}
+
+impl IntoResponse for Response {
+    fn into_response(self) -> Result<Response> {
+        Ok(self)
+    }
+}
+
+impl IntoResponse for ResponseBuilder {
+    fn into_response(self) -> Result<Response> {
+        self.finish()
+    }
+}
+
+impl<T, E> IntoResponse for Result<T, E>
+where
+    T: IntoResponse,
+    Error: From<E>,
+{
+    fn into_response(self) -> Result<Response> {
+        self?.into_response()
+    }
+}

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -1,6 +1,10 @@
 mod body;
 mod builder;
+mod into_response;
 mod redirect;
 mod response;
 
-pub use self::{body::Body, builder::ResponseBuilder, redirect::Redirect, response::Response};
+pub use self::{
+    body::Body, builder::ResponseBuilder, into_response::IntoResponse, redirect::Redirect,
+    response::Response,
+};

--- a/src/response/response.rs
+++ b/src/response/response.rs
@@ -1,9 +1,9 @@
+use bytes::Bytes;
 use futures_util::{Stream, StreamExt};
 use http::{
     header::{self, HeaderMap},
     StatusCode, Version,
 };
-use hyper::body::Bytes;
 
 use super::{
     body::{Body, Frame},


### PR DESCRIPTION
Adds support for streaming request bodies. Also includes custom types for reading request bodies without the use of `http-body-util`. This remaining work of this PR can be found in #9.