### PR TITLE
feat(via): wait for connections to close before exit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ bytes = "1.7"
 futures-core = { version = "0.3", default-features = false }
 http = "1"
 hyper = { features = ["http1", "server"], version = "1.4" }
-hyper-util = { version = "0.1", features = ["http1", "server-graceful", "tokio"] }
+hyper-util = { version = "0.1", features = ["tokio"] }
 percent-encoding = "2.3"
 serde = { optional = true, version = "1" }
 serde_json = { optional = true, version = "1" }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,5 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::net::{TcpListener, ToSocketAddrs};
 
 use crate::router::{Endpoint, Router};
@@ -10,12 +9,8 @@ use crate::{Error, Middleware};
 /// The default value of the maximum number of concurrent connections.
 const DEFAULT_MAX_CONNECTIONS: usize = 256;
 
-/// The default value of the response timeout in seconds.
-const DEFAULT_RESPONSE_TIMEOUT: u64 = 60;
-
 pub struct App<State> {
     max_connections: usize,
-    response_timeout: Duration,
     router: Router<State>,
     state: Arc<State>,
 }
@@ -27,7 +22,6 @@ where
 {
     App {
         max_connections: DEFAULT_MAX_CONNECTIONS,
-        response_timeout: Duration::from_secs(DEFAULT_RESPONSE_TIMEOUT),
         router: Router::new(),
         state: Arc::new(state),
     }
@@ -60,14 +54,6 @@ where
         self
     }
 
-    /// Sets the amount of time in seconds that the server will wait while
-    /// generating a response before responding with a 504 Gateway Timeout. The
-    /// default value is 1 minute.
-    pub fn response_timeout(mut self, timeout: u64) -> Self {
-        self.response_timeout = Duration::from_secs(timeout);
-        self
-    }
-
     pub async fn listen<F, T>(self, address: T, listening: F) -> Result<(), Error>
     where
         F: FnOnce(&SocketAddr),
@@ -91,13 +77,6 @@ where
         }
 
         // Serve incoming connections from the TCP listener.
-        serve(
-            state,
-            router,
-            listener,
-            self.max_connections,
-            self.response_timeout,
-        )
-        .await
+        serve(state, router, listener, self.max_connections).await
     }
 }

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -41,6 +41,9 @@ where
     let semaphore = Arc::new(Semaphore::new(max_connections));
 
     loop {
+        // Remove any handles that have finished.
+        inflight.retain(|handle| !handle.is_finished());
+
         tokio::select! {
             // Wait for a new connection to be accepted.
             result = accept(&listener, &semaphore) => {
@@ -123,9 +126,6 @@ where
                 break;
             }
         }
-
-        // Remove any handles that have finished.
-        inflight.retain(|handle| !handle.is_finished());
     }
 
     tokio::select! {

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -40,18 +40,6 @@ where
         // Remove any handles that have finished.
         handles.retain(|handle| !handle.is_finished());
 
-        let mut rx = rx.clone();
-
-        // Create a hyper service to serve the incoming connection. We'll move
-        // the service into a tokio task to distribute the load across multiple
-        // threads.
-        let service = {
-            let router = Arc::clone(&router);
-            let state = Arc::clone(&state);
-
-            Service::new(router, state, response_timeout)
-        };
-
         tokio::select! {
             result = accept(&listener, &semaphore) => {
                 let (permit, (stream, _addr)) = match result {
@@ -65,6 +53,19 @@ where
                         //
                         continue;
                     }
+                };
+
+
+                let mut rx = rx.clone();
+
+                // Create a hyper service to serve the incoming connection. We'll move
+                // the service into a tokio task to distribute the load across multiple
+                // threads.
+                let service = {
+                    let router = Arc::clone(&router);
+                    let state = Arc::clone(&state);
+
+                    Service::new(router, state, response_timeout)
                 };
 
                 // Create a new connection for the configured HTTP version. For

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -1,9 +1,11 @@
 use hyper::server::conn::http1;
 use hyper_util::rt::{TokioIo, TokioTimer};
+use std::net::SocketAddr;
+use std::pin::pin;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::net::TcpListener;
-use tokio::sync::Semaphore;
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::{watch, OwnedSemaphorePermit, Semaphore};
 use tokio::task::{self, JoinHandle};
 
 use super::service::Service;
@@ -24,6 +26,10 @@ where
     // periodically check if any of the tasks have finished and remove them.
     let mut handles: Vec<JoinHandle<()>> = Vec::new();
 
+    let mut signal = pin!(tokio::signal::ctrl_c());
+
+    let (tx, rx) = watch::channel(false);
+
     // Create a semaphore with a number of permits equal to the maximum number
     // of connections that the server can handle concurrently. If the maximum
     // number of connections is reached, we'll wait until a permit is available
@@ -33,6 +39,8 @@ where
     loop {
         // Remove any handles that have finished.
         handles.retain(|handle| !handle.is_finished());
+
+        let mut rx = rx.clone();
 
         // Create a hyper service to serve the incoming connection. We'll move
         // the service into a tokio task to distribute the load across multiple
@@ -44,47 +52,98 @@ where
             Service::new(router, state, response_timeout)
         };
 
-        // Acquire a permit from the semaphore.
-        let permit = semaphore.clone().acquire_many_owned(2).await?;
+        tokio::select! {
+            result = accept(&listener, &semaphore) => {
+                let (permit, (stream, _addr)) = match result {
+                    Ok(accepted) => accepted,
+                    Err(_) => {
+                        //
+                        // TODO:
+                        //
+                        // Include tracing information about why the connection could not
+                        // be accepted.
+                        //
+                        continue;
+                    }
+                };
 
-        // Attempt to accept a new connection from the TCP listener.
-        let (stream, _addr) = match listener.accept().await {
-            Ok(accepted) => accepted,
-            Err(_) => {
-                drop(permit);
-                //
-                // TODO:
-                //
-                // Include tracing information about why the connection could not
-                // be accepted.
-                //
-                continue;
+                // Create a new connection for the configured HTTP version. For
+                // now we only support HTTP/1.1. This will be expanded to
+                // support HTTP/2 in the future.
+                let connection = http1::Builder::new()
+                    .timer(TokioTimer::new())
+                    .serve_connection(TokioIo::new(stream), service);
+
+                // Spawn a tokio task to serve the connection in a separate thread.
+                handles.push(task::spawn(async move {
+                    let mut connection = pin!(connection);
+
+                    tokio::select! {
+                        result = connection.as_mut() => {
+                            drop(permit);
+
+                            if let Err(error) = result {
+                                //
+                                // TODO:
+                                //
+                                // Replace eprintln with pretty_env_logger or something similar.
+                                // We should also determine if this is how we want to handle
+                                // connection errors long-term.
+                                //
+                                if cfg!(debug_assertions) {
+                                    eprintln!("Error: {}", error);
+                                }
+                            }
+                        }
+                        _ = rx.changed() => {
+                            drop(permit);
+                            connection.graceful_shutdown();
+                        }
+                    }
+                }));
             }
-        };
-
-        // Create a new connection for the configured HTTP version. For
-        // now we only support HTTP/1.1. This will be expanded to
-        // support HTTP/2 in the future.
-        let connection = http1::Builder::new()
-            .timer(TokioTimer::new())
-            .serve_connection(TokioIo::new(stream), service);
-
-        // Spawn a tokio task to serve the connection in a separate thread.
-        handles.push(task::spawn(async {
-            if let Err(error) = connection.await {
-                //
-                // TODO:
-                //
-                // Replace eprintln with pretty_env_logger or something similar.
-                // We should also determine if this is how we want to handle
-                // connection errors long-term.
-                //
-                if cfg!(debug_assertions) {
-                    eprintln!("Error: {}", error);
-                }
+            _ = signal.as_mut() => {
+                tx.send(true)?;
+                break;
             }
+        }
+    }
 
+    let shutdown = async {
+        while !handles.is_empty() {
+            handles.retain(|handle| !handle.is_finished());
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            println!("Waiting for {} connections to close...", handles.len());
+        }
+    };
+
+    tokio::select! {
+        _ = shutdown => Ok(()),
+        _ = tokio::time::sleep(Duration::from_secs(30)) => {
+            Err(Error::new("process exited before all connections were closed.".to_string()))
+        }
+    }
+}
+
+async fn accept(
+    listener: &TcpListener,
+    semaphore: &Arc<Semaphore>,
+) -> Result<(OwnedSemaphorePermit, (TcpStream, SocketAddr)), Error> {
+    // Acquire a permit from the semaphore.
+    let permit = semaphore.clone().acquire_many_owned(2).await?;
+
+    // Attempt to accept a new connection from the TCP listener.
+    match listener.accept().await {
+        Ok(accepted) => Ok((permit, accepted)),
+        Err(error) => {
             drop(permit);
-        }));
+            //
+            // TODO:
+            //
+            // Include tracing information about why the connection could not
+            // be accepted.
+            //
+            Err(error.into())
+        }
     }
 }


### PR DESCRIPTION
Implements graceful shutdown for the server when a signal is sent to the main process with `ctrl+c`. If connections remain open for longer than the `shutdown_timeout`, an error will be returned from `app.listen` resulting in a non-zero exit code. 