### PR TITLE
feat(via): work in progress mutex wrapper around TcpStream

### DIFF
--- a/src/server/io_stream.rs
+++ b/src/server/io_stream.rs
@@ -1,14 +1,43 @@
 use hyper::rt::{Read, ReadBufCursor, Write};
+use std::future::Future;
 use std::io::{self, IoSlice};
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, OwnedMutexGuard};
+
+type IoStreamGuard<T> = OwnedMutexGuard<Pin<Box<T>>>;
 
 /// A wrapper around a stream that implements both `AsyncRead` and `AsyncWrite`.
 pub struct IoStream<T> {
     is_write_vectored: bool,
-    stream: Mutex<Pin<Box<T>>>,
+    guard_future: Option<Pin<Box<dyn Future<Output = IoStreamGuard<T>> + Send + Sync>>>,
+    stream: Arc<Mutex<Pin<Box<T>>>>,
+}
+
+/// Attempts to get a new or existing `IoStreamGuard` in a non-blocking manner.
+macro_rules! try_lock {
+    ($io:ident, $context:ident) => {{
+        let mut io = $io;
+
+        loop {
+            return match &mut io.guard_future {
+                Some(guard_future) => match Pin::as_mut(guard_future).poll($context) {
+                    Poll::Pending => Poll::Pending,
+                    Poll::Ready(guard) => {
+                        io.guard_future = None;
+                        break guard;
+                    }
+                },
+                None => {
+                    let guard_future = Arc::clone(&io.stream).lock_owned();
+                    io.guard_future = Some(Box::pin(guard_future));
+                    continue;
+                }
+            };
+        }
+    }};
 }
 
 impl<T> IoStream<T>
@@ -18,27 +47,22 @@ where
     pub fn new(stream: T) -> Self {
         Self {
             is_write_vectored: stream.is_write_vectored(),
-            stream: Mutex::new(Box::pin(stream)),
+            guard_future: None,
+            stream: Arc::new(Mutex::new(Box::pin(stream))),
         }
     }
 }
 
 impl<R> Read for IoStream<R>
 where
-    R: AsyncRead + Unpin,
+    R: AsyncRead + Send + Sync + Unpin + 'static,
 {
     fn poll_read(
         self: Pin<&mut Self>,
         context: &mut Context<'_>,
         mut buf: ReadBufCursor<'_>,
     ) -> Poll<Result<(), io::Error>> {
-        let mut guard = match self.stream.try_lock() {
-            Ok(guard) => guard,
-            Err(_) => {
-                context.waker().wake_by_ref();
-                return Poll::Pending;
-            }
-        };
+        let mut guard = try_lock!(self, context);
         let mut tokio_buf = unsafe {
             //
             // Safety:
@@ -53,10 +77,9 @@ where
             //
             ReadBuf::uninit(buf.as_mut())
         };
-        let result = {
-            let stream = &mut *guard;
-            stream.as_mut().poll_read(context, &mut tokio_buf)
-        };
+
+        let stream = Pin::as_mut(&mut guard);
+        let result = stream.poll_read(context, &mut tokio_buf);
 
         if let Poll::Ready(Ok(())) = &result {
             // Get the number of bytes that were read into the uninitialized
@@ -79,58 +102,40 @@ where
             }
         }
 
-        result
+        return result;
     }
 }
 
 impl<W> Write for IoStream<W>
 where
-    W: AsyncWrite + Unpin,
+    W: AsyncWrite + Send + Sync + Unpin + 'static,
 {
     fn poll_write(
         self: Pin<&mut Self>,
         context: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<Result<usize, io::Error>> {
-        let mut guard = match self.stream.try_lock() {
-            Ok(guard) => guard,
-            Err(_) => {
-                context.waker().wake_by_ref();
-                return Poll::Pending;
-            }
-        };
-        let stream = &mut *guard;
+        let mut guard = try_lock!(self, context);
+        let stream = Pin::as_mut(&mut guard);
 
-        stream.as_mut().poll_write(context, buf)
+        stream.poll_write(context, buf)
     }
 
     fn poll_flush(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-        let mut guard = match self.stream.try_lock() {
-            Ok(guard) => guard,
-            Err(_) => {
-                context.waker().wake_by_ref();
-                return Poll::Pending;
-            }
-        };
-        let stream = &mut *guard;
+        let mut guard = try_lock!(self, context);
+        let stream = Pin::as_mut(&mut guard);
 
-        stream.as_mut().poll_flush(context)
+        stream.poll_flush(context)
     }
 
     fn poll_shutdown(
         self: Pin<&mut Self>,
         context: &mut Context<'_>,
     ) -> Poll<Result<(), io::Error>> {
-        let mut guard = match self.stream.try_lock() {
-            Ok(guard) => guard,
-            Err(_) => {
-                context.waker().wake_by_ref();
-                return Poll::Pending;
-            }
-        };
-        let stream = &mut *guard;
+        let mut guard = try_lock!(self, context);
+        let stream = Pin::as_mut(&mut guard);
 
-        stream.as_mut().poll_shutdown(context)
+        stream.poll_shutdown(context)
     }
 
     fn poll_write_vectored(
@@ -138,16 +143,10 @@ where
         context: &mut Context<'_>,
         buf_list: &[IoSlice<'_>],
     ) -> Poll<Result<usize, io::Error>> {
-        let mut guard = match self.stream.try_lock() {
-            Ok(guard) => guard,
-            Err(_) => {
-                context.waker().wake_by_ref();
-                return Poll::Pending;
-            }
-        };
-        let stream = &mut *guard;
+        let mut guard = try_lock!(self, context);
+        let stream = Pin::as_mut(&mut guard);
 
-        stream.as_mut().poll_write_vectored(context, buf_list)
+        stream.poll_write_vectored(context, buf_list)
     }
 
     fn is_write_vectored(&self) -> bool {

--- a/src/server/io_stream.rs
+++ b/src/server/io_stream.rs
@@ -1,3 +1,9 @@
+//! A wrapper around a stream that implements both `AsyncRead` and `AsyncWrite`.
+//
+// This code was originally adapted from the `hyper_util::rt::tokio::TokioIo`
+// struct in [hyper-util](https://docs.rs/hyper-util).
+//
+
 use hyper::rt::{Read, ReadBufCursor, Write};
 use std::future::Future;
 use std::io::{self, IoSlice};

--- a/src/server/io_stream.rs
+++ b/src/server/io_stream.rs
@@ -141,7 +141,7 @@ where
             }
         }
 
-        return result;
+        result
     }
 }
 

--- a/src/server/io_stream.rs
+++ b/src/server/io_stream.rs
@@ -117,8 +117,7 @@ where
             ReadBuf::uninit(buf.as_mut())
         };
 
-        let stream = Pin::as_mut(&mut guard);
-        let result = stream.poll_read(context, &mut tokio_buf);
+        let result = guard.as_mut().poll_read(context, &mut tokio_buf);
 
         if let Poll::Ready(Ok(())) = &result {
             // Get the number of bytes that were read into the uninitialized
@@ -155,16 +154,14 @@ where
         buf: &[u8],
     ) -> Poll<Result<usize, io::Error>> {
         let mut guard = try_lock_write!(self, context);
-        let stream = Pin::as_mut(&mut guard);
 
-        stream.poll_write(context, buf)
+        guard.as_mut().poll_write(context, buf)
     }
 
     fn poll_flush(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
         let mut guard = try_lock_write!(self, context);
-        let stream = Pin::as_mut(&mut guard);
 
-        stream.poll_flush(context)
+        guard.as_mut().poll_flush(context)
     }
 
     fn poll_shutdown(
@@ -172,9 +169,8 @@ where
         context: &mut Context<'_>,
     ) -> Poll<Result<(), io::Error>> {
         let mut guard = try_lock_write!(self, context);
-        let stream = Pin::as_mut(&mut guard);
 
-        stream.poll_shutdown(context)
+        guard.as_mut().poll_shutdown(context)
     }
 
     fn poll_write_vectored(
@@ -183,9 +179,8 @@ where
         buf_list: &[IoSlice<'_>],
     ) -> Poll<Result<usize, io::Error>> {
         let mut guard = try_lock_write!(self, context);
-        let stream = Pin::as_mut(&mut guard);
 
-        stream.poll_write_vectored(context, buf_list)
+        guard.as_mut().poll_write_vectored(context, buf_list)
     }
 
     fn is_write_vectored(&self) -> bool {

--- a/src/server/io_stream.rs
+++ b/src/server/io_stream.rs
@@ -60,11 +60,11 @@ impl<T> IoStream<T>
 where
     T: AsyncRead + AsyncWrite,
 {
-    pub fn new(stream: T) -> Self {
+    pub fn new(stream: Pin<Box<T>>) -> Self {
         Self {
             is_write_vectored: stream.is_write_vectored(),
             io_state: IoState::Idle,
-            stream: Arc::new(Mutex::new(Box::pin(stream))),
+            stream: Arc::new(Mutex::new(stream)),
         }
     }
 }

--- a/src/server/io_stream.rs
+++ b/src/server/io_stream.rs
@@ -81,7 +81,7 @@ macro_rules! try_lock_write {
 
 impl<T> IoStream<T>
 where
-    T: AsyncRead + AsyncWrite + Unpin,
+    T: AsyncRead + AsyncWrite,
 {
     pub fn new(stream: T) -> Self {
         Self {
@@ -94,7 +94,7 @@ where
 
 impl<R> Read for IoStream<R>
 where
-    R: AsyncRead + Send + Sync + Unpin + 'static,
+    R: AsyncRead + Send + Sync + 'static,
 {
     fn poll_read(
         self: Pin<&mut Self>,
@@ -147,7 +147,7 @@ where
 
 impl<W> Write for IoStream<W>
 where
-    W: AsyncWrite + Send + Sync + Unpin + 'static,
+    W: AsyncWrite + Send + Sync + 'static,
 {
     fn poll_write(
         self: Pin<&mut Self>,

--- a/src/server/io_stream.rs
+++ b/src/server/io_stream.rs
@@ -29,10 +29,10 @@ macro_rules! try_lock {
         // represents the type of operation that the guard is being acquired
         // for.
         $ty:ident,
-        // Should be an identifier of type `Pin<&mut IoStream<T>>`.
-        $this:ident,
-        // Should be an identifier of type `&mut Context<'_>`.
-        $context:ident
+        // Should be an expression of type `Pin<&mut IoStream<T>>`.
+        $this:expr,
+        // Should be an expression of type `&mut Context<'_>`.
+        $context:expr
     ) => {{
         let mut this = $this;
 

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -43,9 +43,6 @@ where
     let semaphore = Arc::new(Semaphore::new(max_connections));
 
     loop {
-        // Remove any handles that have finished.
-        inflight.retain(|handle| !handle.is_finished());
-
         tokio::select! {
             // Wait for a new connection to be accepted.
             result = accept(&listener, &semaphore) => {
@@ -133,6 +130,9 @@ where
                 break;
             }
         }
+
+        // Remove any handles that have finished.
+        inflight.retain(|handle| !handle.is_finished());
     }
 
     tokio::select! {

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -58,7 +58,6 @@ where
                         continue;
                     }
                 };
-                let stream = Box::pin(stream);
 
                 // Clone the watch channel so that we can notify the connection
                 // to initiate a graceful shutdown process before the server

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -61,6 +61,7 @@ where
                         continue;
                     }
                 };
+                let stream = Box::pin(stream);
 
                 // Clone the watch channel so that we can notify the connection
                 // to initiate a graceful shutdown process before the server


### PR DESCRIPTION
An of `IoStream` that uses a `Mutex` to uphold the safety requirements expressed in the comments of the unsafe blocks in the `poll_read` implementation.

