### PR TITLE
feat: bring back the IntoResponse trait

### DIFF
--- a/docs/examples/hello-world/src/main.rs
+++ b/docs/examples/hello-world/src/main.rs
@@ -1,6 +1,6 @@
-use via::{Event, Next, Request, Response, Result};
+use via::{Event, Next, Request, Result};
 
-async fn hello(request: Request, _: Next) -> Result<Response> {
+async fn hello(request: Request, _: Next) -> Result<String> {
     // Get a reference to the path parameter `name` from the request uri.
     let name = request.param("name").required()?;
     //                               ^^^^^^^^
@@ -14,7 +14,7 @@ async fn hello(request: Request, _: Next) -> Result<Response> {
 
     // Send a plain text response with a greeting that includes the name from
     // the request's uri path.
-    Response::text(format!("Hello, {}!", name)).finish()
+    Ok(format!("Hello, {}!", name))
 }
 
 #[tokio::main]

--- a/docs/examples/shared-state/src/main.rs
+++ b/docs/examples/shared-state/src/main.rs
@@ -2,47 +2,86 @@ use std::sync::{
     atomic::{AtomicU32, Ordering},
     Arc,
 };
-use via::{Error, Event, Response, Result};
+use via::{http::StatusCode, Event, Response, Result};
 
+// Define a type alias for the `via::Request` to include the `Counter` state.
+// This is a convenience to avoid having to write out the full type signature.
 type Request = via::Request<Counter>;
+
+// Define a type alias for the `via::Next` to include the `Counter` state. This
+// is a convenience to avoid having to write out the full type signature.
 type Next = via::Next<Counter>;
 
+/// A struct of containing the shared state for the application. This struct
+/// will be made available to all middleware functions and responders by
+/// calling the `state` method on the `Request` struct.
 struct Counter {
+    /// The number of responses that had a status code in the 1XX-3XX range.
     sucesses: Arc<AtomicU32>,
+
+    /// The number of responses that had a status code in the 4XX-5XX range.
     errors: Arc<AtomicU32>,
+}
+
+// Define a helper function to check if a status code is in the 4XX-5XX range.
+fn status_is_error(status: StatusCode) -> bool {
+    status.is_client_error() || status.is_server_error()
+}
+
+/// A middleware function that will either increment the `successes` or
+/// `errors` field of the `Counter` state based on the response status.
+async fn counter(request: Request, next: Next) -> Result<Response> {
+    // Clone the `Counter` state by incrementing the reference count of the
+    // outer `Arc`. This will allow us to modify the `state` after we pass
+    // ownership of `request` to the `next` middleware.
+    let state = Arc::clone(request.state());
+    // Call the next middleware in the app and await the response.
+    let response = next.call(request).await?;
+
+    if status_is_error(response.status()) {
+        // The status is in the 4XX-5XX range. Increment the `errors` field.
+        state.errors.fetch_add(1, Ordering::Relaxed);
+    } else {
+        // The status is in the 1XX-3XX range. Increment the `successes` field.
+        state.sucesses.fetch_add(1, Ordering::Relaxed);
+    }
+
+    Ok(response)
+}
+
+/// A responder that will return the total number of `successes` and `errors`
+/// in the `Counter` state.
+async fn totals(request: Request, _: Next) -> Result<String> {
+    // Get a reference to the `Counter` state from the request. We don't need
+    // to clone the state since we are consuming the request rather than
+    // passing it as an argument to `next.call`.
+    let state = request.state();
+    // Load the current value of `errors` from the atomic integer.
+    let errors = state.errors.load(Ordering::Relaxed);
+    // Load the current value of `successes` from the atomic integer.
+    let successes = state.sucesses.load(Ordering::Relaxed);
+
+    // Return a string with the total number of `errors` and `successes`.
+    Ok(format!("Errors: {}\nSucesses: {}", errors, successes))
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Create a new application with a `Counter` as state.
     let mut app = via::app(Counter {
         errors: Arc::new(AtomicU32::new(0)),
         sucesses: Arc::new(AtomicU32::new(0)),
     });
 
-    app.include(|request: Request, next: Next| async {
-        let state = Arc::clone(request.state());
-        let response = next.call(request).await?;
+    // Add the `counter` middleware to the application. Since we are not
+    // specifying an endpoint with the `at` method, this middleware will
+    // be applied to all requests.
+    app.include(counter);
 
-        if response.status().is_success() {
-            state.sucesses.fetch_add(1, Ordering::Relaxed);
-        } else {
-            state.errors.fetch_add(1, Ordering::Relaxed);
-        }
+    // Add the `totals` responder to the endpoint GET /totals.
+    app.at("/totals").respond(via::get(totals));
 
-        Ok::<_, Error>(response)
-    });
-
-    app.at("/counter").respond(via::get(|request: Request, _: Next| async move {
-        let state = request.state();
-        let body = format!(
-            "Errors: {}\nSucesses: {}",
-            state.errors.load(Ordering::Relaxed),
-            state.sucesses.load(Ordering::Relaxed)
-        );
-
-        Response::text(body).finish()
-    }));
-
+    // Start the server.
     app.listen(("127.0.0.1", 8080), |event| match event {
         Event::ConnectionError(error) | Event::UncaughtError(error) => {
             eprintln!("Error: {}", error);

--- a/src/middleware/middleware.rs
+++ b/src/middleware/middleware.rs
@@ -1,7 +1,7 @@
 use std::{future::Future, pin::Pin, sync::Arc};
 
 use super::Next;
-use crate::{Request, Response, Result};
+use crate::{response::IntoResponse, Request, Response, Result};
 
 pub(crate) type ArcMiddleware<State> = Arc<dyn Middleware<State>>;
 pub type BoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send + 'static>>;
@@ -13,9 +13,11 @@ pub trait Middleware<State>: Send + Sync + 'static {
 impl<State, T, F> Middleware<State> for T
 where
     T: Fn(Request<State>, Next<State>) -> F + Send + Sync + 'static,
-    F: Future<Output = Result<Response>> + Send + 'static,
+    F: Future + Send + 'static,
+    F::Output: IntoResponse,
 {
     fn call(&self, request: Request<State>, next: Next<State>) -> BoxFuture<Result<Response>> {
-        Box::pin(self(request, next))
+        let future = self(request, next);
+        Box::pin(async { future.await.into_response() })
     }
 }

--- a/src/response/into_response.rs
+++ b/src/response/into_response.rs
@@ -1,0 +1,58 @@
+use super::{Response, ResponseBuilder};
+use crate::{Error, Result};
+
+pub trait IntoResponse {
+    fn into_response(self) -> Result<Response>;
+}
+
+impl IntoResponse for () {
+    fn into_response(self) -> Result<Response> {
+        Ok(Response::new())
+    }
+}
+
+impl IntoResponse for Vec<u8> {
+    fn into_response(self) -> Result<Response> {
+        Response::builder().body(self).finish()
+    }
+}
+
+impl IntoResponse for &'static [u8] {
+    fn into_response(self) -> Result<Response> {
+        Response::builder().body(self).finish()
+    }
+}
+
+impl IntoResponse for String {
+    fn into_response(self) -> Result<Response> {
+        Response::text(self).finish()
+    }
+}
+
+impl IntoResponse for &'static str {
+    fn into_response(self) -> Result<Response> {
+        Response::text(self).finish()
+    }
+}
+
+impl IntoResponse for Response {
+    fn into_response(self) -> Result<Response> {
+        Ok(self)
+    }
+}
+
+impl IntoResponse for ResponseBuilder {
+    fn into_response(self) -> Result<Response> {
+        self.finish()
+    }
+}
+
+impl<T, E> IntoResponse for Result<T, E>
+where
+    T: IntoResponse,
+    Error: From<E>,
+{
+    fn into_response(self) -> Result<Response> {
+        self?.into_response()
+    }
+}

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -1,6 +1,10 @@
 mod body;
 mod builder;
+mod into_response;
 mod redirect;
 mod response;
 
-pub use self::{body::Body, builder::ResponseBuilder, redirect::Redirect, response::Response};
+pub use self::{
+    body::Body, builder::ResponseBuilder, into_response::IntoResponse, redirect::Redirect,
+    response::Response,
+};


### PR DESCRIPTION
Brings back the `IntoResponse` trait. Not having a trait for the conversion wouldn't feel like a Rust framework.