### PR TITLE
fix(via): switch back to using JoinSet to store connections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ hyper-util = { version = "0.1", features = ["tokio"] }
 percent-encoding = "2.3"
 serde = "1"
 serde_json = "1"
-slab = "0.4"
 tokio = { version = "1", features = ["macros", "signal"] }
 via-router = { path = "./crates/via-router" }
 

--- a/src/server/shutdown.rs
+++ b/src/server/shutdown.rs
@@ -1,18 +1,8 @@
-use slab::Slab;
 use tokio::signal;
 use tokio::sync::watch;
 use tokio::task::{self, JoinHandle};
 
 use crate::Error;
-
-pub async fn graceful_shutdown(connections: Slab<JoinHandle<()>>) {
-    for (_, handle) in connections.into_iter() {
-        if let Err(error) = handle.await {
-            // Placeholder for tracing...
-            let _ = error;
-        }
-    }
-}
 
 pub fn wait_for_shutdown() -> (JoinHandle<Result<(), Error>>, watch::Receiver<bool>) {
     // Create a watch channel to notify the connections to initiate a


### PR DESCRIPTION
Switches back to using a `JoinSet` to spawn and store inflight connections. This makes the code easier to work with and memory-usage seems to improve.