### PR TITLE
refactor(via-router): rename Matches iter

### DIFF
--- a/crates/via-router/src/iter.rs
+++ b/crates/via-router/src/iter.rs
@@ -1,23 +1,23 @@
 use std::vec::IntoIter;
 
 use crate::routes::RouteStore;
-use crate::visitor::Visit;
+use crate::visitor::Visited;
 
 /// An iterator over the routes that match a given path.
 ///
-pub struct Matches<'a, T> {
+pub struct Visit<'a, T> {
     store: &'a RouteStore<T>,
-    iter: IntoIter<Visit>,
+    iter: IntoIter<Visited>,
 }
 
-impl<'a, T> Matches<'a, T> {
-    pub(crate) fn new(store: &'a RouteStore<T>, iter: IntoIter<Visit>) -> Self {
+impl<'a, T> Visit<'a, T> {
+    pub(crate) fn new(store: &'a RouteStore<T>, iter: IntoIter<Visited>) -> Self {
         Self { store, iter }
     }
 }
 
-impl<'a, T> Iterator for Matches<'a, T> {
-    type Item = (Option<&'a T>, Option<&'static str>, Visit);
+impl<'a, T> Iterator for Visit<'a, T> {
+    type Item = (Option<&'a T>, Option<&'static str>, Visited);
 
     fn next(&mut self) -> Option<Self::Item> {
         let visited = self.iter.next()?;
@@ -32,7 +32,7 @@ impl<'a, T> Iterator for Matches<'a, T> {
     }
 }
 
-impl<'a, T> DoubleEndedIterator for Matches<'a, T> {
+impl<'a, T> DoubleEndedIterator for Visit<'a, T> {
     fn next_back(&mut self) -> Option<Self::Item> {
         let visited = self.iter.next_back()?;
         let store = self.store;

--- a/crates/via-router/src/lib.rs
+++ b/crates/via-router/src/lib.rs
@@ -6,8 +6,8 @@ mod routes;
 mod stack_vec;
 mod visitor;
 
-pub use iter::Matches;
-pub use visitor::Visit;
+pub use iter::Visit;
+pub use visitor::Visited;
 
 use path::{Pattern, SplitPath};
 use routes::{Node, RouteStore};
@@ -45,7 +45,7 @@ impl<T> Router<T> {
         self.store.shrink_to_fit();
     }
 
-    pub fn visit<'a>(&'a self, path: &str) -> Matches<'a, T> {
+    pub fn visit<'a>(&'a self, path: &str) -> Visit<'a, T> {
         let mut segments = StackVec::new([None; 5]);
 
         for segment in SplitPath::new(path) {
@@ -56,7 +56,7 @@ impl<T> Router<T> {
         let store = &self.store;
 
         Visitor::new(path, store, &segments).visit(&mut results);
-        Matches::new(store, results.into_iter())
+        Visit::new(store, results.into_iter())
     }
 }
 

--- a/crates/via-router/src/visitor.rs
+++ b/crates/via-router/src/visitor.rs
@@ -3,7 +3,7 @@ use crate::routes::RouteStore;
 use crate::stack_vec::StackVec;
 
 #[derive(Debug)]
-pub struct Visit {
+pub struct Visited {
     /// An array containing the start and end index of the path segment that
     /// matches self.
     ///
@@ -45,9 +45,9 @@ impl<'a, 'b, T> Visitor<'a, 'b, T> {
         }
     }
 
-    pub fn visit(self, results: &mut Vec<Visit>) {
+    pub fn visit(self, results: &mut Vec<Visited>) {
         // The root node is a special case that we always consider a match.
-        results.push(Visit {
+        results.push(Visited {
             // The root node's key is always `0`.
             key: 0,
             // The root node's path segment range should produce to an empty str.
@@ -72,7 +72,7 @@ impl<'a, 'b, T> Visitor<'a, 'b, T> {
         &self,
         // A mutable reference to a vector that contains the matches that we
         // have found so far.
-        results: &mut Vec<Visit>,
+        results: &mut Vec<Visited>,
         // The start and end offset of the path segment at `index` in
         // `self.path_value`.
         range: [usize; 2],
@@ -113,7 +113,7 @@ impl<'a, 'b, T> Visitor<'a, 'b, T> {
                 Pattern::Static(value) if value == path_segment => {
                     // The next node has a `Static` pattern that matches the value
                     // of the path segment.
-                    results.push(Visit {
+                    results.push(Visited {
                         key: next_key,
                         range,
                         was_leaf,
@@ -124,7 +124,7 @@ impl<'a, 'b, T> Visitor<'a, 'b, T> {
                 Pattern::Dynamic(_) => {
                     // The next node has a `Dynamic` pattern. Therefore, we consider
                     // it a match regardless of the value of the path segment.
-                    results.push(Visit {
+                    results.push(Visited {
                         key: next_key,
                         range,
                         was_leaf,
@@ -137,7 +137,7 @@ impl<'a, 'b, T> Visitor<'a, 'b, T> {
                     // an exact match. Due to the nature of `CatchAll` patterns, we
                     // do not have to continue searching for descendants of this
                     // node that match the remaining path segments.
-                    results.push(Visit {
+                    results.push(Visited {
                         key: next_key,
                         // The end offset of `path_segment_range` should be the end
                         // offset of the last path segment in the url path since
@@ -161,7 +161,7 @@ impl<'a, 'b, T> Visitor<'a, 'b, T> {
     /// `self.segements` at `index` to match against the descendants of the
     /// node at `key`, we'll instead perform a shallow search for descendants
     /// with a `CatchAll` pattern.
-    fn visit_node(&self, results: &mut Vec<Visit>, index: usize, key: usize) {
+    fn visit_node(&self, results: &mut Vec<Visited>, index: usize, key: usize) {
         // Check if there is a path segment at `index` to match against
         if let Some(range) = self.segments.get(index) {
             return self.visit_descendants(results, range, index, key);
@@ -180,7 +180,7 @@ impl<'a, 'b, T> Visitor<'a, 'b, T> {
             if let Pattern::CatchAll(_) = descendant.pattern {
                 // Add the matching node to the vector of matches and continue to
                 // search for adjacent nodes with a `CatchAll` pattern.
-                results.push(Visit {
+                results.push(Visited {
                     key: next_key,
                     // Due to the fact we are looking for `CatchAll` patterns as
                     // an immediate descendant of a node that we consider a match,

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use via_router::Matches;
+use via_router::Visit;
 
 use crate::request::PathParams;
 use crate::{Middleware, Next};
@@ -87,14 +87,14 @@ where
         }
     }
 
-    pub fn lookup<'a>(&'a self, path: &str) -> Matches<'a, Vec<MatchWhen<State>>> {
+    pub fn lookup<'a>(&'a self, path: &str) -> Visit<'a, Vec<MatchWhen<State>>> {
         self.inner.visit(path)
     }
 
     pub fn resolve<'a>(
         &'a self,
         params: &mut PathParams,
-        routes: Matches<'a, Vec<MatchWhen<State>>>,
+        routes: Visit<'a, Vec<MatchWhen<State>>>,
     ) -> Next<State> {
         let mut stack = Vec::new();
 


### PR DESCRIPTION
Renames the Matches iter to prevent conflicts with the `core` and `std` prelude.