### PR TITLE
fix(via): store param names on the heap

### DIFF
--- a/src/request/params/path_params.rs
+++ b/src/request/params/path_params.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Debug, Formatter};
 
 pub struct PathParams {
-    data: Vec<(&'static str, [usize; 2])>,
+    data: Vec<(String, [usize; 2])>,
 }
 
 impl PathParams {
@@ -15,7 +15,7 @@ impl PathParams {
             .find_map(|(name, at)| if *name == predicate { Some(at) } else { None })
     }
 
-    pub fn push(&mut self, param: (&'static str, [usize; 2])) {
+    pub fn push(&mut self, param: (String, [usize; 2])) {
         self.data.push(param);
     }
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -104,7 +104,7 @@ where
             // build a tuple containing the name and the range of the parameter
             // value in the request's path.
             if let Some(name) = param {
-                params.push((name, visited.range));
+                params.push((name.to_owned(), visited.range));
             }
 
             let middlewares = match route {


### PR DESCRIPTION
Store param names on the heap after they make it out of `via-router`. This ensures that we don't have static references lingering around during async operations.