### PR TITLE
feat(via-router): perf improvements and reduced memory usage

### DIFF
--- a/crates/via-router/benches/bench.rs
+++ b/crates/via-router/benches/bench.rs
@@ -115,6 +115,8 @@ fn find_all_matches(b: &mut Bencher) {
         let _ = router.at(path).get_or_insert_route_with(|| Box::new(()));
     }
 
+    router.shrink_to_fit();
+
     b.iter(|| {
         router.visit("/api/v1/products/12358132134558/edit");
     });

--- a/crates/via-router/benches/bench.rs
+++ b/crates/via-router/benches/bench.rs
@@ -112,7 +112,7 @@ fn find_all_matches(b: &mut Bencher) {
     let mut router: Router<()> = Router::new();
 
     for path in ROUTES {
-        let _ = router.at(path).get_or_insert_route_with(|| Box::new(()));
+        let _ = router.at(path).get_or_insert_route_with(|| ());
     }
 
     router.shrink_to_fit();

--- a/crates/via-router/src/lib.rs
+++ b/crates/via-router/src/lib.rs
@@ -37,7 +37,7 @@ impl<T> Router<T> {
     }
 
     pub fn visit(&self, path: &str) -> Vec<Match<T>> {
-        let mut results = Vec::with_capacity(32);
+        let mut results = Vec::with_capacity(6);
         let segments = path::segments(path);
         let visitor = Visitor::new(path, &segments, &self.store);
 

--- a/crates/via-router/src/lib.rs
+++ b/crates/via-router/src/lib.rs
@@ -42,7 +42,7 @@ impl<T> Router<T> {
     }
 
     pub fn visit(&self, path: &str) -> Vec<Match<T>> {
-        let mut results = Vec::with_capacity(6);
+        let mut results = Vec::with_capacity(24);
         let segments = path::segments(path);
         let visitor = Visitor::new(path, &segments, &self.store);
 

--- a/crates/via-router/src/lib.rs
+++ b/crates/via-router/src/lib.rs
@@ -76,7 +76,7 @@ impl<'a, T> Endpoint<'a, T> {
     /// provided closure `f`.
     pub fn get_or_insert_route_with<F>(&mut self, f: F) -> &mut T
     where
-        F: FnOnce() -> Box<T>,
+        F: FnOnce() -> T,
     {
         self.store
             .get_mut(self.key)
@@ -136,7 +136,7 @@ mod tests {
         let mut router = Router::new();
 
         for path in &PATHS {
-            let _ = router.at(path).get_or_insert_route_with(|| Box::new(()));
+            let _ = router.at(path).get_or_insert_route_with(|| ());
         }
 
         {

--- a/crates/via-router/src/lib.rs
+++ b/crates/via-router/src/lib.rs
@@ -4,60 +4,45 @@ mod path;
 mod routes;
 mod visitor;
 
-use crate::{
-    path::Pattern,
-    routes::{Node, RouteStore},
-};
-
 pub use crate::visitor::Match;
 
+use crate::path::Pattern;
+use crate::routes::{Node, RouteStore};
+use crate::visitor::Visitor;
+
 pub struct Router<T> {
-    root_index: usize,
-    route_store: RouteStore<T>,
+    store: RouteStore<T>,
 }
 
 pub struct Endpoint<'a, T> {
-    node_index: usize,
-    route_store: &'a mut RouteStore<T>,
+    key: usize,
+    store: &'a mut RouteStore<T>,
 }
 
 impl<T> Router<T> {
     pub fn new() -> Self {
-        let mut route_store = RouteStore::new();
-        let root_index = route_store.push(Node {
-            entries: None,
-            pattern: Pattern::Root,
-            route: None,
-        });
+        let mut store = RouteStore::new();
 
-        Self {
-            root_index,
-            route_store,
-        }
+        store.push(Node::new(Pattern::Root));
+        Self { store }
     }
 
     pub fn at(&mut self, path: &'static str) -> Endpoint<T> {
         let mut segments = path::patterns(path);
 
         Endpoint {
-            node_index: insert(&mut self.route_store, &mut segments, 0),
-            route_store: &mut self.route_store,
+            key: insert(&mut self.store, &mut segments, 0),
+            store: &mut self.store,
         }
     }
 
     pub fn visit(&self, path: &str) -> Vec<Match<T>> {
-        let mut matched_routes = Vec::with_capacity(32);
-        let path_segments = path::segments(path);
-        let root_node = self.route_store.node(self.root_index);
+        let mut results = Vec::with_capacity(32);
+        let segments = path::segments(path);
+        let visitor = Visitor::new(path, &segments, &self.store);
 
-        visitor::visit(
-            &mut matched_routes,
-            &path_segments,
-            &self.route_store,
-            root_node,
-        );
-
-        matched_routes
+        visitor.visit(&mut results);
+        results
     }
 }
 
@@ -72,14 +57,13 @@ impl<'a, T> Endpoint<'a, T> {
         let mut segments = path::patterns(path);
 
         Endpoint {
-            node_index: insert(self.route_store, &mut segments, self.node_index),
-            route_store: self.route_store,
+            key: insert(self.store, &mut segments, self.key),
+            store: self.store,
         }
     }
 
     pub fn param(&self) -> Option<&'static str> {
-        let node = self.route_store.node(self.node_index);
-        node.pattern.param()
+        self.store.get(self.key).param()
     }
 
     /// Returns a mutable reference to the route associated with this `Endpoint`.
@@ -89,15 +73,10 @@ impl<'a, T> Endpoint<'a, T> {
     where
         F: FnOnce() -> Box<T>,
     {
-        // Get the index of the route associated with the current node or insert
-        // a new route by calling the provided closure `f` if it does not exist.
-        let route_index = self
-            .route_store
-            .entry(self.node_index)
-            .get_or_insert_route_with(f);
-
-        // Return a mutable reference to the route associated with this `Endpoint`.
-        self.route_store.route_mut(route_index)
+        self.store
+            .get_mut(self.key)
+            .route_mut()
+            .get_or_insert_with(f)
     }
 }
 
@@ -109,7 +88,7 @@ where
     // In the future we may want to panic if the caller tries to insert a node
     // into a catch-all node rather than silently ignoring the rest of the
     // segments.
-    if let Pattern::CatchAll(_) = routes.node(into_index).pattern {
+    if let Pattern::CatchAll(_) = routes.get(into_index).pattern {
         for _ in segments {}
         return into_index;
     }
@@ -122,17 +101,13 @@ where
 
     // Check if the pattern already exists in the node at `current_key`. If it does,
     // we can continue to the next segment.
-    for next_index in routes.node(into_index).entries() {
-        if pattern == routes.node(*next_index).pattern {
+    for next_index in routes.get(into_index).entries() {
+        if pattern == routes.get(*next_index).pattern {
             return insert(routes, segments, *next_index);
         }
     }
 
-    let next_index = routes.entry(into_index).push_node(Node {
-        entries: None,
-        route: None,
-        pattern,
-    });
+    let next_index = routes.entry(into_index).push(Node::new(pattern));
 
     // If the pattern does not exist in the node at `current_key`, we need to create
     // a new node as a descendant of the node at `current_key` and then insert it

--- a/crates/via-router/src/lib.rs
+++ b/crates/via-router/src/lib.rs
@@ -36,6 +36,11 @@ impl<T> Router<T> {
         }
     }
 
+    /// Shrinks the capacity of the router as much as possible.
+    pub fn shrink_to_fit(&mut self) {
+        self.store.shrink_to_fit();
+    }
+
     pub fn visit(&self, path: &str) -> Vec<Match<T>> {
         let mut results = Vec::with_capacity(6);
         let segments = path::segments(path);

--- a/crates/via-router/src/path.rs
+++ b/crates/via-router/src/path.rs
@@ -2,10 +2,10 @@ use core::{iter::Enumerate, str::Bytes};
 
 #[derive(PartialEq)]
 pub enum Pattern {
-    CatchAll(&'static str),
-    Dynamic(&'static str),
-    Static(&'static str),
     Root,
+    Static(&'static str),
+    Dynamic(&'static str),
+    CatchAll(&'static str),
 }
 
 /// An iterator that splits the path into segments and yields a key-value pair

--- a/crates/via-router/src/path.rs
+++ b/crates/via-router/src/path.rs
@@ -87,7 +87,7 @@ impl<'a> Iterator for SplitPath<'a> {
         // Set the start index to the next character that is not a `/`.
         let start = self.next_non_terminator()?;
         // Set the end index to the next character that is a `/`.
-        let end = self.next_terminator().unwrap_or_else(|| self.value.len());
+        let end = self.next_terminator().unwrap_or(self.value.len());
 
         // Return the start and end offset of the current path segment.
         Some((start, end))

--- a/crates/via-router/src/path.rs
+++ b/crates/via-router/src/path.rs
@@ -23,7 +23,7 @@ pub fn patterns(value: &'static str) -> impl Iterator<Item = Pattern> {
 /// Returns a collection containing the start and end offset of each segment in
 /// the url path.
 pub fn segments(value: &str) -> Vec<(usize, usize)> {
-    let mut segments = Vec::with_capacity(6);
+    let mut segments = Vec::with_capacity(12);
 
     segments.extend(split(value));
     segments

--- a/crates/via-router/src/path.rs
+++ b/crates/via-router/src/path.rs
@@ -23,7 +23,7 @@ pub fn patterns(value: &'static str) -> impl Iterator<Item = Pattern> {
 /// Returns a collection containing the start and end offset of each segment in
 /// the url path.
 pub fn segments(value: &str) -> Vec<(usize, usize)> {
-    let mut segments = Vec::with_capacity(10);
+    let mut segments = Vec::with_capacity(6);
 
     segments.extend(split(value));
     segments

--- a/crates/via-router/src/routes.rs
+++ b/crates/via-router/src/routes.rs
@@ -1,9 +1,9 @@
-use std::slice;
+use core::slice;
 
 use crate::path::Pattern;
 
 /// A node in the route tree that represents a single path segment.
-pub struct Node {
+pub struct Node<T> {
     /// The indices of the nodes that are reachable from the current node.
     pub entries: Option<Vec<usize>>,
 
@@ -11,43 +11,70 @@ pub struct Node {
     pub pattern: Pattern,
 
     /// The index of the route in the route store associated with the node.
-    pub route: Option<usize>,
+    route: Option<Box<T>>,
+}
+
+/// A mutable representation of a single node the route store. This type is used
+/// to modify the `entries` field field of the node at `key` while keeping the
+/// internal state of the route store consistent.
+pub struct RouteEntry<'a, T> {
+    /// The key of the node that we are currently working with.
+    key: usize,
+
+    /// A mutable reference to the route store that contains the node.
+    store: &'a mut RouteStore<T>,
 }
 
 /// A container type used to improve the cache locality of nodes and routes in
 /// the route tree.
 pub struct RouteStore<T> {
     /// A collection of nodes that represent the path segments of a route.
-    nodes: Vec<Node>,
-
-    /// A collection of routes that are associated with the nodes stored in
-    /// `self.nodes`.
-    routes: Vec<Box<T>>,
+    nodes: Vec<Node<T>>,
 }
 
-/// A mutable representation of a single node the route store. This type is used
-/// to modify the `entries` field or `route` field of the node at `node_index`
-/// while keeping the internal state of the route store consistent.
-pub struct RouteEntry<'a, T> {
-    /// The index of the node that we are currently working with.
-    node_index: usize,
+impl<T> Node<T> {
+    pub fn new(pattern: Pattern) -> Self {
+        Self {
+            pattern,
+            entries: None,
+            route: None,
+        }
+    }
 
-    /// A mutable reference to the route store that contains the node.
-    route_store: &'a mut RouteStore<T>,
-}
-
-impl Node {
     /// Returns an iterator that yields the indices of the nodes that are
     /// reachable from `self`.
     pub fn entries(&self) -> slice::Iter<usize> {
-        match self.entries.as_ref() {
+        match &self.entries {
             Some(entries) => entries.iter(),
             None => [].iter(),
         }
     }
+
+    /// Returns an optional reference to the name of the dynamic parameter
+    /// associated with the node. The returned value will be `None` if the
+    /// node has a `Root` or `Static` pattern.
+    pub fn param(&self) -> Option<&'static str> {
+        match &self.pattern {
+            Pattern::CatchAll(param) | Pattern::Dynamic(param) => Some(param),
+            _ => None,
+        }
+    }
+
+    /// Returns an optional reference to the route associated with the node.
+    pub fn route(&self) -> Option<&T> {
+        match &self.route {
+            Some(route) => Some(route),
+            None => None,
+        }
+    }
+
+    /// Returns a mutable reference to the `route` field of the node.
+    pub fn route_mut(&mut self) -> &mut Option<Box<T>> {
+        &mut self.route
+    }
 }
 
-impl Node {
+impl<T> Node<T> {
     /// Pushes a new index into the entries of the node and returns the index.
     fn push(&mut self, index: usize) -> usize {
         self.entries.get_or_insert_with(Vec::new).push(index);
@@ -55,116 +82,53 @@ impl Node {
     }
 }
 
+impl<'a, T> RouteEntry<'a, T> {
+    /// Pushes a new node into the store and associates the index of the new
+    /// node to the entries of the current node. Returns the index of the
+    /// newly inserted node.
+    pub fn push(&mut self, node: Node<T>) -> usize {
+        // Push the node into the store and get the index of the newly inserted
+        // node.
+        let next_node_index = self.store.push(node);
+
+        // Associate the index of the newly inserted node with the current node
+        // by adding the index to the entries of the current node.
+        self.store.get_mut(self.key).push(next_node_index);
+
+        // Return the index of the newly inserted node in the store.
+        next_node_index
+    }
+}
+
 impl<T> RouteStore<T> {
     /// Constructs a new, empty `RouteStore`.
     pub fn new() -> Self {
-        Self {
-            nodes: Vec::new(),
-            routes: Vec::new(),
-        }
+        Self { nodes: Vec::new() }
     }
 
     /// Returns a mutable representation of a single node in the route store.
     pub fn entry(&mut self, index: usize) -> RouteEntry<T> {
         RouteEntry {
-            node_index: index,
-            route_store: self,
+            key: index,
+            store: self,
         }
-    }
-
-    /// Returns a shared reference to the node at the given index.
-    pub fn node(&self, index: usize) -> &Node {
-        self.nodes.get(index).unwrap()
-    }
-
-    /// Returns a mutable reference to the node at the given index.
-    pub fn node_mut(&mut self, index: usize) -> &mut Node {
-        self.nodes.get_mut(index).unwrap()
     }
 
     /// Pushes a new node into the store and returns the index of the newly
     /// inserted node.
-    pub fn push(&mut self, node: Node) -> usize {
+    pub fn push(&mut self, node: Node<T>) -> usize {
         let index = self.nodes.len();
         self.nodes.push(node);
         index
     }
 
-    /// Returns a mutable reference to the route at the given index.
-    pub fn route_mut(&mut self, index: usize) -> &mut T {
-        self.routes.get_mut(index).unwrap()
+    /// Returns a shared reference to the node at the given index.
+    pub fn get(&self, index: usize) -> &Node<T> {
+        self.nodes.get(index).unwrap()
     }
 
-    /// Returns an optional shared reference to the route of the node at the
-    /// given index if it exists.
-    pub fn route_at_node(&self, index: usize) -> Option<&T> {
-        let route_index = self.route_index_at_node(index)?;
-        Some(self.routes.get(route_index)?)
-    }
-}
-
-impl<T> RouteStore<T> {
-    /// Pushes a new route into the store and returns the index of the newly
-    /// inserted route.
-    fn push_route(&mut self, route: Box<T>) -> usize {
-        let index = self.routes.len();
-        self.routes.push(route);
-        index
-    }
-
-    /// Returns the index of the route in the route store associated with the
-    /// node at the given index if it exists.
-    fn route_index_at_node(&self, index: usize) -> Option<usize> {
-        self.node(index).route
-    }
-}
-
-impl<'a, T> RouteEntry<'a, T> {
-    /// Pushes a new node into the store and associates the index of the new
-    /// node to the entries of the current node. Returns the index of the
-    /// newly inserted node.
-    pub fn push_node(&mut self, node: Node) -> usize {
-        // Push the node into the store and get the index of the newly inserted
-        // node.
-        let next_node_index = self.route_store.push(node);
-
-        // Associate the index of the newly inserted node with the current node
-        // by adding the index to the entries of the current node.
-        self.route_store
-            .node_mut(self.node_index)
-            .push(next_node_index);
-
-        // Return the index of the newly inserted node in the store.
-        next_node_index
-    }
-
-    /// Inserts a new route into the store and associates the index of the new
-    /// route to the current node. Returns the index of the newly inserted route.
-    pub fn insert_route(&mut self, route: Box<T>) -> usize {
-        // Push the route into the store and get the index of the newly
-        // inserted route.
-        let route_index = self.route_store.push_route(route);
-
-        // Associate the route index with the current node.
-        self.route_store.node_mut(self.node_index).route = Some(route_index);
-
-        // Return the index of the newly inserted route in the store.
-        route_index
-    }
-
-    /// Returns the index of the route at the current node. If the node does not
-    /// have a route associated with it, a new route will be inserted by calling
-    /// the provided closure `f`.
-    pub fn get_or_insert_route_with<F>(&mut self, f: F) -> usize
-    where
-        F: FnOnce() -> Box<T>,
-    {
-        self.route_store
-            // Get the index of the route associated with the node if it exists.
-            .route_index_at_node(self.node_index)
-            // If the node does not have a route associated with it, insert a
-            // new route into the store, associate it with the node, and
-            // return the index of the route in the store.
-            .unwrap_or_else(|| self.insert_route(f()))
+    /// Returns a mutable reference to the node at the given index.
+    pub fn get_mut(&mut self, index: usize) -> &mut Node<T> {
+        self.nodes.get_mut(index).unwrap()
     }
 }

--- a/crates/via-router/src/routes.rs
+++ b/crates/via-router/src/routes.rs
@@ -122,6 +122,11 @@ impl<T> RouteStore<T> {
         index
     }
 
+    /// Shrinks the capacity of the route store as much as possible.
+    pub fn shrink_to_fit(&mut self) {
+        self.nodes.shrink_to_fit();
+    }
+
     /// Returns a shared reference to the node at the given index.
     pub fn get(&self, index: usize) -> &Node<T> {
         self.nodes.get(index).unwrap()

--- a/crates/via-router/src/routes.rs
+++ b/crates/via-router/src/routes.rs
@@ -11,7 +11,7 @@ pub struct Node<T> {
     pub pattern: Pattern,
 
     /// The index of the route in the route store associated with the node.
-    route: Option<Box<T>>,
+    route: Option<T>,
 }
 
 /// A mutable representation of a single node the route store. This type is used
@@ -62,14 +62,11 @@ impl<T> Node<T> {
 
     /// Returns an optional reference to the route associated with the node.
     pub fn route(&self) -> Option<&T> {
-        match &self.route {
-            Some(route) => Some(route),
-            None => None,
-        }
+        self.route.as_ref()
     }
 
     /// Returns a mutable reference to the `route` field of the node.
-    pub fn route_mut(&mut self) -> &mut Option<Box<T>> {
+    pub fn route_mut(&mut self) -> &mut Option<T> {
         &mut self.route
     }
 }

--- a/crates/via-router/src/routes.rs
+++ b/crates/via-router/src/routes.rs
@@ -72,10 +72,10 @@ impl<T> Node<T> {
 }
 
 impl<T> Node<T> {
-    /// Pushes a new index into the entries of the node and returns the index.
-    fn push(&mut self, index: usize) -> usize {
-        self.entries.get_or_insert_with(Vec::new).push(index);
-        index
+    /// Pushes a new key into the entries of the node and return it.
+    fn push(&mut self, key: usize) -> usize {
+        self.entries.get_or_insert_with(Vec::new).push(key);
+        key
     }
 }
 
@@ -84,16 +84,13 @@ impl<'a, T> RouteEntry<'a, T> {
     /// node to the entries of the current node. Returns the index of the
     /// newly inserted node.
     pub fn push(&mut self, node: Node<T>) -> usize {
-        // Push the node into the store and get the index of the newly inserted
+        // Push the node into the store and get the key of the newly inserted
         // node.
-        let next_node_index = self.store.push(node);
+        let next_node_key = self.store.push(node);
 
-        // Associate the index of the newly inserted node with the current node
-        // by adding the index to the entries of the current node.
-        self.store.get_mut(self.key).push(next_node_index);
-
-        // Return the index of the newly inserted node in the store.
-        next_node_index
+        // Associate the key of the newly inserted node with the current node
+        // by adding the key to the entries of the current node.
+        self.store.get_mut(self.key).push(next_node_key)
     }
 }
 
@@ -104,19 +101,17 @@ impl<T> RouteStore<T> {
     }
 
     /// Returns a mutable representation of a single node in the route store.
-    pub fn entry(&mut self, index: usize) -> RouteEntry<T> {
-        RouteEntry {
-            key: index,
-            store: self,
-        }
+    pub fn entry(&mut self, key: usize) -> RouteEntry<T> {
+        RouteEntry { key, store: self }
     }
 
-    /// Pushes a new node into the store and returns the index of the newly
+    /// Pushes a new node into the store and returns the key of the newly
     /// inserted node.
     pub fn push(&mut self, node: Node<T>) -> usize {
-        let index = self.nodes.len();
+        let key = self.nodes.len();
+
         self.nodes.push(node);
-        index
+        key
     }
 
     /// Shrinks the capacity of the route store as much as possible.
@@ -124,13 +119,13 @@ impl<T> RouteStore<T> {
         self.nodes.shrink_to_fit();
     }
 
-    /// Returns a shared reference to the node at the given index.
-    pub fn get(&self, index: usize) -> &Node<T> {
-        self.nodes.get(index).unwrap()
+    /// Returns a shared reference to the node at the given `key`.
+    pub fn get(&self, key: usize) -> &Node<T> {
+        &self.nodes[key]
     }
 
-    /// Returns a mutable reference to the node at the given index.
-    pub fn get_mut(&mut self, index: usize) -> &mut Node<T> {
-        self.nodes.get_mut(index).unwrap()
+    /// Returns a mutable reference to the node at the given `key`.
+    pub fn get_mut(&mut self, key: usize) -> &mut Node<T> {
+        &mut self.nodes[key]
     }
 }

--- a/crates/via-router/src/visitor.rs
+++ b/crates/via-router/src/visitor.rs
@@ -1,5 +1,5 @@
-use crate::path::{PathSegments, Pattern};
-use crate::routes::{Node, RouteStore};
+use crate::path::Pattern;
+use crate::routes::RouteStore;
 
 /// Represents either a partial or exact match for a given path segment.
 pub struct Match<'a, T> {
@@ -20,138 +20,16 @@ pub struct Match<'a, T> {
     param: Option<&'static str>,
 }
 
-struct Visitor<'a, 'b, T> {
-    matched_routes: &'b mut Vec<Match<'a, T>>,
-    path_segments: &'b PathSegments<'b>,
-    route_store: &'a RouteStore<T>,
-}
+pub struct Visitor<'a, 'b, T> {
+    /// The url path that we are attempting to match against the route tree.
+    path_value: &'b str,
 
-struct Visit<'a> {
-    /// The index of the path segment that matches `self.node`.
-    index: usize,
+    /// A slice of tuples that contain the start and end offset of each path
+    /// segment in `self.path_value`.
+    segments: &'b [(usize, usize)],
 
-    /// The node that matches the path segment at `self.index`.
-    node: &'a Node,
-}
-
-pub fn visit<'a, 'b, T>(
-    matched_routes: &'b mut Vec<Match<'a, T>>,
-    path_segments: &'b PathSegments<'b>,
-    route_store: &'a RouteStore<T>,
-    node: &'a Node,
-) {
-    let mut visitor = Visitor {
-        matched_routes,
-        path_segments,
-        route_store,
-    };
-
-    // The root node is a special case that we always consider a match.
-    visitor.push(
-        // If there are no path segments to match against, we consider the root
-        // node to be an exact match.
-        path_segments.is_empty(),
-        // The root node's path segment range should produce to an empty str.
-        (0, 0),
-        None,
-        0,
-    );
-
-    // Begin the search for matches recursively starting with descendants of
-    // the root node.
-    visit_node(&mut visitor, Visit { index: 0, node });
-}
-
-/// Perform a shallow search for descendants of the current node that have a
-/// `CatchAll` pattern. This is required to support matching the "index" path
-/// of a descendant node with a `CatchAll` pattern.
-fn visit_catch_all_entries<T>(visitor: &mut Visitor<'_, '_, T>, visit: Visit) {
-    for index in visit.node.entries().copied() {
-        let node = visitor.route_store.node(index);
-
-        if let Pattern::CatchAll(param) = node.pattern {
-            // Add the matching node to the vector of matches and continue to
-            // search for adjacent nodes with a `CatchAll` pattern.
-            visitor.push(
-                // `CatchAll` patterns are always considered an exact match.
-                true,
-                // Due to the fact we are looking for `CatchAll` patterns as an
-                // immediate descendant of a node that we consider a match, we
-                // can safely assume that the path segment range should always
-                // produce an empty str.
-                (0, 0),
-                // Include the name of the dynamic segment even if the value
-                // of the path segment is empty.
-                Some(param),
-                index,
-            );
-        }
-    }
-}
-
-/// Recursively search for descendants of the current node that have a pattern
-/// that matches the path segment at `range`. If a match is found, we will add
-/// it to our vector of matches and continue to search for matching nodes at
-/// the next depth in the route tree.
-fn visit_matching_entries<'a, T>(
-    visitor: &mut Visitor<'a, '_, T>,
-    visit: Visit<'a>,
-    range: (usize, usize),
-) {
-    let path_segment = &visitor.path_segments.value[range.0..range.1];
-    let next_index = visit.index + 1;
-    let exact = next_index == visitor.path_segments.len();
-
-    for index in visit.node.entries().copied() {
-        let node = visitor.route_store.node(index);
-
-        match node.pattern {
-            Pattern::CatchAll(param) => {
-                // The next node has a `CatchAll` pattern and will be considered
-                // an exact match. Due to the nature of `CatchAll` patterns, we
-                // do not have to continue searching for descendants of this
-                // node that match the remaining path segments.
-                visitor.push(
-                    // `CatchAll` patterns are always considered an exact match.
-                    true,
-                    // The end offset of `path_segment_range` should be the end
-                    // offset of the last path segment in the url path since
-                    // `CatchAll` patterns match the entire remainder of the
-                    // url path from which they are matched.
-                    visitor.path_segments.slice_from(visit.index),
-                    Some(param),
-                    index,
-                );
-            }
-            Pattern::Dynamic(param) => {
-                // The next node has a `Dynamic` pattern. Therefore, we consider
-                // it a match regardless of the value of the path segment.
-                visitor.push(exact, range, Some(param), index);
-                visit_node(visitor, visit.next(node));
-            }
-            Pattern::Static(value) if value == path_segment => {
-                // The next node has a `Static` pattern that matches the value
-                // of the path segment.
-                visitor.push(exact, range, None, index);
-                visit_node(visitor, visit.next(node));
-            }
-            _ => {
-                // We don't have to check and see if the pattern is `Pattern::Root`
-                // since we already added our root node to the matches vector.
-            }
-        }
-    }
-}
-
-/// Recursively search for matches in the route tree starting at the current node.
-/// If there is no path segment to match against, we will attempt to find immediate
-/// descendants of the current node with a `CatchAll` pattern.
-fn visit_node<'a, T>(visitor: &mut Visitor<'a, '_, T>, visit: Visit<'a>) {
-    if let Some(range) = visitor.path_segments.get(visit.index) {
-        visit_matching_entries(visitor, visit, *range);
-    } else {
-        visit_catch_all_entries(visitor, visit);
-    }
+    /// A reference to the route store that contains the route tree.
+    store: &'a RouteStore<T>,
 }
 
 impl<'a, T> Match<'a, T> {
@@ -173,32 +51,163 @@ impl<'a, T> Match<'a, Vec<T>> {
 }
 
 impl<'a, 'b, T> Visitor<'a, 'b, T> {
-    fn push(
-        &mut self,
-        // Indicates whether or not the match is considered an exact match.
-        exact: bool,
-        // The start and end offset of the path segment that matches the node.
-        range: (usize, usize),
-        // The name of the dynamic segment that was matched against if the
-        // matched node has a `CatchAll` or `Dynamic` pattern.
-        param: Option<&'static str>,
-        // The index of the node that matches the path segment at `range`.
-        index: usize,
-    ) {
-        self.matched_routes.push(Match {
-            route: self.route_store.route_at_node(index),
-            exact,
-            param,
-            range,
+    pub fn new(
+        path_value: &'b str,
+        segments: &'b [(usize, usize)],
+        store: &'a RouteStore<T>,
+    ) -> Self {
+        Self {
+            path_value,
+            segments,
+            store,
+        }
+    }
+
+    pub fn visit(&self, results: &mut Vec<Match<'a, T>>) {
+        // The root node is a special case that we always consider a match.
+        results.push(Match {
+            // If there are no path segments to match against, we consider the root
+            // node to be an exact match.
+            exact: self.segments.is_empty(),
+            // The root node cannot have parameters.
+            param: None,
+            // The root node's path segment range should produce to an empty str.
+            range: (0, 0),
+            route: self.store.get(0).route(),
         });
+
+        // Begin the search for matches recursively starting with descendants of
+        // the root node.
+        self.visit_node(results, 0, 0)
     }
 }
 
-impl<'a> Visit<'a> {
-    fn next(&self, node: &'a Node) -> Self {
-        Self {
-            index: self.index + 1,
-            node,
+impl<'a, 'b, T> Visitor<'a, 'b, T> {
+    /// Recursively search for descendants of the node at `key` that have a
+    /// pattern that matches the path segment at `index`. If a match is found,
+    /// we'll add it to `results` and continue our search with the descendants
+    /// of matched node against the path segment at next index.
+    fn visit_descendants(
+        &self,
+        // A mutable reference to a vector that contains the matches that we
+        // have found so far.
+        results: &mut Vec<Match<'a, T>>,
+        // The start and end offset of the path segment at `index` in
+        // `self.path_value`.
+        range: (usize, usize),
+        // The index of the path segment in `self.segments` that we are matching
+        // against the node at `key`.
+        index: usize,
+        // The key of the parent node that contains the descendants that we are
+        // attempting to match against the path segment at `index`.
+        key: usize,
+    ) {
+        // Get the value of the path segment at `index`. We'll eagerly borrow
+        // and cache this slice from `self.path_value` to avoid having to build
+        // the reference for each descendant with a `Static` pattern.
+        let path_segment = &self.path_value[range.0..range.1];
+        // Eagerly calculate and store the next index to avoid having to do so
+        // for each descendant with a `Dynamic` or `Static` pattern.
+        let next_index = index + 1;
+        // Use the value of `next_index` to determine if we are working with the
+        // last path segment in `self.segments`. If so, we'll consider any
+        // matching descendant to be an exact match. We perform this check
+        // eagerly to avoid having to do so for each descendant with a
+        // `Dynamic` or `Static` pattern.
+        let exact = next_index == self.segments.len();
+
+        // Iterate over the keys of the descendants of the node at `key`.
+        for next_key in self.store.get(key).entries().copied() {
+            // Get the node at `next_key` from the route store.
+            let descendant = self.store.get(next_key);
+
+            // Check if `descendant` has a pattern that matches `path_segment`.
+            match descendant.pattern {
+                Pattern::CatchAll(param) => {
+                    // The next node has a `CatchAll` pattern and will be considered
+                    // an exact match. Due to the nature of `CatchAll` patterns, we
+                    // do not have to continue searching for descendants of this
+                    // node that match the remaining path segments.
+                    results.push(Match {
+                        // `CatchAll` patterns are always considered an exact match.
+                        exact: true,
+                        // The end offset of `path_segment_range` should be the end
+                        // offset of the last path segment in the url path since
+                        // `CatchAll` patterns match the entire remainder of the
+                        // url path from which they are matched.
+                        range: (range.0, self.path_value.len()),
+                        param: Some(param),
+                        route: descendant.route(),
+                    });
+                }
+                Pattern::Dynamic(param) => {
+                    // The next node has a `Dynamic` pattern. Therefore, we consider
+                    // it a match regardless of the value of the path segment.
+                    results.push(Match {
+                        exact,
+                        range,
+                        param: Some(param),
+                        route: descendant.route(),
+                    });
+
+                    self.visit_node(results, next_index, next_key);
+                }
+                Pattern::Static(value) if value == path_segment => {
+                    // The next node has a `Static` pattern that matches the value
+                    // of the path segment.
+                    results.push(Match {
+                        exact,
+                        range,
+                        param: None,
+                        route: descendant.route(),
+                    });
+
+                    self.visit_node(results, next_index, next_key);
+                }
+                _ => {
+                    // We don't have to check and see if the pattern is `Pattern::Root`
+                    // since we already added our root node to the matches vector.
+                }
+            }
+        }
+    }
+
+    /// Recursively search for matches in the route tree starting with the
+    /// descendants of the node at `key`. If there is not a path segment in
+    /// `self.segements` at `index` to match against the descendants of the
+    /// node at `key`, we'll instead perform a shallow search for descendants
+    /// with a `CatchAll` pattern.
+    fn visit_node(&self, results: &mut Vec<Match<'a, T>>, index: usize, key: usize) {
+        // Check if there is a path segment at `index` to match against
+        if let Some(range) = self.segments.get(index).copied() {
+            return self.visit_descendants(results, range, index, key);
+        }
+
+        // Perform a shallow search for descendants of the current node that
+        // have a `CatchAll` pattern. This is required to support matching the
+        // "index" path of a descendant node with a `CatchAll` pattern.
+        for next_key in self.store.get(key).entries().copied() {
+            // Get the node at `next_key` from the route store.
+            let descendant = self.store.get(next_key);
+
+            // Check if `descendant` has a `CatchAll` pattern.
+            if let Pattern::CatchAll(param) = descendant.pattern {
+                // Add the matching node to the vector of matches and continue to
+                // search for adjacent nodes with a `CatchAll` pattern.
+                results.push(Match {
+                    // `CatchAll` patterns are always considered an exact match.
+                    exact: true,
+                    // Include the name of the dynamic segment even if the value
+                    // of the path segment is empty for API consistency.
+                    param: Some(param),
+                    // Due to the fact we are looking for `CatchAll` patterns as an
+                    // immediate descendant of a node that we consider a match, we
+                    // can safely assume that the path segment range should always
+                    // produce an empty str.
+                    range: (0, 0),
+                    route: descendant.route(),
+                });
+            }
         }
     }
 }

--- a/crates/via-router/src/visitor.rs
+++ b/crates/via-router/src/visitor.rs
@@ -123,6 +123,30 @@ impl<'a, 'b, T> Visitor<'a, 'b, T> {
 
             // Check if `descendant` has a pattern that matches `path_segment`.
             match descendant.pattern {
+                Pattern::Static(value) if value == path_segment => {
+                    // The next node has a `Static` pattern that matches the value
+                    // of the path segment.
+                    results.push(Match {
+                        exact,
+                        range,
+                        param: None,
+                        route: descendant.route(),
+                    });
+
+                    self.visit_node(results, next_index, next_key);
+                }
+                Pattern::Dynamic(param) => {
+                    // The next node has a `Dynamic` pattern. Therefore, we consider
+                    // it a match regardless of the value of the path segment.
+                    results.push(Match {
+                        exact,
+                        range,
+                        param: Some(param),
+                        route: descendant.route(),
+                    });
+
+                    self.visit_node(results, next_index, next_key);
+                }
                 Pattern::CatchAll(param) => {
                     // The next node has a `CatchAll` pattern and will be considered
                     // an exact match. Due to the nature of `CatchAll` patterns, we
@@ -139,30 +163,6 @@ impl<'a, 'b, T> Visitor<'a, 'b, T> {
                         param: Some(param),
                         route: descendant.route(),
                     });
-                }
-                Pattern::Dynamic(param) => {
-                    // The next node has a `Dynamic` pattern. Therefore, we consider
-                    // it a match regardless of the value of the path segment.
-                    results.push(Match {
-                        exact,
-                        range,
-                        param: Some(param),
-                        route: descendant.route(),
-                    });
-
-                    self.visit_node(results, next_index, next_key);
-                }
-                Pattern::Static(value) if value == path_segment => {
-                    // The next node has a `Static` pattern that matches the value
-                    // of the path segment.
-                    results.push(Match {
-                        exact,
-                        range,
-                        param: None,
-                        route: descendant.route(),
-                    });
-
-                    self.visit_node(results, next_index, next_key);
                 }
                 _ => {
                     // We don't have to check and see if the pattern is `Pattern::Root`

--- a/src/app.rs
+++ b/src/app.rs
@@ -45,11 +45,14 @@ where
         self
     }
 
-    pub async fn listen<F, T>(self, address: T, listening: F) -> Result<(), Error>
+    pub async fn listen<F, T>(mut self, address: T, listening: F) -> Result<(), Error>
     where
         F: FnOnce(&SocketAddr),
         T: ToSocketAddrs,
     {
+        // Shrink the router to fit the number of routes that have been added.
+        self.router.shrink_to_fit();
+
         let state = self.state;
         let router = Arc::new(self.router);
         let listener = TcpListener::bind(address).await?;

--- a/src/router.rs
+++ b/src/router.rs
@@ -65,7 +65,7 @@ impl<'a, State> Endpoint<'a, State> {
     }
 
     fn route_mut(&mut self) -> &mut Vec<MatchWhen<State>> {
-        self.inner.get_or_insert_route_with(|| Box::new(Vec::new()))
+        self.inner.get_or_insert_route_with(Vec::new)
     }
 }
 

--- a/src/router.rs
+++ b/src/router.rs
@@ -85,6 +85,10 @@ where
         }
     }
 
+    pub fn shrink_to_fit(&mut self) {
+        self.inner.shrink_to_fit();
+    }
+
     pub fn lookup(&self, request: &mut Request<State>) -> Next<State> {
         let (params, path) = request.params_mut_with_path();
         let mut stack = VecDeque::with_capacity(32);


### PR DESCRIPTION
Attempts to clean up the code in via-router similar to #12 but keeps the business logic within `impl Visitor` block. The code in this PR seems easier to reason about and the performance is better (if you drop the changes in [`192d075`](https://github.com/zacharygolba/via/pull/13/commits/192d075ce9f2091117559a43f956c1d402ece343)).