### PR TITLE
feat(via): optionally decode path and query params

### DIFF
--- a/crates/via-serve-static/src/respond.rs
+++ b/crates/via-serve-static/src/respond.rs
@@ -115,7 +115,7 @@ fn build_path_from_request<State>(
     request: &Request<State>,
     config: &ServerConfig,
 ) -> Result<PathBuf> {
-    let path_param = request.param(config.path_param).required()?;
+    let path_param = request.param(config.path_param).into_result()?;
     Ok(config.public_dir.join(path_param.trim_end_matches('/')))
 }
 

--- a/docs/examples/hello-world/src/main.rs
+++ b/docs/examples/hello-world/src/main.rs
@@ -2,7 +2,7 @@ use via::{Error, Next, Request, Server};
 
 async fn hello(request: Request, _: Next) -> Result<String, Error> {
     // Get a reference to the path parameter `name` from the request uri.
-    let name = request.param("name").into_result()?;
+    let name = request.param("name").percent_decode().into_result()?;
 
     // Send a plain text response with our greeting message.
     Ok(format!("Hello, {}!", name))

--- a/docs/examples/hello-world/src/main.rs
+++ b/docs/examples/hello-world/src/main.rs
@@ -2,7 +2,7 @@ use via::{Error, Next, Request, Server};
 
 async fn hello(request: Request, _: Next) -> Result<String, Error> {
     // Get a reference to the path parameter `name` from the request uri.
-    let name = request.param("name").required()?;
+    let name = request.param("name").into_result()?;
 
     // Send a plain text response with our greeting message.
     Ok(format!("Hello, {}!", name))

--- a/docs/examples/static-files/src/main.rs
+++ b/docs/examples/static-files/src/main.rs
@@ -2,7 +2,7 @@ use via::{Error, Next, Request, Response, Server};
 use via_serve_static::serve_static;
 
 async fn not_found(request: Request, _: Next) -> Result<Response, Error> {
-    let path = request.param("path").required()?;
+    let path = request.param("path").into_result()?;
     let html = format!(
         "
         <!DOCTYPE html>

--- a/docs/examples/tls-rustls/src/main.rs
+++ b/docs/examples/tls-rustls/src/main.rs
@@ -4,7 +4,7 @@ use via::{Error, Next, Request, Server};
 
 async fn hello(request: Request, _: Next) -> Result<String, Error> {
     // Get a reference to the path parameter `name` from the request uri.
-    let name = request.param("name").required()?;
+    let name = request.param("name").percent_decode().into_result()?;
 
     // Send a plain text response with our greeting message.
     Ok(format!("Hello, {}! (via TLS)", name))

--- a/src/request/params/decode.rs
+++ b/src/request/params/decode.rs
@@ -3,26 +3,28 @@ use std::borrow::Cow;
 
 use crate::error::Error;
 
-/// A trait that defines how to decode the value of a `Param`.
+/// A trait that defines how to decode the value of a parameter.
+///
 pub trait DecodeParam {
     fn decode(encoded: &str) -> Result<Cow<str>, Error>;
 }
 
-/// A decoder that does nothing. This is used in cases where we know the value
-/// of a `Param` is already in the correct format.
-pub struct NoopDecoder;
+/// The default decoder used for unencoded path and query params.
+///
+pub struct NoopDecode;
 
-/// A decoder that decodes a percent-encoded `&str`.
-pub struct PercentDecoder;
+/// The decoder used for percent-encoded path and query params.
+///
+pub struct PercentDecode;
 
-impl DecodeParam for NoopDecoder {
+impl DecodeParam for NoopDecode {
     #[inline]
     fn decode(encoded: &str) -> Result<Cow<str>, Error> {
         Ok(Cow::Borrowed(encoded))
     }
 }
 
-impl DecodeParam for PercentDecoder {
+impl DecodeParam for PercentDecode {
     fn decode(encoded: &str) -> Result<Cow<str>, Error> {
         Ok(percent_decode_str(encoded).decode_utf8()?)
     }

--- a/src/request/params/mod.rs
+++ b/src/request/params/mod.rs
@@ -1,11 +1,13 @@
-mod decode;
+pub mod decode;
+
 mod param;
 mod path_params;
 mod query_param;
 mod query_parser;
 
-pub use decode::{DecodeParam, NoopDecoder, PercentDecoder};
 pub use param::Param;
 pub use query_param::{QueryParam, QueryParamIter};
 
 pub(crate) use path_params::PathParams;
+
+use decode::{DecodeParam, NoopDecode, PercentDecode};

--- a/src/request/params/param.rs
+++ b/src/request/params/param.rs
@@ -59,14 +59,6 @@ impl<'a, 'b, T: DecodeParam> Param<'a, 'b, T> {
         })
     }
 
-    /// Converts the param into an optional `Cow<'a, str>` if it exists and was
-    /// able to be decoded (if encoded). If the param does not exist or could not
-    /// be decoded, `None` is returned.
-    ///
-    pub fn ok(self) -> Option<Cow<'a, str>> {
-        self.into_result().ok()
-    }
-
     /// Returns a result with the parameter value if it exists. If the param is
     /// encoded, it will be decoded before it is returned.
     ///

--- a/src/request/params/param.rs
+++ b/src/request/params/param.rs
@@ -50,7 +50,7 @@ impl<'a, 'b, T: DecodeParam> Param<'a, 'b, T> {
         Error: From<<U as FromStr>::Err>,
         U: FromStr,
     {
-        self.required()?.parse().map_err(|error| {
+        self.into_result()?.parse().map_err(|error| {
             let mut error = Error::from(error);
             let status = StatusCode::BAD_REQUEST;
 
@@ -64,7 +64,7 @@ impl<'a, 'b, T: DecodeParam> Param<'a, 'b, T> {
     /// be decoded, `None` is returned.
     ///
     pub fn ok(self) -> Option<Cow<'a, str>> {
-        self.required().ok()
+        self.into_result().ok()
     }
 
     /// Returns a result with the parameter value if it exists. If the param is
@@ -73,10 +73,10 @@ impl<'a, 'b, T: DecodeParam> Param<'a, 'b, T> {
     /// # Errors
     ///
     /// If the parameter does not exist or could not be decoded with the
-    /// implementation of `T::decode`, an error is returned with a
-    /// `400 Bad Request` status code.
+    /// implementation of `T::decode`, an error is returned with a 400 Bad
+    /// Request status code.
     ///
-    pub fn required(self) -> Result<Cow<'a, str>, Error> {
+    pub fn into_result(self) -> Result<Cow<'a, str>, Error> {
         self.at
             .and_then(|at| {
                 let (start, end) = at?;

--- a/src/request/params/param.rs
+++ b/src/request/params/param.rs
@@ -3,10 +3,10 @@ use std::borrow::Cow;
 use std::marker::PhantomData;
 use std::str::FromStr;
 
-use super::{DecodeParam, NoopDecoder, PercentDecoder};
+use super::{DecodeParam, NoopDecode, PercentDecode};
 use crate::{Error, Result};
 
-pub struct Param<'a, 'b, T = NoopDecoder> {
+pub struct Param<'a, 'b, T = NoopDecode> {
     at: Option<Option<(usize, usize)>>,
     name: &'b str,
     source: &'a str,
@@ -33,7 +33,7 @@ impl<'a, 'b, T: DecodeParam> Param<'a, 'b, T> {
     /// Returns a new `Param` that will percent-decode the parameter value
     /// before it is used.
     ///
-    pub fn encoded(self) -> Param<'a, 'b, PercentDecoder> {
+    pub fn decode(self) -> Param<'a, 'b, PercentDecode> {
         Param {
             at: self.at,
             name: self.name,

--- a/src/request/params/param.rs
+++ b/src/request/params/param.rs
@@ -30,16 +30,23 @@ impl<'a, 'b, T: DecodeParam> Param<'a, 'b, T> {
         }
     }
 
-    /// Returns a new `Param` that will percent-decode the parameter value
-    /// before it is used.
+    /// Returns a new `Param` that will decode the parameter value with
+    /// `U::decode` when the parameter is converted to a result.
     ///
-    pub fn decode(self) -> Param<'a, 'b, PercentDecode> {
+    pub fn decode<U: DecodeParam>(self) -> Param<'a, 'b, U> {
         Param {
             at: self.at,
             name: self.name,
             source: self.source,
             _decode: PhantomData,
         }
+    }
+
+    /// Returns a new `Param` that will percent-decode the parameter value with
+    /// when the parameter is converted to a result.
+    ///
+    pub fn percent_decode(self) -> Param<'a, 'b, PercentDecode> {
+        self.decode()
     }
 
     /// Calls [`str::parse`] on the parameter value if it exists and returns the

--- a/src/request/params/query_param.rs
+++ b/src/request/params/query_param.rs
@@ -21,12 +21,22 @@ fn find_next(parser: &mut QueryParser, name: &str) -> Option<Option<(usize, usiz
 }
 
 impl<'a, 'b, T: DecodeParam> QueryParam<'a, 'b, T> {
-    pub fn decode(self) -> QueryParam<'a, 'b, PercentDecode> {
+    /// Returns a new `QueryParam` that will decode parameter values with
+    /// `U::decode` when an individual parameter is converted to a result.
+    ///
+    pub fn decode<U: DecodeParam>(self) -> QueryParam<'a, 'b, U> {
         QueryParam {
             name: self.name,
             parser: self.parser,
             _decode: PhantomData,
         }
+    }
+
+    /// Returns a new `QueryParam` that will percent-decode parameter values
+    /// when an individual parameter is converted to a result.
+    ///
+    pub fn percent_decode(self) -> QueryParam<'a, 'b, PercentDecode> {
+        self.decode()
     }
 
     pub fn exists(mut self) -> bool {

--- a/src/request/params/query_param.rs
+++ b/src/request/params/query_param.rs
@@ -1,41 +1,43 @@
 use std::borrow::Cow;
+use std::marker::PhantomData;
 
 use super::query_parser::QueryParser;
-use super::{DecodeParam, Param, PercentDecoder};
+use super::{DecodeParam, NoopDecoder, Param};
 
-pub struct QueryParam<'a, 'b> {
+pub struct QueryParam<'a, 'b, T = NoopDecoder> {
     name: &'b str,
     parser: QueryParser<'a>,
+    _decode: PhantomData<T>,
 }
 
-pub struct QueryParamIter<'a, 'b> {
+pub struct QueryParamIter<'a, 'b, T> {
     name: &'b str,
     parser: QueryParser<'a>,
+    _decode: PhantomData<T>,
 }
 
 fn find_next(parser: &mut QueryParser, name: &str) -> Option<Option<(usize, usize)>> {
     parser.find_map(|(n, at)| if n == name { Some(at) } else { None })
 }
 
-impl<'a, 'b> QueryParam<'a, 'b> {
-    pub fn exists(self) -> bool {
-        let QueryParam { name, mut parser } = self;
-
-        parser.any(|(n, _)| n == name)
+impl<'a, 'b, T: DecodeParam> QueryParam<'a, 'b, T> {
+    pub fn exists(mut self) -> bool {
+        self.parser.any(|(n, _)| n == self.name)
     }
 
-    pub fn first(self) -> Param<'a, 'b, PercentDecoder> {
-        let QueryParam { name, mut parser } = self;
-        let query = parser.input();
-        let at = find_next(&mut parser, name);
+    pub fn first(mut self) -> Param<'a, 'b, T> {
+        let query = self.parser.input();
+        let name = self.name;
+        let at = find_next(&mut self.parser, name);
 
         Param::new(at, name, query)
     }
 
-    pub fn last(self) -> Param<'a, 'b, PercentDecoder> {
-        let QueryParam { name, parser } = self;
-        let query = parser.input();
-        let at = parser
+    pub fn last(self) -> Param<'a, 'b> {
+        let query = self.parser.input();
+        let name = self.name;
+        let at = self
+            .parser
             .filter_map(|(n, at)| if n == name { Some(at) } else { None })
             .last();
 
@@ -43,34 +45,36 @@ impl<'a, 'b> QueryParam<'a, 'b> {
     }
 }
 
-impl<'a, 'b> QueryParam<'a, 'b> {
+impl<'a, 'b, T: DecodeParam> QueryParam<'a, 'b, T> {
     pub(crate) fn new(name: &'b str, query: &'a str) -> Self {
         Self {
             name,
             parser: QueryParser::new(query),
+            _decode: PhantomData,
         }
     }
 }
 
-impl<'a> Iterator for QueryParamIter<'a, '_> {
+impl<'a, T: DecodeParam> Iterator for QueryParamIter<'a, '_, T> {
     type Item = Cow<'a, str>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let (start, end) = find_next(&mut self.parser, self.name)??;
         let encoded = self.parser.input().get(start..end)?;
 
-        PercentDecoder::decode(encoded).ok()
+        T::decode(encoded).ok()
     }
 }
 
-impl<'a, 'b> IntoIterator for QueryParam<'a, 'b> {
+impl<'a, 'b, T: DecodeParam> IntoIterator for QueryParam<'a, 'b, T> {
     type Item = Cow<'a, str>;
-    type IntoIter = QueryParamIter<'a, 'b>;
+    type IntoIter = QueryParamIter<'a, 'b, T>;
 
     fn into_iter(self) -> Self::IntoIter {
         QueryParamIter {
             name: self.name,
             parser: self.parser,
+            _decode: PhantomData,
         }
     }
 }

--- a/src/request/request.rs
+++ b/src/request/request.rs
@@ -73,10 +73,8 @@ impl<State> Request<State> {
     /// use std::borrow::Cow;
     ///
     /// async fn hello(request: Request, _: Next) -> Result<String, Error> {
-    ///     let required: Result<Cow<str>, Error> = request.param("name").required();
-    ///     let _optional: Option<Cow<str>> = request.param("name").ok();
-    ///
-    ///     Ok(format!("Hello, {}!", required?))
+    ///     let name: Result<Cow<str>, Error> = request.param("name").into_result();
+    ///     Ok(format!("Hello, {}!", name?))
     /// }
     /// ```
     pub fn param<'a>(&self, name: &'a str) -> Param<'_, 'a> {
@@ -105,7 +103,7 @@ impl<State> Request<State> {
     ///     let n = request.query("n").first().parse().unwrap_or(1).min(1000);
     ///
     ///     // Get a reference to the path parameter `name` from the request uri.
-    ///     let name = request.param("name").required()?;
+    ///     let name = request.param("name").into_result()?;
     ///
     ///     // Create a greeting message with the provided `name`.
     ///     let message = format!("Hello, {}!\n", name);


### PR DESCRIPTION
Adds support for encoded URL path parameters. Also makes percent-decoding parameters optional by introducing the `decode` method to `Param` and `QueryParam`. Below is a modified version of the hello responder from the `hello-world` example that was used to test this feature.

```rust
use std::fmt::Write;
use via::{Error, Next, Request};

async fn hello(request: Request, _: Next) -> Result<String, Error> {
    // Attempt to parse the query parameter `n` to a `usize` no greater than
    // 1000. If the query parameter doesn't exist or can't be converted to a
    // `usize`, default to 1.
    let n = request.query("n").first().parse().unwrap_or(1).min(1000);

    // Get a reference to the path parameter `name` from the request uri.
    let name = request.param("name").percent_decode().into_result()?;

    // Create a greeting message with the provided name.
    let mut message = String::new();

    // Write a greeting message to the `message` buffer `n` times.
    for _ in 0..n {
        writeln!(&mut message, "Hello, {}!", name)?;
    }

    // Print a message to the console for each friend of the person with `name`.
    for friend in request
        .query("friend")
        .percent_decode()
        .into_iter()
        .take(100)
    {
        println!(
            "Hello, {}! Any friend of {} is a friend of mine.",
            friend, name
        );
    }

    // Send a response with our greeting message, repeated `n` times.
    Ok(message)
}

```

