### PR TITLE
refactor(via): improve code reuse and serialize impl for Error

### DIFF
--- a/docs/examples/blog-api/src/api/mod.rs
+++ b/docs/examples/blog-api/src/api/mod.rs
@@ -1,5 +1,6 @@
 pub mod posts;
 pub mod users;
+pub mod util;
 
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};

--- a/docs/examples/blog-api/src/api/util.rs
+++ b/docs/examples/blog-api/src/api/util.rs
@@ -1,0 +1,46 @@
+use diesel::result::Error as DieselError;
+use via::error::Error;
+use via::http::StatusCode;
+
+use crate::State;
+
+/// Used with the InspectErrorBoundary to log errors that occur on /api routes.
+///
+pub fn inspect_error(error: &Error, _: &State) {
+    // In production you'll likely want to use tracing or report to some error
+    // tracking service.
+    eprintln!("Error: {}", error);
+}
+
+/// Used with the MapErrorBoundary to map errors that occur on /api routes. This
+/// function ensures that errors that occur in the /api namespace respond with
+/// JSON and do not leak sensitive information to the client.
+///
+pub fn map_error(error: Error, _: &State) -> Error {
+    // Define the error argument as a mutable variable.
+    let mut error = error;
+
+    match error.source().downcast_ref() {
+        // The error occurred because a record was not found in the
+        // database, set the status to 404 Not Found.
+        Some(DieselError::NotFound) => {
+            error = Error::new("Not Found".to_string());
+            error.set_status(StatusCode::NOT_FOUND);
+        }
+
+        // The error occurred because of a database error. Return a
+        // new error with an opaque message.
+        Some(_) => {
+            error = Error::new("Internal Server Error".to_string());
+        }
+
+        // The error occurred for some other reason.
+        None => {}
+    }
+
+    // Configure the error to respond with JSON.
+    error.respond_with_json();
+
+    // Return the modified error.
+    error
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,12 @@
 #![allow(clippy::module_inception)]
 
 pub mod body;
+pub mod error;
 pub mod middleware;
 pub mod request;
 pub mod response;
 
 mod app;
-mod error;
 mod router;
 mod server;
 

--- a/src/middleware/timeout.rs
+++ b/src/middleware/timeout.rs
@@ -29,7 +29,7 @@ fn respond_with_timeout<State>(_: &State) -> Result<Response, Error> {
     message.push_str("The server is taking too long to respond. ");
     message.push_str("Please try again later.");
 
-    Ok(Error::with_status(message, status).into_response())
+    Ok(Error::new_with_status(message, status).into_response())
 }
 
 impl<State> Timeout<RespondWithTimeout<State>> {

--- a/src/request/body/body.rs
+++ b/src/request/body/body.rs
@@ -41,7 +41,8 @@ impl RequestBody {
 
         serde_json::from_slice(&buffer).map_err(|source| {
             let mut error = Error::from(source);
-            *error.status_mut() = StatusCode::BAD_REQUEST;
+
+            error.set_status(StatusCode::BAD_REQUEST);
             error
         })
     }

--- a/src/request/params/param.rs
+++ b/src/request/params/param.rs
@@ -15,9 +15,7 @@ pub struct Param<'a, 'b, T = NoopDecode> {
 
 fn missing_required_param<'a>(name: &str) -> Result<Cow<'a, str>, Error> {
     let message = format!("missing required parameter: \"{}\"", name);
-    let status = StatusCode::BAD_REQUEST;
-
-    Err(Error::with_status(message, status))
+    Err(Error::new_with_status(message, StatusCode::BAD_REQUEST))
 }
 
 impl<'a, 'b, T: DecodeParam> Param<'a, 'b, T> {
@@ -59,9 +57,8 @@ impl<'a, 'b, T: DecodeParam> Param<'a, 'b, T> {
     {
         self.into_result()?.parse().map_err(|error| {
             let mut error = Error::from(error);
-            let status = StatusCode::BAD_REQUEST;
 
-            *error.status_mut() = status;
+            error.set_status(StatusCode::BAD_REQUEST);
             error
         })
     }

--- a/src/response/response.rs
+++ b/src/response/response.rs
@@ -26,6 +26,13 @@ impl Response {
         }
     }
 
+    pub fn new_with_status(body: ResponseBody, status: StatusCode) -> Self {
+        let mut response = Self::new(body);
+
+        response.set_status(status);
+        response
+    }
+
     pub fn html(body: String) -> Self {
         let len = body.len();
 
@@ -151,18 +158,18 @@ impl Response {
         self.headers_mut().insert(name, value);
     }
 
-    /// A shorthand method for `*self.status_mut() = status`.
-    ///
-    pub fn set_status(&mut self, status: StatusCode) {
-        *self.response.status_mut() = status;
-    }
-
     pub fn status(&self) -> StatusCode {
         self.response.status()
     }
 
     pub fn status_mut(&mut self) -> &mut StatusCode {
         self.response.status_mut()
+    }
+
+    /// A shorthand method for `*self.status_mut() = status`.
+    ///
+    pub fn set_status(&mut self, status: StatusCode) {
+        *self.response.status_mut() = status;
     }
 
     pub fn version(&self) -> Version {


### PR DESCRIPTION
Cleans up the serialize impl for the Error type and improves code reuse in the error module.