### PR TITLE
fix(via-router): store routes adjacent to nodes

### DIFF
--- a/crates/via-router/benches/bench.rs
+++ b/crates/via-router/benches/bench.rs
@@ -78,6 +78,7 @@ static ROUTES: [&str; 100] = [
     "/api/:version/:resource",
     "/api/:version/:resource/:resource_id",
     "/api/:version/:resource/:resource_id/edit",
+    "/api/:version/:resource/:resource_id/comments/:comment_id",
     "/api/:version/:resource/:resource_id/delete",
     "/checkout",
     "/checkout/cart",
@@ -100,7 +101,6 @@ static ROUTES: [&str; 100] = [
     "/billing/history",
     "/billing/payment-methods",
     "/billing/invoice/:invoice_id",
-    "/report",
     "/report/user/:user_id",
     "/report/post/:post_id",
     "/report/comment/:comment_id",
@@ -108,7 +108,7 @@ static ROUTES: [&str; 100] = [
 ];
 
 #[bench]
-fn find_all_matches_heap(b: &mut Bencher) {
+fn find_matches_simple(b: &mut Bencher) {
     let mut router: Router<()> = Router::new();
 
     for path in ROUTES {
@@ -118,12 +118,12 @@ fn find_all_matches_heap(b: &mut Bencher) {
     router.shrink_to_fit();
 
     b.iter(|| {
-        router.visit("/api/v1/products/12358132134558/edit");
+        router.visit("/help/article/12345678987654321");
     });
 }
 
 #[bench]
-fn find_all_matches_stack(b: &mut Bencher) {
+fn find_matches_nested_stack(b: &mut Bencher) {
     let mut router: Router<()> = Router::new();
 
     for path in ROUTES {
@@ -133,6 +133,21 @@ fn find_all_matches_stack(b: &mut Bencher) {
     router.shrink_to_fit();
 
     b.iter(|| {
-        router.visit("/checkout/confirmation");
+        router.visit("/api/v1/products/12345678987654321/edit");
+    });
+}
+
+#[bench]
+fn find_matches_nested_heap(b: &mut Bencher) {
+    let mut router: Router<()> = Router::new();
+
+    for path in ROUTES {
+        let _ = router.at(path).get_or_insert_route_with(|| ());
+    }
+
+    router.shrink_to_fit();
+
+    b.iter(|| {
+        router.visit("/api/v1/products/12345678987654321/comments/12345678987654321");
     });
 }

--- a/crates/via-router/benches/bench.rs
+++ b/crates/via-router/benches/bench.rs
@@ -108,7 +108,7 @@ static ROUTES: [&str; 100] = [
 ];
 
 #[bench]
-fn find_all_matches(b: &mut Bencher) {
+fn find_all_matches_heap(b: &mut Bencher) {
     let mut router: Router<()> = Router::new();
 
     for path in ROUTES {
@@ -119,5 +119,20 @@ fn find_all_matches(b: &mut Bencher) {
 
     b.iter(|| {
         router.visit("/api/v1/products/12358132134558/edit");
+    });
+}
+
+#[bench]
+fn find_all_matches_stack(b: &mut Bencher) {
+    let mut router: Router<()> = Router::new();
+
+    for path in ROUTES {
+        let _ = router.at(path).get_or_insert_route_with(|| ());
+    }
+
+    router.shrink_to_fit();
+
+    b.iter(|| {
+        router.visit("/checkout/confirmation");
     });
 }

--- a/crates/via-router/src/iter.rs
+++ b/crates/via-router/src/iter.rs
@@ -17,11 +17,13 @@ pub struct Match<'a, T> {
     /// matched the path segment as well as the start and end offset of the
     /// path segment value.
     ///
-    pub param: Option<(&'static str, [usize; 2])>,
+    pub range: [usize; 2],
 
     /// The route that matches the path segement at `self.range`.
     ///
     pub route: Option<&'a T>,
+
+    param: Option<&'static str>,
 }
 
 /// An iterator over the routes that match a given path.
@@ -29,6 +31,12 @@ pub struct Match<'a, T> {
 pub struct Matches<'a, T> {
     store: &'a RouteStore<T>,
     iter: IntoIter<Visit>,
+}
+
+impl<'a, T> Match<'a, T> {
+    pub fn param(&self) -> Option<(&'static str, [usize; 2])> {
+        self.param.map(|name| (name, self.range))
+    }
 }
 
 impl<'a, T> Match<'a, Vec<T>> {
@@ -57,7 +65,8 @@ impl<'a, T> Iterator for Matches<'a, T> {
 
         Some(Match {
             exact: next.exact,
-            param: node.param().zip(Some(next.range)),
+            param: node.param(),
+            range: next.range,
             route: node.route.map(|key| self.store.route(key)),
         })
     }

--- a/crates/via-router/src/iter.rs
+++ b/crates/via-router/src/iter.rs
@@ -1,12 +1,12 @@
-use std::slice::Iter;
+use core::slice::Iter;
+use std::vec::IntoIter;
 
 use crate::routes::RouteStore;
-use crate::stack_vec::StackVecIntoIter;
-use crate::visitor::Visited;
+use crate::visitor::Visit;
 
 /// Represents either a partial or exact match for a given path segment.
 ///
-pub struct Matched<'a, T> {
+pub struct Match<'a, T> {
     /// Indicates whether or not the match is considered an exact match.
     /// If the match is exact, both the middleware and responders will be
     /// called during a request. Otherwise, only the middleware will be
@@ -28,10 +28,10 @@ pub struct Matched<'a, T> {
 ///
 pub struct Matches<'a, T> {
     store: &'a RouteStore<T>,
-    iter: StackVecIntoIter<Visited, 4>,
+    iter: IntoIter<Visit>,
 }
 
-impl<'a, T> Matched<'a, Vec<T>> {
+impl<'a, T> Match<'a, Vec<T>> {
     /// Returns an iterator that yields a reference to each item in the matched
     /// route.
     pub fn iter(&self) -> Iter<'a, T> {
@@ -43,32 +43,19 @@ impl<'a, T> Matched<'a, Vec<T>> {
 }
 
 impl<'a, T> Matches<'a, T> {
-    pub(crate) fn new(store: &'a RouteStore<T>, iter: StackVecIntoIter<Visited, 4>) -> Self {
+    pub(crate) fn new(store: &'a RouteStore<T>, iter: IntoIter<Visit>) -> Self {
         Self { store, iter }
     }
 }
 
 impl<'a, T> Iterator for Matches<'a, T> {
-    type Item = Matched<'a, T>;
+    type Item = Match<'a, T>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let next = self.iter.next()?;
         let node = self.store.get(next.key);
 
-        Some(Matched {
-            exact: next.exact,
-            param: node.param().zip(Some(next.range)),
-            route: node.route.map(|key| self.store.route(key)),
-        })
-    }
-}
-
-impl<'a, T> DoubleEndedIterator for Matches<'a, T> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        let next = self.iter.next_back()?;
-        let node = self.store.get(next.key);
-
-        Some(Matched {
+        Some(Match {
             exact: next.exact,
             param: node.param().zip(Some(next.range)),
             route: node.route.map(|key| self.store.route(key)),

--- a/crates/via-router/src/iter.rs
+++ b/crates/via-router/src/iter.rs
@@ -60,28 +60,30 @@ impl<'a, T> Iterator for Matches<'a, T> {
     type Item = Match<'a, T>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        let store = self.store;
         let next = self.iter.next()?;
-        let node = self.store.get(next.key);
+        let node = store.get(next.key);
 
         Some(Match {
             exact: next.exact,
             param: node.param(),
             range: next.range,
-            route: node.route.map(|key| self.store.route(key)),
+            route: node.route.map(|key| store.route(key)),
         })
     }
 }
 
 impl<'a, T> DoubleEndedIterator for Matches<'a, T> {
     fn next_back(&mut self) -> Option<Self::Item> {
+        let store = self.store;
         let next = self.iter.next_back()?;
-        let node = self.store.get(next.key);
+        let node = store.get(next.key);
 
         Some(Match {
             exact: next.exact,
             param: node.param(),
             range: next.range,
-            route: node.route.map(|key| self.store.route(key)),
+            route: node.route.map(|key| store.route(key)),
         })
     }
 }

--- a/crates/via-router/src/iter.rs
+++ b/crates/via-router/src/iter.rs
@@ -1,7 +1,7 @@
 use std::slice::Iter;
-use std::vec::IntoIter;
 
 use crate::routes::RouteStore;
+use crate::stack_vec::StackVecIntoIter;
 use crate::visitor::Visited;
 
 /// Represents either a partial or exact match for a given path segment.
@@ -28,7 +28,7 @@ pub struct Matched<'a, T> {
 ///
 pub struct Matches<'a, T> {
     store: &'a RouteStore<T>,
-    iter: IntoIter<Visited>,
+    iter: StackVecIntoIter<Visited, 2>,
 }
 
 impl<'a, T> Matched<'a, Vec<T>> {
@@ -43,11 +43,8 @@ impl<'a, T> Matched<'a, Vec<T>> {
 }
 
 impl<'a, T> Matches<'a, T> {
-    pub(crate) fn new(store: &'a RouteStore<T>, visited: Vec<Visited>) -> Self {
-        Self {
-            store,
-            iter: visited.into_iter(),
-        }
+    pub(crate) fn new(store: &'a RouteStore<T>, iter: StackVecIntoIter<Visited, 2>) -> Self {
+        Self { store, iter }
     }
 }
 

--- a/crates/via-router/src/iter.rs
+++ b/crates/via-router/src/iter.rs
@@ -25,7 +25,7 @@ impl<'a, T> Iterator for Matches<'a, T> {
         let node = store.get(visited.key);
 
         Some((
-            node.route.map(|key| store.route(key)),
+            node.route.and_then(|key| store.route(key)),
             node.param(),
             visited,
         ))
@@ -39,7 +39,7 @@ impl<'a, T> DoubleEndedIterator for Matches<'a, T> {
         let node = store.get(visited.key);
 
         Some((
-            node.route.map(|key| store.route(key)),
+            node.route.and_then(|key| store.route(key)),
             node.param(),
             visited,
         ))

--- a/crates/via-router/src/iter.rs
+++ b/crates/via-router/src/iter.rs
@@ -28,7 +28,7 @@ pub struct Matched<'a, T> {
 ///
 pub struct Matches<'a, T> {
     store: &'a RouteStore<T>,
-    iter: StackVecIntoIter<Visited, 2>,
+    iter: StackVecIntoIter<Visited, 4>,
 }
 
 impl<'a, T> Matched<'a, Vec<T>> {
@@ -43,7 +43,7 @@ impl<'a, T> Matched<'a, Vec<T>> {
 }
 
 impl<'a, T> Matches<'a, T> {
-    pub(crate) fn new(store: &'a RouteStore<T>, iter: StackVecIntoIter<Visited, 2>) -> Self {
+    pub(crate) fn new(store: &'a RouteStore<T>, iter: StackVecIntoIter<Visited, 4>) -> Self {
         Self { store, iter }
     }
 }

--- a/crates/via-router/src/iter.rs
+++ b/crates/via-router/src/iter.rs
@@ -17,7 +17,7 @@ pub struct Matched<'a, T> {
     /// matched the path segment as well as the start and end offset of the
     /// path segment value.
     ///
-    pub param: Option<(&'static str, (usize, usize))>,
+    pub param: Option<(&'static str, [usize; 2])>,
 
     /// The route that matches the path segement at `self.range`.
     ///

--- a/crates/via-router/src/iter.rs
+++ b/crates/via-router/src/iter.rs
@@ -71,3 +71,17 @@ impl<'a, T> Iterator for Matches<'a, T> {
         })
     }
 }
+
+impl<'a, T> DoubleEndedIterator for Matches<'a, T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        let next = self.iter.next_back()?;
+        let node = self.store.get(next.key);
+
+        Some(Match {
+            exact: next.exact,
+            param: node.param(),
+            range: next.range,
+            route: node.route.map(|key| self.store.route(key)),
+        })
+    }
+}

--- a/crates/via-router/src/iter.rs
+++ b/crates/via-router/src/iter.rs
@@ -1,0 +1,80 @@
+use std::slice::Iter;
+use std::vec::IntoIter;
+
+use crate::routes::RouteStore;
+use crate::visitor::Visited;
+
+/// Represents either a partial or exact match for a given path segment.
+///
+pub struct Matched<'a, T> {
+    /// Indicates whether or not the match is considered an exact match.
+    /// If the match is exact, both the middleware and responders will be
+    /// called during a request. Otherwise, only the middleware will be
+    /// called.
+    pub exact: bool,
+
+    /// An optional tuple containing the name of the dynamic segment that
+    /// matched the path segment as well as the start and end offset of the
+    /// path segment value.
+    ///
+    pub param: Option<(&'static str, (usize, usize))>,
+
+    /// The route that matches the path segement at `self.range`.
+    ///
+    pub route: Option<&'a T>,
+}
+
+/// An iterator over the routes that match a given path.
+///
+pub struct Matches<'a, T> {
+    store: &'a RouteStore<T>,
+    iter: IntoIter<Visited>,
+}
+
+impl<'a, T> Matched<'a, Vec<T>> {
+    /// Returns an iterator that yields a reference to each item in the matched
+    /// route.
+    pub fn iter(&self) -> Iter<'a, T> {
+        match self.route {
+            Some(route) => route.iter(),
+            None => [].iter(),
+        }
+    }
+}
+
+impl<'a, T> Matches<'a, T> {
+    pub(crate) fn new(store: &'a RouteStore<T>, visited: Vec<Visited>) -> Self {
+        Self {
+            store,
+            iter: visited.into_iter(),
+        }
+    }
+}
+
+impl<'a, T> Iterator for Matches<'a, T> {
+    type Item = Matched<'a, T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let next = self.iter.next()?;
+        let node = self.store.get(next.key);
+
+        Some(Matched {
+            exact: next.exact,
+            param: node.param().zip(Some(next.range)),
+            route: node.route.map(|key| self.store.route(key)),
+        })
+    }
+}
+
+impl<'a, T> DoubleEndedIterator for Matches<'a, T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        let next = self.iter.next_back()?;
+        let node = self.store.get(next.key);
+
+        Some(Matched {
+            exact: next.exact,
+            param: node.param().zip(Some(next.range)),
+            route: node.route.map(|key| self.store.route(key)),
+        })
+    }
+}

--- a/crates/via-router/src/lib.rs
+++ b/crates/via-router/src/lib.rs
@@ -46,7 +46,7 @@ impl<T> Router<T> {
     }
 
     pub fn visit<'a>(&'a self, path: &str) -> Matches<'a, T> {
-        let mut segments = StackVec::new([None; 6]);
+        let mut segments = StackVec::new([None; 5]);
 
         for segment in path::split(path) {
             segments.push(segment);

--- a/crates/via-router/src/lib.rs
+++ b/crates/via-router/src/lib.rs
@@ -159,10 +159,10 @@ mod tests {
                 // /
                 // ^ as Pattern::Root
                 let matched = &matches[0];
-                // let (start, end) = matched.range;
+                let [start, end] = matched.range;
 
                 assert_eq!(matched.route, None);
-                // assert_eq!(&path[start..end], "");
+                assert_eq!(&path[start..end], "");
                 assert!(matched.exact);
             }
 
@@ -170,10 +170,10 @@ mod tests {
                 // /
                 //  ^ as Pattern::CatchAll("*path")
                 let matched = &matches[1];
-                // let (start, end) = matched.range;
+                let [start, end] = matched.range;
 
                 assert_eq!(matched.route, Some(&()));
-                // assert_eq!(&path[start..end], "");
+                assert_eq!(&path[start..end], "");
                 // Should be considered exact because of the catch-all pattern.
                 assert!(matched.exact);
             }
@@ -189,10 +189,10 @@ mod tests {
                 // /not/a/path
                 // ^ as Pattern::Root
                 let matched = &matches[0];
-                // let (start, end) = matched.range;
+                let [start, end] = matched.range;
 
                 assert_eq!(matched.route, None);
-                // assert_eq!(&path[start..end], "");
+                assert_eq!(&path[start..end], "");
                 assert!(!matched.exact);
             }
 
@@ -200,10 +200,10 @@ mod tests {
                 // /not/a/path
                 //  ^^^^^^^^^^ as Pattern::CatchAll("*path")
                 let matched = &matches[1];
-                // let (start, end) = matched.range;
+                let [start, end] = matched.range;
 
                 assert_eq!(matched.route, Some(&()));
-                // assert_eq!(&path[start..end], &path[1..]);
+                assert_eq!(&path[start..end], &path[1..]);
                 // Should be considered exact because of the catch-all pattern.
                 assert!(matched.exact);
             }
@@ -219,10 +219,10 @@ mod tests {
                 // /echo/hello/world
                 // ^ as Pattern::Root
                 let matched = &matches[0];
-                // let (start, end) = matched.range;
+                let [start, end] = matched.range;
 
                 assert_eq!(matched.route, None);
-                // assert_eq!(&path[start..end], "");
+                assert_eq!(&path[start..end], "");
                 assert!(!matched.exact);
             }
 
@@ -230,10 +230,10 @@ mod tests {
                 // /echo/hello/world
                 //  ^^^^^^^^^^^^^^^^ as Pattern::CatchAll("*path")
                 let matched = &matches[1];
-                // let (start, end) = matched.range;
+                let [start, end] = matched.range;
 
                 assert_eq!(matched.route, Some(&()));
-                // assert_eq!(&path[start..end], &path[1..]);
+                assert_eq!(&path[start..end], &path[1..]);
                 // Should be considered exact because of the catch-all pattern.
                 assert!(matched.exact);
             }
@@ -242,10 +242,10 @@ mod tests {
                 // /echo/hello/world
                 //  ^^^^ as Pattern::Static("echo")
                 let matched = &matches[2];
-                // let (start, end) = matched.range;
+                let [start, end] = matched.range;
 
                 assert_eq!(matched.route, None);
-                // assert_eq!(&path[start..end], "echo");
+                assert_eq!(&path[start..end], "echo");
                 assert!(!matched.exact);
             }
 
@@ -253,10 +253,10 @@ mod tests {
                 // /echo/hello/world
                 //       ^^^^^^^^^^^ as Pattern::CatchAll("*path")
                 let matched = &matches[3];
-                // let (start, end) = matched.range;
+                let [start, end] = matched.range;
 
                 assert_eq!(matched.route, Some(&()));
-                // assert_eq!(&path[start..end], "hello/world");
+                assert_eq!(&path[start..end], "hello/world");
                 assert!(matched.exact);
             }
         }
@@ -271,10 +271,10 @@ mod tests {
                 // /articles/100
                 // ^ as Pattern::Root
                 let matched = &matches[0];
-                // let (start, end) = matched.range;
+                let [start, end] = matched.range;
 
                 assert_eq!(matched.route, None);
-                // assert_eq!(&path[start..end], "");
+                assert_eq!(&path[start..end], "");
                 assert!(!matched.exact);
             }
 
@@ -282,10 +282,10 @@ mod tests {
                 // /articles/100
                 //  ^^^^^^^^^^^^ as Pattern::CatchAll("*path")
                 let matched = &matches[1];
-                // let (start, end) = matched.range;
+                let [start, end] = matched.range;
 
                 assert_eq!(matched.route, Some(&()));
-                // assert_eq!(&path[start..end], &path[1..]);
+                assert_eq!(&path[start..end], &path[1..]);
                 // Should be considered exact because of the catch-all pattern.
                 assert!(matched.exact);
             }
@@ -294,10 +294,10 @@ mod tests {
                 // /articles/100
                 //  ^^^^^^^^ as Pattern::Static("articles")
                 let matched = &matches[2];
-                // let (start, end) = matched.range;
+                let [start, end] = matched.range;
 
                 assert_eq!(matched.route, None);
-                // assert_eq!(&path[start..end], "articles");
+                assert_eq!(&path[start..end], "articles");
                 assert!(!matched.exact);
             }
 
@@ -305,10 +305,10 @@ mod tests {
                 // /articles/100
                 //           ^^^ as Pattern::Dynamic(":id")
                 let matched = &matches[3];
-                // let (start, end) = matched.range;
+                let [start, end] = matched.range;
 
                 assert_eq!(matched.route, Some(&()));
-                // assert_eq!(&path[start..end], "100");
+                assert_eq!(&path[start..end], "100");
                 assert!(matched.exact);
             }
         }
@@ -323,10 +323,10 @@ mod tests {
                 // /articles/100/comments
                 // ^ as Pattern::Root
                 let matched = &matches[0];
-                // let (start, end) = matched.range;
+                let [start, end] = matched.range;
 
                 assert_eq!(matched.route, None);
-                // assert_eq!(&path[start..end], "");
+                assert_eq!(&path[start..end], "");
                 assert!(!matched.exact);
             }
 
@@ -334,10 +334,10 @@ mod tests {
                 // /articles/100/comments
                 //  ^^^^^^^^^^^^^^^^^^^^^ as Pattern::CatchAll("*path")
                 let matched = &matches[1];
-                // let (start, end) = matched.range;
+                let [start, end] = matched.range;
 
                 assert_eq!(matched.route, Some(&()));
-                // assert_eq!(&path[start..end], &path[1..]);
+                assert_eq!(&path[start..end], &path[1..]);
                 // Should be considered exact because of the catch-all pattern.
                 assert!(matched.exact);
             }
@@ -346,10 +346,10 @@ mod tests {
                 // /articles/100/comments
                 //  ^^^^^^^^ as Pattern::Static("articles")
                 let matched = &matches[2];
-                // let (start, end) = matched.range;
+                let [start, end] = matched.range;
 
                 assert_eq!(matched.route, None);
-                // assert_eq!(&path[start..end], "articles");
+                assert_eq!(&path[start..end], "articles");
                 assert!(!matched.exact);
             }
 
@@ -357,10 +357,10 @@ mod tests {
                 // /articles/100/comments
                 //           ^^^ as Pattern::Dynamic(":id")
                 let matched = &matches[3];
-                // let (start, end) = matched.range;
+                let [start, end] = matched.range;
 
                 assert_eq!(matched.route, Some(&()));
-                // assert_eq!(&path[start..end], "100");
+                assert_eq!(&path[start..end], "100");
                 assert!(!matched.exact);
             }
 
@@ -368,10 +368,10 @@ mod tests {
                 // /articles/100/comments
                 //               ^^^^^^^^ as Pattern::Static("comments")
                 let matched = &matches[4];
-                // let (start, end) = matched.range;
+                let [start, end] = matched.range;
 
                 assert_eq!(matched.route, Some(&()));
-                // assert_eq!(&path[start..end], "comments");
+                assert_eq!(&path[start..end], "comments");
                 // Should be considered exact because it is the last path segment.
                 assert!(matched.exact);
             }

--- a/crates/via-router/src/lib.rs
+++ b/crates/via-router/src/lib.rs
@@ -3,7 +3,10 @@
 mod iter;
 mod path;
 mod routes;
+mod stack_vec;
 mod visitor;
+
+use stack_vec::StackVec;
 
 pub use crate::iter::{Matched, Matches};
 
@@ -43,12 +46,12 @@ impl<T> Router<T> {
     }
 
     pub fn visit<'a>(&'a self, path: &str) -> Matches<'a, T> {
-        let mut results = Vec::with_capacity(24);
+        let mut results = StackVec::new();
         let segments = path::segments(path);
         let store = &self.store;
 
         Visitor::new(path, &segments, store).visit(&mut results);
-        Matches::new(store, results)
+        Matches::new(store, results.into_iter())
     }
 }
 
@@ -116,9 +119,9 @@ where
     }
 
     let next_index = routes.entry(into_index).push(Node {
-        entries: None,
-        route: None,
         pattern,
+        entries: StackVec::new(),
+        route: None,
     });
 
     // If the pattern does not exist in the node at `current_key`, we need to create

--- a/crates/via-router/src/lib.rs
+++ b/crates/via-router/src/lib.rs
@@ -6,6 +6,8 @@ mod routes;
 mod stack_vec;
 mod visitor;
 
+use stack_vec::StackVec;
+
 pub use crate::iter::{Match, Matches};
 
 use crate::path::Pattern;
@@ -44,8 +46,13 @@ impl<T> Router<T> {
     }
 
     pub fn visit<'a>(&'a self, path: &str) -> Matches<'a, T> {
+        let mut segments = StackVec::new([None; 6]);
+
+        for segment in path::split(path) {
+            segments.push(segment);
+        }
+
         let mut results = Vec::new();
-        let segments = path::segments(path);
         let store = &self.store;
 
         Visitor::new(path, store, &segments).visit(&mut results);

--- a/crates/via-router/src/lib.rs
+++ b/crates/via-router/src/lib.rs
@@ -8,7 +8,7 @@ mod visitor;
 
 use stack_vec::StackVec;
 
-pub use crate::iter::{Matched, Matches};
+pub use crate::iter::{Match, Matches};
 
 use crate::path::Pattern;
 use crate::routes::{Node, RouteStore};
@@ -46,11 +46,11 @@ impl<T> Router<T> {
     }
 
     pub fn visit<'a>(&'a self, path: &str) -> Matches<'a, T> {
-        let mut results = StackVec::new();
+        let mut results = Vec::new();
         let segments = path::segments(path);
         let store = &self.store;
 
-        Visitor::new(path, &segments, store).visit(&mut results);
+        Visitor::new(path, store, &segments).visit(&mut results);
         Matches::new(store, results.into_iter())
     }
 }

--- a/crates/via-router/src/lib.rs
+++ b/crates/via-router/src/lib.rs
@@ -6,6 +6,7 @@ mod routes;
 mod stack_vec;
 mod visitor;
 
+use path::SplitPath;
 use stack_vec::StackVec;
 
 pub use crate::iter::{Match, Matches};
@@ -48,7 +49,7 @@ impl<T> Router<T> {
     pub fn visit<'a>(&'a self, path: &str) -> Matches<'a, T> {
         let mut segments = StackVec::new([None; 5]);
 
-        for segment in path::split(path) {
+        for segment in SplitPath::new(path) {
             segments.push(segment);
         }
 

--- a/crates/via-router/src/lib.rs
+++ b/crates/via-router/src/lib.rs
@@ -6,8 +6,6 @@ mod routes;
 mod stack_vec;
 mod visitor;
 
-use stack_vec::StackVec;
-
 pub use crate::iter::{Match, Matches};
 
 use crate::path::Pattern;
@@ -120,7 +118,7 @@ where
 
     let next_index = routes.entry(into_index).push(Node {
         pattern,
-        entries: StackVec::new(),
+        entries: None,
         route: None,
     });
 

--- a/crates/via-router/src/path.rs
+++ b/crates/via-router/src/path.rs
@@ -12,7 +12,7 @@ pub enum Pattern {
 }
 
 pub struct PathSegments {
-    segments: StackVec<(usize, usize), 4>,
+    segments: StackVec<[usize; 2], 4>,
 }
 
 /// An iterator that splits the path into segments and yields a key-value pair
@@ -25,7 +25,7 @@ struct SplitPath<'a> {
 /// Returns an iterator that yields a `Pattern` for each segment in the uri path.
 pub fn patterns(path: &'static str) -> impl Iterator<Item = Pattern> {
     split(path).map(|range| {
-        let value = segment_at(path, range);
+        let value = segment_at(path, &range);
 
         match value.chars().next() {
             Some('*') => {
@@ -63,8 +63,8 @@ pub fn segments(path: &str) -> PathSegments {
 }
 
 // Gets the value of the path segment at `range` from `path`.
-pub fn segment_at(path: &str, range: (usize, usize)) -> &str {
-    match path.get(range.0..range.1) {
+pub fn segment_at<'a>(path: &'a str, range: &[usize; 2]) -> &'a str {
+    match path.get(range[0]..range[1]) {
         Some(value) => {
             // The `range` is valid, return it.
             value
@@ -93,7 +93,7 @@ fn split(value: &str) -> SplitPath {
 }
 
 impl PathSegments {
-    pub fn get(&self, index: usize) -> Option<&(usize, usize)> {
+    pub fn get(&self, index: usize) -> Option<&[usize; 2]> {
         self.segments.get(index)
     }
 
@@ -135,7 +135,7 @@ impl<'a> SplitPath<'a> {
 }
 
 impl<'a> Iterator for SplitPath<'a> {
-    type Item = (usize, usize);
+    type Item = [usize; 2];
 
     fn next(&mut self) -> Option<Self::Item> {
         // Set the start index to the next character that is not a `/`.
@@ -144,7 +144,7 @@ impl<'a> Iterator for SplitPath<'a> {
         let end = self.next_terminator().unwrap_or(self.value.len());
 
         // Return the start and end offset of the current path segment.
-        Some((start, end))
+        Some([start, end])
     }
 }
 
@@ -170,23 +170,23 @@ mod tests {
         "/services/contact//us",
     ];
 
-    fn get_expected_results() -> [Vec<(usize, usize)>; 15] {
+    fn get_expected_results() -> [Vec<[usize; 2]>; 15] {
         [
-            vec![(1, 5), (6, 11)],
-            vec![(1, 9), (10, 14), (15, 18)],
-            vec![(1, 5), (6, 11), (12, 16), (17, 21)],
-            vec![(1, 5), (6, 13), (14, 22)],
-            vec![(1, 9), (10, 17)],
-            vec![(1, 7), (8, 23)],
-            vec![(1, 5), (6, 12)],
-            vec![(1, 10), (11, 18)],
-            vec![(1, 4)],
-            vec![(1, 8), (9, 16)],
-            vec![(2, 6), (8, 13)],
-            vec![(1, 9), (11, 15), (16, 19)],
-            vec![(1, 5), (6, 11), (12, 16), (18, 22)],
-            vec![(1, 5), (7, 14), (15, 23)],
-            vec![(1, 9), (10, 17), (19, 21)],
+            vec![[1, 5], [6, 11]],
+            vec![[1, 9], [10, 14], [15, 18]],
+            vec![[1, 5], [6, 11], [12, 16], [17, 21]],
+            vec![[1, 5], [6, 13], [14, 22]],
+            vec![[1, 9], [10, 17]],
+            vec![[1, 7], [8, 23]],
+            vec![[1, 5], [6, 12]],
+            vec![[1, 10], [11, 18]],
+            vec![[1, 4]],
+            vec![[1, 8], [9, 16]],
+            vec![[2, 6], [8, 13]],
+            vec![[1, 9], [11, 15], [16, 19]],
+            vec![[1, 5], [6, 11], [12, 16], [18, 22]],
+            vec![[1, 5], [7, 14], [15, 23]],
+            vec![[1, 9], [10, 17], [19, 21]],
         ]
     }
 

--- a/crates/via-router/src/path.rs
+++ b/crates/via-router/src/path.rs
@@ -1,8 +1,6 @@
 use core::iter::Enumerate;
 use core::str::Bytes;
 
-use crate::stack_vec::StackVec;
-
 #[derive(PartialEq)]
 pub enum Pattern {
     Root,
@@ -10,14 +8,9 @@ pub enum Pattern {
     Dynamic(&'static str),
     CatchAll(&'static str),
 }
-
-pub struct PathSegments {
-    segments: StackVec<[usize; 2], 5>,
-}
-
 /// An iterator that splits the path into segments and yields a key-value pair
 /// containing the start and end offset of the substring separated by `/`.
-struct SplitPath<'a> {
+pub struct SplitPath<'a> {
     bytes: Enumerate<Bytes<'a>>,
     value: &'a str,
 }
@@ -50,18 +43,6 @@ pub fn patterns(path: &'static str) -> impl Iterator<Item = Pattern> {
     })
 }
 
-/// Returns a collection containing the start and end offset of each segment in
-/// the uri path.
-pub fn segments(path: &str) -> PathSegments {
-    let mut segments = StackVec::new();
-
-    for segment in split(path) {
-        segments.push(segment);
-    }
-
-    PathSegments { segments }
-}
-
 // Gets the value of the path segment at `range` from `path`.
 pub fn segment_at<'a>(path: &'a str, range: &[usize; 2]) -> &'a str {
     match path.get(range[0]..range[1]) {
@@ -85,20 +66,10 @@ pub fn segment_at<'a>(path: &'a str, range: &[usize; 2]) -> &'a str {
 
 /// Returns an iterator that yields a tuple containing the start and end offset
 /// of each segment in the url path.
-fn split(value: &str) -> SplitPath {
+pub fn split(value: &str) -> SplitPath {
     SplitPath {
         bytes: value.bytes().enumerate(),
         value,
-    }
-}
-
-impl PathSegments {
-    pub fn get(&self, index: usize) -> Option<&[usize; 2]> {
-        self.segments.get(index)
-    }
-
-    pub fn len(&self) -> usize {
-        self.segments.len()
     }
 }
 

--- a/crates/via-router/src/path.rs
+++ b/crates/via-router/src/path.rs
@@ -12,7 +12,7 @@ pub enum Pattern {
 }
 
 pub struct PathSegments {
-    segments: StackVec<[usize; 2], 4>,
+    segments: StackVec<[usize; 2], 5>,
 }
 
 /// An iterator that splits the path into segments and yields a key-value pair

--- a/crates/via-router/src/path.rs
+++ b/crates/via-router/src/path.rs
@@ -1,4 +1,7 @@
-use core::{iter::Enumerate, str::Bytes};
+use core::iter::Enumerate;
+use core::str::Bytes;
+
+use crate::stack_vec::StackVec;
 
 #[derive(PartialEq)]
 pub enum Pattern {
@@ -6,6 +9,10 @@ pub enum Pattern {
     Static(&'static str),
     Dynamic(&'static str),
     CatchAll(&'static str),
+}
+
+pub struct PathSegments {
+    segments: StackVec<(usize, usize), 4>,
 }
 
 /// An iterator that splits the path into segments and yields a key-value pair
@@ -45,11 +52,14 @@ pub fn patterns(path: &'static str) -> impl Iterator<Item = Pattern> {
 
 /// Returns a collection containing the start and end offset of each segment in
 /// the uri path.
-pub fn segments(path: &str) -> Vec<(usize, usize)> {
-    let mut segments = Vec::with_capacity(12);
+pub fn segments(path: &str) -> PathSegments {
+    let mut segments = StackVec::new();
 
-    segments.extend(split(path));
-    segments
+    for segment in split(path) {
+        segments.push(segment);
+    }
+
+    PathSegments { segments }
 }
 
 // Gets the value of the path segment at `range` from `path`.
@@ -79,6 +89,16 @@ fn split(value: &str) -> SplitPath {
     SplitPath {
         bytes: value.bytes().enumerate(),
         value,
+    }
+}
+
+impl PathSegments {
+    pub fn get(&self, index: usize) -> Option<&(usize, usize)> {
+        self.segments.get(index)
+    }
+
+    pub fn len(&self) -> usize {
+        self.segments.len()
     }
 }
 

--- a/crates/via-router/src/routes.rs
+++ b/crates/via-router/src/routes.rs
@@ -1,10 +1,11 @@
+use core::slice::Iter;
+
 use crate::path::Pattern;
-use crate::stack_vec::{StackVec, StackVecIter};
 
 /// A node in the route tree that represents a single path segment.
 pub struct Node {
     /// The indices of the nodes that are reachable from the current node.
-    pub entries: StackVec<usize, 2>,
+    pub entries: Option<Vec<usize>>,
 
     /// The pattern used to match the node against a path segment.
     pub pattern: Pattern,
@@ -38,15 +39,18 @@ impl Node {
     pub fn new(pattern: Pattern) -> Self {
         Self {
             pattern,
-            entries: StackVec::new(),
+            entries: None,
             route: None,
         }
     }
 
     /// Returns an iterator that yields the indices of the nodes that are
     /// reachable from `self`.
-    pub fn entries(&self) -> StackVecIter<usize> {
-        self.entries.iter()
+    pub fn entries(&self) -> Iter<usize> {
+        match &self.entries {
+            Some(entries) => entries.iter(),
+            None => [].iter(),
+        }
     }
 
     /// Returns an optional reference to the name of the dynamic parameter
@@ -63,7 +67,7 @@ impl Node {
 impl Node {
     /// Pushes a new key into the entries of the node and return it.
     fn push(&mut self, key: usize) -> usize {
-        self.entries.push(key);
+        self.entries.get_or_insert_with(Vec::new).push(key);
         key
     }
 }

--- a/crates/via-router/src/routes.rs
+++ b/crates/via-router/src/routes.rs
@@ -45,7 +45,7 @@ impl Node {
 
     /// Returns an iterator that yields the indices of the nodes that are
     /// reachable from `self`.
-    pub fn entries(&self) -> StackVecIter<usize, 2> {
+    pub fn entries(&self) -> StackVecIter<usize> {
         self.entries.iter()
     }
 

--- a/crates/via-router/src/routes.rs
+++ b/crates/via-router/src/routes.rs
@@ -1,11 +1,10 @@
-use std::slice;
-
 use crate::path::Pattern;
+use crate::stack_vec::{StackVec, StackVecIter};
 
 /// A node in the route tree that represents a single path segment.
 pub struct Node {
     /// The indices of the nodes that are reachable from the current node.
-    pub entries: Option<Vec<usize>>,
+    pub entries: StackVec<usize, 2>,
 
     /// The pattern used to match the node against a path segment.
     pub pattern: Pattern,
@@ -39,18 +38,15 @@ impl Node {
     pub fn new(pattern: Pattern) -> Self {
         Self {
             pattern,
-            entries: None,
+            entries: StackVec::new(),
             route: None,
         }
     }
 
     /// Returns an iterator that yields the indices of the nodes that are
     /// reachable from `self`.
-    pub fn entries(&self) -> slice::Iter<usize> {
-        match &self.entries {
-            Some(entries) => entries.iter(),
-            None => [].iter(),
-        }
+    pub fn entries(&self) -> StackVecIter<usize, 2> {
+        self.entries.iter()
     }
 
     /// Returns an optional reference to the name of the dynamic parameter
@@ -67,7 +63,7 @@ impl Node {
 impl Node {
     /// Pushes a new key into the entries of the node and return it.
     fn push(&mut self, key: usize) -> usize {
-        self.entries.get_or_insert_with(Vec::new).push(key);
+        self.entries.push(key);
         key
     }
 }

--- a/crates/via-router/src/routes.rs
+++ b/crates/via-router/src/routes.rs
@@ -160,8 +160,8 @@ impl<T> RouteStore<T> {
 
     /// Returns a shared reference to the route at the given `key`.
     ///
-    pub fn route(&self, key: usize) -> &T {
-        &self.routes[key]
+    pub fn route(&self, key: usize) -> Option<&T> {
+        self.routes.get(key)
     }
 
     /// Returns a mutable reference to the route at the given `key`.

--- a/crates/via-router/src/stack_vec.rs
+++ b/crates/via-router/src/stack_vec.rs
@@ -32,8 +32,6 @@ fn get<T: Copy, const N: usize>(data: &StackVecInner<T, N>, index: usize) -> Opt
 }
 
 impl<T: Copy, const N: usize> StackVec<T, N> {
-    /// Returns a option containing a reference to the element at `index`.
-    ///
     pub fn new(init: [Option<T>; N]) -> Self {
         let len = init.iter().filter(|entry| entry.is_some()).count();
 
@@ -45,13 +43,13 @@ impl<T: Copy, const N: usize> StackVec<T, N> {
         }
     }
 
-    /// Returns an option containing a reference to the element at `index`.
+    /// Returns a option containing a copy of the element at `index`.
     ///
     pub fn get(&self, index: usize) -> Option<T> {
         get(&self.inner, index)
     }
 
-    /// Returns the number of elements in the vec.
+    /// Returns the number of elements in self.
     ///
     pub fn len(&self) -> usize {
         match &self.inner {
@@ -60,7 +58,7 @@ impl<T: Copy, const N: usize> StackVec<T, N> {
         }
     }
 
-    /// Returns the number of elements in the vec.
+    /// Returns the number of elements in self.
     ///
     pub fn is_empty(&self) -> bool {
         match &self.inner {
@@ -69,7 +67,7 @@ impl<T: Copy, const N: usize> StackVec<T, N> {
         }
     }
 
-    /// Appends an element to the end of the vec.
+    /// Appends an element to the end of self.
     ///
     /// # Panics
     ///

--- a/crates/via-router/src/stack_vec.rs
+++ b/crates/via-router/src/stack_vec.rs
@@ -54,18 +54,18 @@ impl<T: Copy, const N: usize> StackVec<T, N> {
     /// Returns the number of elements in the vec.
     ///
     pub fn len(&self) -> usize {
-        match self.inner {
-            StackVecInner::Stack { len, .. } => len,
-            StackVecInner::Heap { ref data } => data.len(),
+        match &self.inner {
+            StackVecInner::Stack { len, .. } => *len,
+            StackVecInner::Heap { data } => data.len(),
         }
     }
 
     /// Returns the number of elements in the vec.
     ///
     pub fn is_empty(&self) -> bool {
-        match self.inner {
-            StackVecInner::Stack { len, .. } => len == 0,
-            StackVecInner::Heap { ref data } => data.is_empty(),
+        match &self.inner {
+            StackVecInner::Stack { len, .. } => *len == 0,
+            StackVecInner::Heap { data } => data.is_empty(),
         }
     }
 

--- a/crates/via-router/src/stack_vec.rs
+++ b/crates/via-router/src/stack_vec.rs
@@ -1,12 +1,8 @@
-use core::{array, slice};
+use core::array;
 use std::vec;
 
 pub struct StackVec<T, const N: usize> {
     data: StackVecData<T, N>,
-}
-
-pub struct StackVecIter<'a, T> {
-    iter: slice::Iter<'a, Option<T>>,
 }
 
 pub struct StackVecIntoIter<T, const N: usize> {
@@ -51,15 +47,6 @@ impl<T: Copy, const N: usize> StackVec<T, N> {
         }
     }
 
-    pub fn iter(&self) -> StackVecIter<T> {
-        let iter = match self.data {
-            StackVecData::Stack { ref array, len } => array[..len].iter(),
-            StackVecData::Heap { ref vec } => vec.iter(),
-        };
-
-        StackVecIter { iter }
-    }
-
     pub fn push(&mut self, value: T) {
         let data = &mut self.data;
 
@@ -99,17 +86,6 @@ impl<T, const N: usize> IntoIterator for StackVec<T, N> {
             StackVecData::Heap { vec } => StackVecIntoIter {
                 iter: StackVecIntoIterInner::Heap(vec.into_iter()),
             },
-        }
-    }
-}
-
-impl<'a, T> Iterator for StackVecIter<'a, T> {
-    type Item = &'a T;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match self.iter.next()? {
-            Some(value) => Some(value),
-            None => None,
         }
     }
 }

--- a/crates/via-router/src/stack_vec.rs
+++ b/crates/via-router/src/stack_vec.rs
@@ -110,8 +110,12 @@ impl<T: Copy, const N: usize> StackVec<T, N> {
                     // Allocate a new vec to store the data in `array`.
                     let mut vec = Vec::new();
 
-                    // Move the array out of `store` and into `vec`.
-                    vec.extend(data.take().into_iter().flatten());
+                    if let Some(array) = data.take() {
+                        // Move the array out of `store` and into `vec`.
+                        vec.extend(array);
+                    } else {
+                        // Placeholder for tracing...
+                    }
 
                     // Transition `data` to `StackVecData::Heap`.
                     *inner = StackVecInner::Heap { data: vec };

--- a/crates/via-router/src/stack_vec.rs
+++ b/crates/via-router/src/stack_vec.rs
@@ -1,0 +1,130 @@
+use std::{array, vec};
+
+pub struct StackVec<T, const N: usize> {
+    data: StackVecData<T, N>,
+}
+
+pub struct StackVecIter<'a, T, const N: usize> {
+    index: usize,
+    store: &'a StackVec<T, N>,
+}
+
+pub struct StackVecIntoIter<T, const N: usize> {
+    inner: StackVecIntoIterInner<T, N>,
+}
+
+enum StackVecData<T, const N: usize> {
+    Stack([Option<T>; N]),
+    Heap(Vec<T>),
+}
+
+enum StackVecIntoIterInner<T, const N: usize> {
+    Stack(array::IntoIter<Option<T>, N>),
+    Heap(vec::IntoIter<T>),
+}
+
+impl<T: Copy, const N: usize> StackVec<T, N> {
+    pub fn new() -> Self {
+        Self {
+            data: StackVecData::Stack([None; N]),
+        }
+    }
+
+    pub fn get(&self, index: usize) -> Option<&T> {
+        match &self.data {
+            StackVecData::Stack(stack) => stack.get(index)?.as_ref(),
+            StackVecData::Heap(heap) => heap.get(index),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        match &self.data {
+            StackVecData::Stack(stack) => stack.iter().flatten().count(),
+            StackVecData::Heap(heap) => heap.len(),
+        }
+    }
+
+    pub fn iter(&self) -> StackVecIter<T, N> {
+        StackVecIter {
+            index: 0,
+            store: self,
+        }
+    }
+
+    pub fn push(&mut self, value: T) {
+        let data = &mut self.data;
+
+        loop {
+            match data {
+                // Attempt to store `value` on the stack. If there is no vacant
+                // entry, move the data to the heap.
+                StackVecData::Stack(stack) => {
+                    if let Some(index) = stack.iter().position(Option::is_none) {
+                        stack[index] = Some(value);
+                        break;
+                    }
+
+                    let mut heap = Vec::new();
+                    let array = std::mem::replace(stack, [None; N]);
+
+                    for item in array.into_iter().flatten() {
+                        heap.push(item);
+                    }
+
+                    *data = StackVecData::Heap(heap);
+                }
+
+                // We have a heap-allocated vector. Push `value` into it.
+                StackVecData::Heap(heap) => {
+                    heap.push(value);
+                    break;
+                }
+            }
+        }
+    }
+}
+
+impl<T: Copy, const N: usize> IntoIterator for StackVec<T, N> {
+    type IntoIter = StackVecIntoIter<T, N>;
+    type Item = T;
+
+    fn into_iter(self) -> Self::IntoIter {
+        let inner = match self.data {
+            StackVecData::Stack(stack) => StackVecIntoIterInner::Stack(stack.into_iter()),
+            StackVecData::Heap(heap) => StackVecIntoIterInner::Heap(heap.into_iter()),
+        };
+
+        StackVecIntoIter { inner }
+    }
+}
+
+impl<'a, T: Copy, const N: usize> Iterator for StackVecIter<'a, T, N> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let next = self.store.get(self.index)?;
+
+        self.index += 1;
+        Some(next)
+    }
+}
+
+impl<T: Copy, const N: usize> Iterator for StackVecIntoIter<T, N> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match &mut self.inner {
+            StackVecIntoIterInner::Stack(stack) => stack.next()?,
+            StackVecIntoIterInner::Heap(heap) => heap.next(),
+        }
+    }
+}
+
+impl<const N: usize, T: Copy> DoubleEndedIterator for StackVecIntoIter<T, N> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        match &mut self.inner {
+            StackVecIntoIterInner::Stack(stack) => stack.next_back()?,
+            StackVecIntoIterInner::Heap(heap) => heap.next_back(),
+        }
+    }
+}

--- a/crates/via-router/src/stack_vec.rs
+++ b/crates/via-router/src/stack_vec.rs
@@ -24,10 +24,10 @@ enum StackVecIntoIterInner<T, const N: usize> {
     Heap(vec::IntoIter<Option<T>>),
 }
 
-fn get<T, const N: usize>(data: &StackVecInner<T, N>, index: usize) -> Option<&T> {
+fn get<T: Copy, const N: usize>(data: &StackVecInner<T, N>, index: usize) -> Option<T> {
     match data {
-        StackVecInner::Stack { data, .. } => data.as_ref()?.get(index)?.as_ref(),
-        StackVecInner::Heap { data } => data.get(index)?.as_ref(),
+        StackVecInner::Stack { data, .. } => *data.as_ref()?.get(index)?,
+        StackVecInner::Heap { data } => *data.get(index)?,
     }
 }
 
@@ -47,7 +47,7 @@ impl<T: Copy, const N: usize> StackVec<T, N> {
 
     /// Returns an option containing a reference to the element at `index`.
     ///
-    pub fn get(&self, index: usize) -> Option<&T> {
+    pub fn get(&self, index: usize) -> Option<T> {
         get(&self.inner, index)
     }
 

--- a/crates/via-router/src/stack_vec.rs
+++ b/crates/via-router/src/stack_vec.rs
@@ -52,9 +52,9 @@ impl<T: Copy, const N: usize> StackVec<T, N> {
     }
 
     pub fn iter(&self) -> StackVecIter<T> {
-        let iter = match &self.data {
-            StackVecData::Stack { array, len } => (&array[..*len]).iter(),
-            StackVecData::Heap { vec } => vec.iter(),
+        let iter = match self.data {
+            StackVecData::Stack { ref array, len } => array[..len].iter(),
+            StackVecData::Heap { ref vec } => vec.iter(),
         };
 
         StackVecIter { iter }

--- a/crates/via-router/src/stack_vec.rs
+++ b/crates/via-router/src/stack_vec.rs
@@ -54,9 +54,18 @@ impl<T: Copy, const N: usize> StackVec<T, N> {
     /// Returns the number of elements in the vec.
     ///
     pub fn len(&self) -> usize {
-        match &self.inner {
-            StackVecInner::Stack { len, .. } => *len,
-            StackVecInner::Heap { data } => data.len(),
+        match self.inner {
+            StackVecInner::Stack { len, .. } => len,
+            StackVecInner::Heap { ref data } => data.len(),
+        }
+    }
+
+    /// Returns the number of elements in the vec.
+    ///
+    pub fn is_empty(&self) -> bool {
+        match self.inner {
+            StackVecInner::Stack { len, .. } => len == 0,
+            StackVecInner::Heap { ref data } => data.is_empty(),
         }
     }
 

--- a/crates/via-router/src/visitor.rs
+++ b/crates/via-router/src/visitor.rs
@@ -12,7 +12,7 @@ pub struct Visited {
     /// A tuple that contains the start and end offset of the path segment that
     /// matches the node at `self.key`.
     ///
-    pub range: (usize, usize),
+    pub range: [usize; 2],
 
     /// Indicates whether or not the match is considered an exact match.
     /// If the match is exact, both the middleware and responders will be
@@ -55,7 +55,7 @@ impl<'a, 'b, T> Visitor<'a, 'b, T> {
             // The root node's key is always `0`.
             key: 0,
             // The root node's path segment range should produce to an empty str.
-            range: (0, 0),
+            range: [0, 0],
             // If there are no path segments to match against, we consider the root
             // node to be an exact match.
             exact: self.depth == 0,
@@ -79,7 +79,7 @@ impl<'a, 'b, T> Visitor<'a, 'b, T> {
         results: &mut StackVec<Visited, 2>,
         // The start and end offset of the path segment at `index` in
         // `self.path_value`.
-        range: (usize, usize),
+        range: [usize; 2],
         // The index of the path segment in `self.segments` that we are matching
         // against the node at `key`.
         index: usize,
@@ -92,7 +92,7 @@ impl<'a, 'b, T> Visitor<'a, 'b, T> {
         // Get the value of the path segment at `index`. We'll eagerly borrow
         // and cache this slice from `self.path_value` to avoid having to build
         // the reference for each descendant with a `Static` pattern.
-        let path_segment = path::segment_at(path_value, range);
+        let path_segment = path::segment_at(path_value, &range);
 
         // Eagerly calculate and store the next index to avoid having to do so
         // for each descendant with a `Dynamic` or `Static` pattern.
@@ -149,7 +149,7 @@ impl<'a, 'b, T> Visitor<'a, 'b, T> {
                         // offset of the last path segment in the url path since
                         // `CatchAll` patterns match the entire remainder of the
                         // url path from which they are matched.
-                        range: (range.0, path_value.len()),
+                        range: [range[0], path_value.len()],
                     });
                 }
                 _ => {
@@ -190,7 +190,7 @@ impl<'a, 'b, T> Visitor<'a, 'b, T> {
                     // an immediate descendant of a node that we consider a match,
                     // we can safely assume that the path segment range should
                     // always produce an empty str.
-                    range: (0, 0),
+                    range: [0, 0],
                     // `CatchAll` patterns are always considered an exact match.
                     exact: true,
                 });

--- a/crates/via-router/src/visitor.rs
+++ b/crates/via-router/src/visitor.rs
@@ -28,7 +28,7 @@ pub struct Visitor<'a, 'b, T> {
 
     /// A slice of tuples that contain the start and end offset of each path
     /// segment in `self.path_value`.
-    segments: &'b StackVec<[usize; 2], 6>,
+    segments: &'b StackVec<[usize; 2], 5>,
 
     /// A reference to the route store that contains the route tree.
     store: &'a RouteStore<T>,
@@ -41,7 +41,7 @@ impl<'a, 'b, T> Visitor<'a, 'b, T> {
     pub fn new(
         path: &'b str,
         store: &'a RouteStore<T>,
-        segments: &'b StackVec<[usize; 2], 6>,
+        segments: &'b StackVec<[usize; 2], 5>,
     ) -> Self {
         let depth = segments.len();
 
@@ -171,7 +171,7 @@ impl<'a, 'b, T> Visitor<'a, 'b, T> {
     /// with a `CatchAll` pattern.
     fn visit_node(&self, results: &mut Vec<Visit>, index: usize, key: usize) {
         // Check if there is a path segment at `index` to match against
-        if let Some(range) = self.segments.get(index).copied() {
+        if let Some(range) = self.segments.get(index) {
             return self.visit_descendants(results, range, index, key);
         }
 

--- a/crates/via-router/src/visitor.rs
+++ b/crates/via-router/src/visitor.rs
@@ -1,5 +1,6 @@
-use crate::path::{self, PathSegments, Pattern};
+use crate::path::{self, Pattern};
 use crate::routes::RouteStore;
+use crate::stack_vec::StackVec;
 
 #[derive(Debug)]
 pub struct Visit {
@@ -27,7 +28,7 @@ pub struct Visitor<'a, 'b, T> {
 
     /// A slice of tuples that contain the start and end offset of each path
     /// segment in `self.path_value`.
-    segments: &'b PathSegments,
+    segments: &'b StackVec<[usize; 2], 6>,
 
     /// A reference to the route store that contains the route tree.
     store: &'a RouteStore<T>,
@@ -37,7 +38,11 @@ pub struct Visitor<'a, 'b, T> {
 }
 
 impl<'a, 'b, T> Visitor<'a, 'b, T> {
-    pub fn new(path: &'b str, store: &'a RouteStore<T>, segments: &'b PathSegments) -> Self {
+    pub fn new(
+        path: &'b str,
+        store: &'a RouteStore<T>,
+        segments: &'b StackVec<[usize; 2], 6>,
+    ) -> Self {
         let depth = segments.len();
 
         Self {

--- a/crates/via-router/src/visitor.rs
+++ b/crates/via-router/src/visitor.rs
@@ -2,7 +2,7 @@ use crate::path::{self, PathSegments, Pattern};
 use crate::routes::RouteStore;
 use crate::stack_vec::StackVec;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Visited {
     /// The key of the node that matches the path segement at `self.range` in the
     /// route store.
@@ -49,7 +49,7 @@ impl<'a, 'b, T> Visitor<'a, 'b, T> {
         }
     }
 
-    pub fn visit(&self, results: &mut StackVec<Visited, 2>) {
+    pub fn visit(&self, results: &mut StackVec<Visited, 4>) {
         // The root node is a special case that we always consider a match.
         results.push(Visited {
             // The root node's key is always `0`.
@@ -76,7 +76,7 @@ impl<'a, 'b, T> Visitor<'a, 'b, T> {
         &self,
         // A mutable reference to a vector that contains the matches that we
         // have found so far.
-        results: &mut StackVec<Visited, 2>,
+        results: &mut StackVec<Visited, 4>,
         // The start and end offset of the path segment at `index` in
         // `self.path_value`.
         range: [usize; 2],
@@ -165,7 +165,7 @@ impl<'a, 'b, T> Visitor<'a, 'b, T> {
     /// `self.segements` at `index` to match against the descendants of the
     /// node at `key`, we'll instead perform a shallow search for descendants
     /// with a `CatchAll` pattern.
-    fn visit_node(&self, results: &mut StackVec<Visited, 2>, index: usize, key: usize) {
+    fn visit_node(&self, results: &mut StackVec<Visited, 4>, index: usize, key: usize) {
         // Check if there is a path segment at `index` to match against
         if let Some(range) = self.segments.get(index).copied() {
             return self.visit_descendants(results, range, index, key);

--- a/crates/via-router/src/visitor.rs
+++ b/crates/via-router/src/visitor.rs
@@ -32,9 +32,6 @@ pub struct Visitor<'a, 'b, T> {
 
     /// A reference to the route store that contains the route tree.
     store: &'a RouteStore<T>,
-
-    /// A cache of `self.segments.len()`.
-    depth: usize,
 }
 
 impl<'a, 'b, T> Visitor<'a, 'b, T> {
@@ -43,13 +40,10 @@ impl<'a, 'b, T> Visitor<'a, 'b, T> {
         store: &'a RouteStore<T>,
         segments: &'b StackVec<[usize; 2], 5>,
     ) -> Self {
-        let depth = segments.len();
-
         Self {
             path_value: path,
             segments,
             store,
-            depth,
         }
     }
 
@@ -62,7 +56,7 @@ impl<'a, 'b, T> Visitor<'a, 'b, T> {
             range: [0, 0],
             // If there are no path segments to match against, we consider the root
             // node to be an exact match.
-            exact: self.depth == 0,
+            exact: self.segments.is_empty(),
         });
 
         // Begin the search for matches recursively starting with descendants of
@@ -107,7 +101,7 @@ impl<'a, 'b, T> Visitor<'a, 'b, T> {
         // matching descendant to be an exact match. We perform this check
         // eagerly to avoid having to do so for each descendant with a
         // `Dynamic` or `Static` pattern.
-        let exact = next_index == self.depth;
+        let exact = next_index == self.segments.len();
 
         let store = self.store;
 

--- a/src/middleware/next.rs
+++ b/src/middleware/next.rs
@@ -1,17 +1,19 @@
+use std::collections::VecDeque;
+
 use super::{ArcMiddleware, BoxFuture};
 use crate::{Error, Request, Response, Result};
 
 pub struct Next<State = ()> {
-    stack: Vec<ArcMiddleware<State>>,
+    stack: VecDeque<ArcMiddleware<State>>,
 }
 
 impl<State> Next<State> {
-    pub(crate) fn new(stack: Vec<ArcMiddleware<State>>) -> Self {
+    pub(crate) fn new(stack: VecDeque<ArcMiddleware<State>>) -> Self {
         Self { stack }
     }
 
     pub fn call(mut self, request: Request<State>) -> BoxFuture<Result<Response, Error>> {
-        if let Some(middleware) = self.stack.pop() {
+        if let Some(middleware) = self.stack.pop_front() {
             middleware.call(request, self)
         } else {
             Box::pin(async { Ok(Response::not_found()) })

--- a/src/middleware/next.rs
+++ b/src/middleware/next.rs
@@ -1,19 +1,17 @@
-use std::collections::VecDeque;
-
 use super::{ArcMiddleware, BoxFuture};
 use crate::{Error, Request, Response, Result};
 
 pub struct Next<State = ()> {
-    stack: VecDeque<ArcMiddleware<State>>,
+    stack: Vec<ArcMiddleware<State>>,
 }
 
 impl<State> Next<State> {
-    pub(crate) fn new(stack: VecDeque<ArcMiddleware<State>>) -> Self {
+    pub(crate) fn new(stack: Vec<ArcMiddleware<State>>) -> Self {
         Self { stack }
     }
 
     pub fn call(mut self, request: Request<State>) -> BoxFuture<Result<Response, Error>> {
-        if let Some(middleware) = self.stack.pop_front() {
+        if let Some(middleware) = self.stack.pop() {
             middleware.call(request, self)
         } else {
             Box::pin(async { Ok(Response::not_found()) })

--- a/src/request/params/param.rs
+++ b/src/request/params/param.rs
@@ -7,7 +7,7 @@ use super::{DecodeParam, NoopDecode, PercentDecode};
 use crate::{Error, Result};
 
 pub struct Param<'a, 'b, T = NoopDecode> {
-    at: Option<Option<(usize, usize)>>,
+    at: Option<Option<[usize; 2]>>,
     name: &'b str,
     source: &'a str,
     _decode: PhantomData<T>,
@@ -21,7 +21,7 @@ fn missing_required_param<'a>(name: &str) -> Result<Cow<'a, str>, Error> {
 }
 
 impl<'a, 'b, T: DecodeParam> Param<'a, 'b, T> {
-    pub(crate) fn new(at: Option<Option<(usize, usize)>>, name: &'b str, source: &'a str) -> Self {
+    pub(crate) fn new(at: Option<Option<[usize; 2]>>, name: &'b str, source: &'a str) -> Self {
         Self {
             at,
             name,
@@ -77,8 +77,8 @@ impl<'a, 'b, T: DecodeParam> Param<'a, 'b, T> {
     ///
     pub fn into_result(self) -> Result<Cow<'a, str>, Error> {
         self.at
-            .and_then(|at| {
-                let (start, end) = at?;
+            .and_then(|option| {
+                let [start, end] = option?;
                 self.source.get(start..end)
             })
             .map_or_else(

--- a/src/request/params/path_params.rs
+++ b/src/request/params/path_params.rs
@@ -10,15 +10,9 @@ impl PathParams {
     }
 
     pub fn get(&self, predicate: &str) -> Option<&[usize; 2]> {
-        self.data.iter().find_map(
-            |(name, at)| {
-                if *name == predicate {
-                    Some(at)
-                } else {
-                    None
-                }
-            },
-        )
+        self.data
+            .iter()
+            .find_map(|(name, at)| if *name == predicate { Some(at) } else { None })
     }
 
     pub fn push(&mut self, param: (&'static str, [usize; 2])) {

--- a/src/request/params/path_params.rs
+++ b/src/request/params/path_params.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Debug, Formatter};
 
 pub struct PathParams {
-    data: Vec<(&'static str, (usize, usize))>,
+    data: Vec<(&'static str, [usize; 2])>,
 }
 
 impl PathParams {
@@ -9,11 +9,11 @@ impl PathParams {
         Self { data: Vec::new() }
     }
 
-    pub fn get(&self, predicate: &str) -> Option<(usize, usize)> {
+    pub fn get(&self, predicate: &str) -> Option<&[usize; 2]> {
         self.data.iter().find_map(
             |(name, at)| {
                 if *name == predicate {
-                    Some(*at)
+                    Some(at)
                 } else {
                     None
                 }
@@ -21,7 +21,7 @@ impl PathParams {
         )
     }
 
-    pub fn push(&mut self, param: (&'static str, (usize, usize))) {
+    pub fn push(&mut self, param: (&'static str, [usize; 2])) {
         self.data.push(param);
     }
 }

--- a/src/request/params/query_param.rs
+++ b/src/request/params/query_param.rs
@@ -16,7 +16,7 @@ pub struct QueryParamIter<'a, 'b, T> {
     _decode: PhantomData<T>,
 }
 
-fn find_next(parser: &mut QueryParser, name: &str) -> Option<Option<(usize, usize)>> {
+fn find_next(parser: &mut QueryParser, name: &str) -> Option<Option<[usize; 2]>> {
     parser.find_map(|(n, at)| if n == name { Some(at) } else { None })
 }
 
@@ -77,7 +77,7 @@ impl<'a, T: DecodeParam> Iterator for QueryParamIter<'a, '_, T> {
     type Item = Cow<'a, str>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let (start, end) = find_next(&mut self.parser, self.name)??;
+        let [start, end] = find_next(&mut self.parser, self.name)??;
         let encoded = self.parser.input().get(start..end)?;
 
         T::decode(encoded).ok()

--- a/src/request/params/query_parser.rs
+++ b/src/request/params/query_parser.rs
@@ -1,7 +1,7 @@
 use percent_encoding::percent_decode_str;
 use std::borrow::Cow;
 
-type QueryParserOutput<'a> = (Cow<'a, str>, Option<(usize, usize)>);
+type QueryParserOutput<'a> = (Cow<'a, str>, Option<[usize; 2]>);
 
 pub struct QueryParser<'a> {
     input: &'a str,
@@ -35,7 +35,7 @@ fn take_name(input: &str, from: usize) -> (usize, Option<Cow<str>>) {
     }
 }
 
-fn take_value(input: &str, from: usize) -> (usize, Option<(usize, usize)>) {
+fn take_value(input: &str, from: usize) -> (usize, Option<[usize; 2]>) {
     // Get the length of the input. We'll use this value as the end index if we
     // reach the end of the input.
     let len = input.len();
@@ -46,14 +46,14 @@ fn take_value(input: &str, from: usize) -> (usize, Option<(usize, usize)>) {
         // Continue consuming the input until we reach the terminating `&`.
         match take_while(input, start, |byte| byte != b'&') {
             // If we find the terminating `&`, return the complete range.
-            Some(end) => (start, end),
+            Some(end) => [start, end],
             // Otherwise, return the start index and the length of the input.
-            None => (start, len),
+            None => [start, len],
         }
     });
 
     match at {
-        Some((_, end)) => (end, at),
+        Some([_, end]) => (end, at),
         None => (len, None),
     }
 }
@@ -120,41 +120,41 @@ mod tests {
         "query%C3%28=books&category=%C3%28", // Invalid UTF-8 sequence in key
     ];
 
-    fn get_expected_results() -> [Vec<(&'static str, Option<(usize, usize)>)>; 21] {
+    fn get_expected_results() -> [Vec<(&'static str, Option<[usize; 2]>)>; 21] {
         [
             vec![
-                ("query", Some((6, 11))),
-                ("category", Some((21, 28))),
-                ("sort", Some((34, 37))),
+                ("query", Some([6, 11])),
+                ("category", Some([21, 28])),
+                ("sort", Some([34, 37])),
             ],
-            vec![("query", Some((6, 19))), ("category", Some((29, 38)))],
+            vec![("query", Some([6, 19])), ("category", Some([29, 38]))],
             vec![
-                ("category", Some((9, 14))),
-                ("category", Some((24, 35))),
-                ("category", Some((45, 53))),
+                ("category", Some([9, 14])),
+                ("category", Some([24, 35])),
+                ("category", Some([45, 53])),
             ],
-            vec![("query", Some((6, 11))), ("category", None)],
-            vec![("query", Some((6, 22))), ("category", Some((32, 36)))],
-            vec![("query", Some((6, 11))), ("filter", Some((19, 45)))],
+            vec![("query", Some([6, 11])), ("category", None)],
+            vec![("query", Some([6, 22])), ("category", Some([32, 36]))],
+            vec![("query", Some([6, 11])), ("filter", Some([19, 45]))],
             vec![
-                ("items[]", Some((8, 12))),
-                ("items[]", Some((21, 24))),
-                ("items[]", Some((33, 41))),
+                ("items[]", Some([8, 12])),
+                ("items[]", Some([21, 24])),
+                ("items[]", Some([33, 41])),
             ],
             vec![],
-            vec![("data", Some((5, 47)))],
-            vec![("query", Some((6, 11))), ("category", Some((21, 37)))],
-            vec![("query", Some((6, 11))), ("category", Some((22, 29)))],
-            vec![("query", Some((7, 12))), ("category", Some((22, 29)))],
-            vec![("query", Some((6, 11))), ("category", None)],
-            vec![("query", Some((6, 11))), ("", Some((13, 20)))],
-            vec![("query", Some((6, 11))), ("category", Some((21, 28)))],
-            vec![("query", Some((8, 13))), ("category", Some((25, 32)))],
-            vec![("query", Some((8, 13))), ("category", Some((25, 32)))],
-            vec![("query", Some((6, 11))), ("category", Some((23, 32)))],
-            vec![("query", Some((6, 11))), ("category", Some((21, 30)))],
-            vec![("query", Some((6, 11))), ("category", Some((21, 27)))],
-            vec![("query�(", Some((12, 17))), ("category", Some((27, 33)))],
+            vec![("data", Some([5, 47]))],
+            vec![("query", Some([6, 11])), ("category", Some([21, 37]))],
+            vec![("query", Some([6, 11])), ("category", Some([22, 29]))],
+            vec![("query", Some([7, 12])), ("category", Some([22, 29]))],
+            vec![("query", Some([6, 11])), ("category", None)],
+            vec![("query", Some([6, 11])), ("", Some([13, 20]))],
+            vec![("query", Some([6, 11])), ("category", Some([21, 28]))],
+            vec![("query", Some([8, 13])), ("category", Some([25, 32]))],
+            vec![("query", Some([8, 13])), ("category", Some([25, 32]))],
+            vec![("query", Some([6, 11])), ("category", Some([23, 32]))],
+            vec![("query", Some([6, 11])), ("category", Some([21, 30]))],
+            vec![("query", Some([6, 11])), ("category", Some([21, 27]))],
+            vec![("query�(", Some([12, 17])), ("category", Some([27, 33]))],
         ]
     }
 

--- a/src/request/request.rs
+++ b/src/request/request.rs
@@ -114,10 +114,10 @@ impl<State> Request<State> {
     pub fn param<'a>(&self, name: &'a str) -> Param<'_, 'a> {
         // Get the path of the request's uri.
         let path = self.parts.uri.path();
-        // Get an `Option<(usize, usize)>` that represents the start and end
-        // offset of the path parameter with the provided `name` in the request's
-        // uri.
-        let at = self.params.get(name);
+
+        // Get an `Option<[usize; 2]>` that represents the start and end offset
+        // of the path parameter with the provided `name` in the request's uri.
+        let at = self.params.get(name).copied();
 
         Param::new(Some(at), name, path)
     }

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,4 +1,3 @@
-use std::collections::VecDeque;
 use std::sync::Arc;
 use via_router::Matches;
 
@@ -97,17 +96,17 @@ where
         params: &mut PathParams,
         routes: Matches<'a, Vec<MatchWhen<State>>>,
     ) -> Next<State> {
-        let mut stack = VecDeque::new();
+        let mut stack = Vec::new();
 
         // Iterate over the routes that match the request's path.
-        for route in routes {
+        for route in routes.rev() {
             if let Some(param) = route.param() {
                 params.push(param);
             }
 
             // Extend `stack` with middleware in `matched` depending on whether
             // or not the middleware expects a partial or exact match.
-            for middleware in route.iter().filter_map(|when| match when {
+            for middleware in route.iter().rev().filter_map(|when| match when {
                 // Include this middleware in `stack` because it expects an
                 // exact match and `matched.exact` is `true`.
                 MatchWhen::Exact(exact) if route.exact => Some(exact),
@@ -120,7 +119,7 @@ where
                 // exact match and `matched.exact` is `false`.
                 MatchWhen::Exact(_) => None,
             }) {
-                stack.push_back(Arc::clone(middleware));
+                stack.push(Arc::clone(middleware));
             }
         }
 

--- a/src/router.rs
+++ b/src/router.rs
@@ -101,7 +101,7 @@ where
 
         // Iterate over the routes that match the request's path.
         for route in routes {
-            if let Some(param) = route.param {
+            if let Some(param) = route.param() {
                 params.push(param);
             }
 

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,3 +1,4 @@
+use std::collections::VecDeque;
 use std::sync::Arc;
 use via_router::Matches;
 
@@ -96,17 +97,17 @@ where
         params: &mut PathParams,
         routes: Matches<'a, Vec<MatchWhen<State>>>,
     ) -> Next<State> {
-        let mut stack = Vec::new();
+        let mut stack = VecDeque::new();
 
         // Iterate over the routes that match the request's path.
-        for route in routes.rev() {
+        for route in routes {
             if let Some(param) = route.param {
                 params.push(param);
             }
 
             // Extend `stack` with middleware in `matched` depending on whether
             // or not the middleware expects a partial or exact match.
-            for middleware in route.iter().rev().filter_map(|when| match when {
+            for middleware in route.iter().filter_map(|when| match when {
                 // Include this middleware in `stack` because it expects an
                 // exact match and `matched.exact` is `true`.
                 MatchWhen::Exact(exact) if route.exact => Some(exact),
@@ -119,7 +120,7 @@ where
                 // exact match and `matched.exact` is `false`.
                 MatchWhen::Exact(_) => None,
             }) {
-                stack.push(Arc::clone(middleware));
+                stack.push_back(Arc::clone(middleware));
             }
         }
 

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use via_router::Match;
+use via_router::Matches;
 
 use crate::request::PathParams;
 use crate::{Middleware, Next};
@@ -87,20 +87,20 @@ where
         }
     }
 
-    pub fn lookup<'a>(&'a self, path: &str) -> Vec<Match<'a, Vec<MatchWhen<State>>>> {
+    pub fn lookup<'a>(&'a self, path: &str) -> Matches<'a, Vec<MatchWhen<State>>> {
         self.inner.visit(path)
     }
 
-    pub fn resolve(
-        &self,
+    pub fn resolve<'a>(
+        &'a self,
         params: &mut PathParams,
-        routes: &[Match<Vec<MatchWhen<State>>>],
+        routes: Matches<'a, Vec<MatchWhen<State>>>,
     ) -> Next<State> {
         let mut stack = Vec::new();
 
         // Iterate over the routes that match the request's path.
-        for route in routes.iter().rev() {
-            if let Some(param) = route.param() {
+        for route in routes.rev() {
+            if let Some(param) = route.param {
                 params.push(param);
             }
 

--- a/src/server/service.rs
+++ b/src/server/service.rs
@@ -86,7 +86,7 @@ where
             // Get a mutable reference to the request's path parameters.
             let params = request.params_mut();
 
-            self.router.resolve(params, &routes)
+            self.router.resolve(params, routes)
         };
 
         // Call the middleware stack and return a Future that resolves to


### PR DESCRIPTION
Improves the memory usage in via-router by doing the following:

- Storing routes adjacent to nodes and returning a `Matches` iterator that builds the reference to the route rather than returning a `Vec<Match<'_, T>>`.
- Includes a simplified version of a smallvec optimization that will fallback to the `Vec` from the standard library. This is used to store up to five path parameter ranges `[usize, usize]`.