### PR TITLE
fix(via-router): impl newtype around Box<str> for param names

### DIFF
--- a/crates/via-router/benches/bench.rs
+++ b/crates/via-router/benches/bench.rs
@@ -115,8 +115,6 @@ fn find_matches_simple(b: &mut Bencher) {
         let _ = router.at(path).get_or_insert_route_with(|| ());
     }
 
-    router.shrink_to_fit();
-
     b.iter(|| {
         router.visit("/help/article/12345678987654321");
     });
@@ -130,8 +128,6 @@ fn find_matches_nested_stack(b: &mut Bencher) {
         let _ = router.at(path).get_or_insert_route_with(|| ());
     }
 
-    router.shrink_to_fit();
-
     b.iter(|| {
         router.visit("/api/v1/products/12345678987654321/edit");
     });
@@ -144,8 +140,6 @@ fn find_matches_nested_heap(b: &mut Bencher) {
     for path in ROUTES {
         let _ = router.at(path).get_or_insert_route_with(|| ());
     }
-
-    router.shrink_to_fit();
 
     b.iter(|| {
         router.visit("/api/v1/products/12345678987654321/comments/12345678987654321");

--- a/crates/via-router/src/iter.rs
+++ b/crates/via-router/src/iter.rs
@@ -31,7 +31,7 @@ pub struct Found<'a, T> {
     /// A reference to the name of the dynamic parameter that matched the path
     /// segment.
     ///
-    pub param: Option<Param>,
+    pub param: Option<&'a Param>,
 
     /// An array containing the start and end index of the path segment that
     /// matched the node containing `route`.
@@ -56,7 +56,7 @@ impl<'a, T> Iterator for Visit<'a, T> {
         Some(Found {
             is_leaf: visited.is_leaf,
             route: node.route.and_then(|key| store.route(key)),
-            param: node.param().cloned(),
+            param: node.param(),
             at: visited.at,
         })
     }
@@ -71,7 +71,7 @@ impl<'a, T> DoubleEndedIterator for Visit<'a, T> {
         Some(Found {
             is_leaf: visited.is_leaf,
             route: node.route.and_then(|key| store.route(key)),
-            param: node.param().cloned(),
+            param: node.param(),
             at: visited.at,
         })
     }

--- a/crates/via-router/src/iter.rs
+++ b/crates/via-router/src/iter.rs
@@ -1,5 +1,6 @@
 use std::vec::IntoIter;
 
+use crate::path::ParamName;
 use crate::routes::RouteStore;
 use crate::visitor::Visited;
 
@@ -17,7 +18,7 @@ impl<'a, T> Visit<'a, T> {
 }
 
 impl<'a, T> Iterator for Visit<'a, T> {
-    type Item = (Option<&'a T>, Option<&'static str>, Visited);
+    type Item = (Option<&'a T>, Option<&'a ParamName>, Visited);
 
     fn next(&mut self) -> Option<Self::Item> {
         let visited = self.iter.next()?;

--- a/crates/via-router/src/iter.rs
+++ b/crates/via-router/src/iter.rs
@@ -4,29 +4,34 @@ use crate::path::Param;
 use crate::routes::RouteStore;
 use crate::visitor::Visited;
 
-/// An iterator over the routes that match a given path.
+/// An iterator over the nodes that match a uri path.
 ///
 pub struct Visit<'a, T> {
     store: &'a RouteStore<T>,
     iter: IntoIter<Visited>,
 }
 
+/// A matched node in the route tree.
+///
+/// Contains a reference to the route associated with the node and additional
+/// metadata about the match.
+///
 #[derive(Debug)]
 pub struct Found<'a, T> {
     /// True if there were no more segments to match against the children of the
     /// matched node. Otherwise, false.
     ///
-    pub is_leaf_match: bool,
-
-    /// A reference to the name of the dynamic parameter that matched the path
-    /// segment.
-    ///
-    pub param_name: Option<&'a Param>,
+    pub is_leaf: bool,
 
     /// A reference to the route referenced by the node that matched the path
     /// segment.
     ///
     pub route: Option<&'a T>,
+
+    /// A reference to the name of the dynamic parameter that matched the path
+    /// segment.
+    ///
+    pub param: Option<Param>,
 
     /// An array containing the start and end index of the path segment that
     /// matched the node containing `route`.
@@ -49,9 +54,9 @@ impl<'a, T> Iterator for Visit<'a, T> {
         let node = store.get(visited.key);
 
         Some(Found {
-            is_leaf_match: visited.is_leaf_match,
-            param_name: node.param(),
+            is_leaf: visited.is_leaf,
             route: node.route.and_then(|key| store.route(key)),
+            param: node.param().cloned(),
             at: visited.at,
         })
     }
@@ -64,9 +69,9 @@ impl<'a, T> DoubleEndedIterator for Visit<'a, T> {
         let node = store.get(visited.key);
 
         Some(Found {
-            is_leaf_match: visited.is_leaf_match,
-            param_name: node.param(),
+            is_leaf: visited.is_leaf,
             route: node.route.and_then(|key| store.route(key)),
+            param: node.param().cloned(),
             at: visited.at,
         })
     }

--- a/crates/via-router/src/lib.rs
+++ b/crates/via-router/src/lib.rs
@@ -7,6 +7,7 @@ mod stack_vec;
 mod visitor;
 
 pub use iter::Visit;
+pub use path::ParamName;
 pub use visitor::Visited;
 
 use path::{Pattern, SplitPath};
@@ -76,7 +77,7 @@ impl<'a, T> Endpoint<'a, T> {
         }
     }
 
-    pub fn param(&self) -> Option<&'static str> {
+    pub fn param(&self) -> Option<&ParamName> {
         self.store.get(self.key).param()
     }
 
@@ -137,6 +138,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use crate::ParamName;
+
     use super::Router;
 
     const PATHS: [&str; 4] = [
@@ -166,8 +169,8 @@ mod tests {
                 let (route, param, visited) = &matches[0];
                 let [start, end] = visited.range;
 
-                assert_eq!(*route, None);
-                assert_eq!(*param, None);
+                assert_eq!(route, &None);
+                assert_eq!(param, &None);
                 assert_eq!(&path[start..end], "");
                 assert!(visited.was_leaf);
             }
@@ -178,8 +181,8 @@ mod tests {
                 let (route, param, visited) = &matches[1];
                 let [start, end] = visited.range;
 
-                assert_eq!(*route, Some(&()));
-                assert_eq!(*param, Some("path"));
+                assert_eq!(route, &Some(&()));
+                assert_eq!(param, &Some(&ParamName::new("path")));
                 assert_eq!(&path[start..end], "");
                 // Should be considered exact because of the catch-all pattern.
                 assert!(visited.was_leaf);
@@ -198,8 +201,8 @@ mod tests {
                 let (route, param, visited) = &matches[0];
                 let [start, end] = visited.range;
 
-                assert_eq!(*route, None);
-                assert_eq!(*param, None);
+                assert_eq!(route, &None);
+                assert_eq!(param, &None);
                 assert_eq!(&path[start..end], "");
                 assert!(!visited.was_leaf);
             }
@@ -210,8 +213,8 @@ mod tests {
                 let (route, param, visited) = &matches[1];
                 let [start, end] = visited.range;
 
-                assert_eq!(*route, Some(&()));
-                assert_eq!(*param, Some("path"));
+                assert_eq!(route, &Some(&()));
+                assert_eq!(param, &Some(&ParamName::new("path")));
                 assert_eq!(&path[start..end], &path[1..]);
                 // Should be considered exact because of the catch-all pattern.
                 assert!(visited.was_leaf);
@@ -230,8 +233,8 @@ mod tests {
                 let (route, param, visited) = &matches[0];
                 let [start, end] = visited.range;
 
-                assert_eq!(*route, None);
-                assert_eq!(*param, None);
+                assert_eq!(route, &None);
+                assert_eq!(param, &None);
                 assert_eq!(&path[start..end], "");
                 assert!(!visited.was_leaf);
             }
@@ -242,8 +245,8 @@ mod tests {
                 let (route, param, visited) = &matches[1];
                 let [start, end] = visited.range;
 
-                assert_eq!(*route, Some(&()));
-                assert_eq!(*param, Some("path"));
+                assert_eq!(route, &Some(&()));
+                assert_eq!(param, &Some(&ParamName::new("path")));
                 assert_eq!(&path[start..end], &path[1..]);
                 // Should be considered exact because of the catch-all pattern.
                 assert!(visited.was_leaf);
@@ -255,8 +258,8 @@ mod tests {
                 let (route, param, visited) = &matches[2];
                 let [start, end] = visited.range;
 
-                assert_eq!(*route, None);
-                assert_eq!(*param, None);
+                assert_eq!(route, &None);
+                assert_eq!(param, &None);
                 assert_eq!(&path[start..end], "echo");
                 assert!(!visited.was_leaf);
             }
@@ -267,8 +270,8 @@ mod tests {
                 let (route, param, visited) = &matches[3];
                 let [start, end] = visited.range;
 
-                assert_eq!(*route, Some(&()));
-                assert_eq!(*param, Some("path"));
+                assert_eq!(route, &Some(&()));
+                assert_eq!(param, &Some(&ParamName::new("path")));
                 assert_eq!(&path[start..end], "hello/world");
                 assert!(visited.was_leaf);
             }
@@ -286,8 +289,8 @@ mod tests {
                 let (route, param, visited) = &matches[0];
                 let [start, end] = visited.range;
 
-                assert_eq!(*route, None);
-                assert_eq!(*param, None);
+                assert_eq!(route, &None);
+                assert_eq!(param, &None);
                 assert_eq!(&path[start..end], "");
                 assert!(!visited.was_leaf);
             }
@@ -298,8 +301,8 @@ mod tests {
                 let (route, param, visited) = &matches[1];
                 let [start, end] = visited.range;
 
-                assert_eq!(*route, Some(&()));
-                assert_eq!(*param, Some("path"));
+                assert_eq!(route, &Some(&()));
+                assert_eq!(param, &Some(&ParamName::new("path")));
                 assert_eq!(&path[start..end], &path[1..]);
                 // Should be considered exact because of the catch-all pattern.
                 assert!(visited.was_leaf);
@@ -311,8 +314,8 @@ mod tests {
                 let (route, param, visited) = &matches[2];
                 let [start, end] = visited.range;
 
-                assert_eq!(*route, None);
-                assert_eq!(*param, None);
+                assert_eq!(route, &None);
+                assert_eq!(param, &None);
                 assert_eq!(&path[start..end], "articles");
                 assert!(!visited.was_leaf);
             }
@@ -323,8 +326,8 @@ mod tests {
                 let (route, param, visited) = &matches[3];
                 let [start, end] = visited.range;
 
-                assert_eq!(*route, Some(&()));
-                assert_eq!(*param, Some("id"));
+                assert_eq!(route, &Some(&()));
+                assert_eq!(param, &Some(&ParamName::new("id")));
                 assert_eq!(&path[start..end], "100");
                 assert!(visited.was_leaf);
             }
@@ -342,8 +345,8 @@ mod tests {
                 let (route, param, visited) = &matches[0];
                 let [start, end] = visited.range;
 
-                assert_eq!(*route, None);
-                assert_eq!(*param, None);
+                assert_eq!(route, &None);
+                assert_eq!(param, &None);
                 assert_eq!(&path[start..end], "");
                 assert!(!visited.was_leaf);
             }
@@ -354,8 +357,8 @@ mod tests {
                 let (route, param, visited) = &matches[1];
                 let [start, end] = visited.range;
 
-                assert_eq!(*route, Some(&()));
-                assert_eq!(*param, Some("path"));
+                assert_eq!(route, &Some(&()));
+                assert_eq!(param, &Some(&ParamName::new("path")));
                 assert_eq!(&path[start..end], &path[1..]);
                 // Should be considered exact because of the catch-all pattern.
                 assert!(visited.was_leaf);
@@ -367,8 +370,8 @@ mod tests {
                 let (route, param, visited) = &matches[2];
                 let [start, end] = visited.range;
 
-                assert_eq!(*route, None);
-                assert_eq!(*param, None);
+                assert_eq!(route, &None);
+                assert_eq!(param, &None);
                 assert_eq!(&path[start..end], "articles");
                 assert!(!visited.was_leaf);
             }
@@ -379,8 +382,8 @@ mod tests {
                 let (route, param, visited) = &matches[3];
                 let [start, end] = visited.range;
 
-                assert_eq!(*route, Some(&()));
-                assert_eq!(*param, Some("id"));
+                assert_eq!(route, &Some(&()));
+                assert_eq!(param, &Some(&ParamName::new("id")));
                 assert_eq!(&path[start..end], "100");
                 assert!(!visited.was_leaf);
             }
@@ -391,8 +394,8 @@ mod tests {
                 let (route, param, visited) = &matches[4];
                 let [start, end] = visited.range;
 
-                assert_eq!(*route, Some(&()));
-                assert_eq!(*param, None);
+                assert_eq!(route, &Some(&()));
+                assert_eq!(param, &None);
                 assert_eq!(&path[start..end], "comments");
                 // Should be considered exact because it is the last path segment.
                 assert!(visited.was_leaf);

--- a/crates/via-router/src/path/mod.rs
+++ b/crates/via-router/src/path/mod.rs
@@ -1,0 +1,5 @@
+mod pattern;
+mod split_path;
+
+pub use pattern::{patterns, ParamName, Pattern};
+pub use split_path::SplitPath;

--- a/crates/via-router/src/path/mod.rs
+++ b/crates/via-router/src/path/mod.rs
@@ -1,5 +1,5 @@
 mod pattern;
 mod split_path;
 
-pub use pattern::{patterns, ParamName, Pattern};
+pub use pattern::{patterns, Param, Pattern};
 pub use split_path::SplitPath;

--- a/crates/via-router/src/path/pattern.rs
+++ b/crates/via-router/src/path/pattern.rs
@@ -1,0 +1,70 @@
+use std::fmt::{self, Debug, Display};
+use std::sync::Arc;
+
+use super::SplitPath;
+
+#[derive(PartialEq)]
+pub enum Pattern {
+    Root,
+    Static(ParamName),
+    Dynamic(ParamName),
+    CatchAll(ParamName),
+}
+
+/// An identifier for a named path segment.
+///
+#[derive(Debug, PartialEq)]
+pub struct ParamName {
+    ident: Arc<str>,
+}
+
+/// Returns an iterator that yields a `Pattern` for each segment in the uri path.
+///
+pub fn patterns(path: &'static str) -> impl Iterator<Item = Pattern> {
+    SplitPath::new(path).map(|[start, end]| {
+        let segment = path.get(start..end).unwrap_or("");
+
+        match segment.chars().next() {
+            Some(':') => {
+                let rest = segment.get(1..).unwrap_or("");
+                Pattern::Dynamic(ParamName::new(rest))
+            }
+            Some('*') => {
+                let rest = segment.get(1..).unwrap_or("");
+                Pattern::CatchAll(ParamName::new(rest))
+            }
+            _ => {
+                // Segment does not contain a dynamic parameter.
+                Pattern::Static(ParamName::new(segment))
+            }
+        }
+    })
+}
+
+impl ParamName {
+    pub fn as_str(&self) -> &str {
+        &self.ident
+    }
+}
+
+impl ParamName {
+    pub(crate) fn new(ident: &str) -> Self {
+        Self {
+            ident: ident.into(),
+        }
+    }
+}
+
+impl Clone for ParamName {
+    fn clone(&self) -> Self {
+        Self {
+            ident: Arc::clone(&self.ident),
+        }
+    }
+}
+
+impl Display for ParamName {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&self.ident, f)
+    }
+}

--- a/crates/via-router/src/path/pattern.rs
+++ b/crates/via-router/src/path/pattern.rs
@@ -1,5 +1,4 @@
 use std::fmt::{self, Debug, Display};
-use std::sync::Arc;
 
 use super::SplitPath;
 
@@ -15,7 +14,7 @@ pub enum Pattern {
 ///
 #[derive(Debug, PartialEq)]
 pub struct ParamName {
-    ident: Arc<str>,
+    ident: Box<str>,
 }
 
 /// Returns an iterator that yields a `Pattern` for each segment in the uri path.
@@ -58,7 +57,7 @@ impl ParamName {
 impl Clone for ParamName {
     fn clone(&self) -> Self {
         Self {
-            ident: Arc::clone(&self.ident),
+            ident: self.ident.clone(),
         }
     }
 }

--- a/crates/via-router/src/path/pattern.rs
+++ b/crates/via-router/src/path/pattern.rs
@@ -5,15 +5,15 @@ use super::SplitPath;
 #[derive(PartialEq)]
 pub enum Pattern {
     Root,
-    Static(ParamName),
-    Dynamic(ParamName),
-    CatchAll(ParamName),
+    Static(Param),
+    Dynamic(Param),
+    CatchAll(Param),
 }
 
 /// An identifier for a named path segment.
 ///
 #[derive(Debug, PartialEq)]
-pub struct ParamName {
+pub struct Param {
     ident: Box<str>,
 }
 
@@ -26,27 +26,27 @@ pub fn patterns(path: &'static str) -> impl Iterator<Item = Pattern> {
         match segment.chars().next() {
             Some(':') => {
                 let rest = segment.get(1..).unwrap_or("");
-                Pattern::Dynamic(ParamName::new(rest))
+                Pattern::Dynamic(Param::new(rest))
             }
             Some('*') => {
                 let rest = segment.get(1..).unwrap_or("");
-                Pattern::CatchAll(ParamName::new(rest))
+                Pattern::CatchAll(Param::new(rest))
             }
             _ => {
                 // Segment does not contain a dynamic parameter.
-                Pattern::Static(ParamName::new(segment))
+                Pattern::Static(Param::new(segment))
             }
         }
     })
 }
 
-impl ParamName {
+impl Param {
     pub fn as_str(&self) -> &str {
         &self.ident
     }
 }
 
-impl ParamName {
+impl Param {
     pub(crate) fn new(ident: &str) -> Self {
         Self {
             ident: ident.into(),
@@ -54,7 +54,7 @@ impl ParamName {
     }
 }
 
-impl Clone for ParamName {
+impl Clone for Param {
     fn clone(&self) -> Self {
         Self {
             ident: self.ident.clone(),
@@ -62,7 +62,7 @@ impl Clone for ParamName {
     }
 }
 
-impl Display for ParamName {
+impl Display for Param {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         Display::fmt(&self.ident, f)
     }

--- a/crates/via-router/src/path/split_path.rs
+++ b/crates/via-router/src/path/split_path.rs
@@ -1,69 +1,12 @@
 use core::iter::Enumerate;
 use core::str::Bytes;
 
-#[derive(PartialEq)]
-pub enum Pattern {
-    Root,
-    Static(&'static str),
-    Dynamic(&'static str),
-    CatchAll(&'static str),
-}
-
 /// An iterator that yields a tuple containing the start and end offset of each
 /// segment in the url path.
 ///
 pub struct SplitPath<'a> {
     bytes: Enumerate<Bytes<'a>>,
     value: &'a str,
-}
-
-/// Returns an iterator that yields a `Pattern` for each segment in the uri path.
-pub fn patterns(path: &'static str) -> impl Iterator<Item = Pattern> {
-    SplitPath::new(path).map(|range| {
-        let value = segment_at(path, &range);
-
-        match value.chars().next() {
-            Some('*') => {
-                // Remove the leading `*` character. If we reach the end of
-                // `value`, default to an empty string.
-                let rest = value.get(1..).unwrap_or_default();
-
-                Pattern::CatchAll(rest)
-            }
-            Some(':') => {
-                // Remove the leading `:` character. If we reach the end of
-                // `value`, default to an empty string.
-                let rest = value.get(1..).unwrap_or_default();
-
-                Pattern::Dynamic(rest)
-            }
-            _ => {
-                // The value is a static segment. Keep it as is.
-                Pattern::Static(value)
-            }
-        }
-    })
-}
-
-// Gets the value of the path segment at `range` from `path`.
-pub fn segment_at<'a>(path: &'a str, range: &[usize; 2]) -> &'a str {
-    match path.get(range[0]..range[1]) {
-        Some(value) => {
-            // The `range` is valid, return it.
-            value
-        }
-        None => {
-            // The range is invalid. This should never happen..
-
-            if cfg!(debug_assertions) {
-                // Panic with a somewhat descriptive error message in debug mode.
-                panic!("invalid path segment for '{}' {:?}", path, range);
-            }
-
-            // Panic with a generic error message in release mode.
-            panic!("invalid path segment");
-        }
-    }
 }
 
 impl<'a> SplitPath<'a> {

--- a/crates/via-router/src/routes.rs
+++ b/crates/via-router/src/routes.rs
@@ -1,6 +1,6 @@
 use core::slice::Iter;
 
-use crate::path::Pattern;
+use crate::path::{ParamName, Pattern};
 
 /// A node in the route tree that represents a single path segment.
 pub struct Node {
@@ -56,7 +56,7 @@ impl Node {
     /// Returns an optional reference to the name of the dynamic parameter
     /// associated with the node. The returned value will be `None` if the
     /// node has a `Root` or `Static` pattern.
-    pub fn param(&self) -> Option<&'static str> {
+    pub fn param(&self) -> Option<&ParamName> {
         match &self.pattern {
             Pattern::CatchAll(param) | Pattern::Dynamic(param) => Some(param),
             _ => None,

--- a/crates/via-router/src/routes.rs
+++ b/crates/via-router/src/routes.rs
@@ -1,6 +1,6 @@
 use core::slice::Iter;
 
-use crate::path::{ParamName, Pattern};
+use crate::path::{Param, Pattern};
 
 /// A node in the route tree that represents a single path segment.
 pub struct Node {
@@ -56,7 +56,7 @@ impl Node {
     /// Returns an optional reference to the name of the dynamic parameter
     /// associated with the node. The returned value will be `None` if the
     /// node has a `Root` or `Static` pattern.
-    pub fn param(&self) -> Option<&ParamName> {
+    pub fn param(&self) -> Option<&Param> {
         match &self.pattern {
             Pattern::CatchAll(param) | Pattern::Dynamic(param) => Some(param),
             _ => None,
@@ -141,11 +141,6 @@ impl<T> RouteStore<T> {
 
         self.nodes.push(node);
         key
-    }
-
-    /// Shrinks the capacity of the route store as much as possible.
-    pub fn shrink_to_fit(&mut self) {
-        self.nodes.shrink_to_fit();
     }
 
     /// Returns a shared reference to the node at the given `key`.

--- a/crates/via-router/src/visitor.rs
+++ b/crates/via-router/src/visitor.rs
@@ -7,7 +7,7 @@ pub struct Visited {
     /// True if there were no more segments to match against the children of the
     /// matched node. Otherwise, false.
     ///
-    pub is_leaf_match: bool,
+    pub is_leaf: bool,
 
     /// An array containing the start and end index of the path segment that
     /// matched the node containing `route`.
@@ -47,7 +47,7 @@ impl<'a, 'b, T> Visitor<'a, 'b, T> {
         results.push(Visited {
             // If there are no path segments to match against, we consider the
             // root node to be an exact match.
-            is_leaf_match: self.segments.is_empty(),
+            is_leaf: self.segments.is_empty(),
             // The root node's key is always `0`.
             key: 0,
             // The root node's path segment range should produce to an empty str.
@@ -99,7 +99,7 @@ impl<'a, 'b, T> Visitor<'a, 'b, T> {
         // matching descendant to be a leaf node. We perform this check eagerly
         // to avoid having to do so for each descendant with a `Dynamic` or
         // `Static` pattern.
-        let is_leaf_match = next_index == self.segments.len();
+        let is_leaf = next_index == self.segments.len();
 
         let store = self.store;
 
@@ -114,7 +114,7 @@ impl<'a, 'b, T> Visitor<'a, 'b, T> {
                     // The next node has a `Static` pattern that matches the value
                     // of the path segment.
                     results.push(Visited {
-                        is_leaf_match,
+                        is_leaf,
                         key: next_key,
                         at: range,
                     });
@@ -125,7 +125,7 @@ impl<'a, 'b, T> Visitor<'a, 'b, T> {
                     // The next node has a `Dynamic` pattern. Therefore, we consider
                     // it a match regardless of the value of the path segment.
                     results.push(Visited {
-                        is_leaf_match,
+                        is_leaf,
                         key: next_key,
                         at: range,
                     });
@@ -139,7 +139,7 @@ impl<'a, 'b, T> Visitor<'a, 'b, T> {
                     // node that match the remaining path segments.
                     results.push(Visited {
                         // `CatchAll` patterns are always considered a leaf node.
-                        is_leaf_match: true,
+                        is_leaf: true,
                         key: next_key,
                         // The end offset of `path_segment_range` should be the end
                         // offset of the last path segment in the url path since
@@ -182,7 +182,7 @@ impl<'a, 'b, T> Visitor<'a, 'b, T> {
                 // search for adjacent nodes with a `CatchAll` pattern.
                 results.push(Visited {
                     // `CatchAll` patterns are always considered an exact match.
-                    is_leaf_match: true,
+                    is_leaf: true,
                     key: next_key,
                     // Due to the fact we are looking for `CatchAll` patterns as
                     // an immediate descendant of a node that we consider a match,

--- a/crates/via-serve-static/src/lib.rs
+++ b/crates/via-serve-static/src/lib.rs
@@ -20,7 +20,7 @@ pub struct ServeStatic<'a, State> {
 pub(crate) struct ServerConfig {
     eager_read_threshold: u64,
     read_stream_timeout: u64,
-    path_param: &'static str,
+    path_param: Box<str>,
     public_dir: Arc<Path>,
     flags: Flags,
 }
@@ -98,14 +98,13 @@ where
             ..
         } = self;
         let mut public_dir = public_dir.as_ref().to_path_buf();
-        let path_param = match self.endpoint.param() {
-            Some(param) => param,
-            None => {
-                return Err(Error::new(
-                    "The provided endpoint does not have a path parameter.".to_owned(),
-                ))
-            }
-        };
+        let path_param = self.endpoint.param().map_or_else(
+            || {
+                let message = "The provided endpoint does not have a path parameter.";
+                Err(Error::new(message.to_owned()))
+            },
+            |value| Ok(value.to_owned().into_boxed_str()),
+        )?;
 
         if public_dir.is_relative() {
             let current_dir = std::env::current_dir()?;

--- a/crates/via-serve-static/src/respond.rs
+++ b/crates/via-serve-static/src/respond.rs
@@ -115,7 +115,7 @@ fn build_path_from_request<State>(
     request: &Request<State>,
     config: &ServerConfig,
 ) -> Result<PathBuf> {
-    let path_param = request.param(config.path_param).into_result()?;
+    let path_param = request.param(&config.path_param).into_result()?;
     Ok(config.public_dir.join(path_param.trim_end_matches('/')))
 }
 

--- a/src/request/params/path_params.rs
+++ b/src/request/params/path_params.rs
@@ -6,8 +6,8 @@ pub struct PathParams {
 }
 
 impl PathParams {
-    pub fn new() -> Self {
-        Self { data: Vec::new() }
+    pub fn new(data: Vec<(Param, [usize; 2])>) -> Self {
+        Self { data }
     }
 
     pub fn get(&self, predicate: &str) -> Option<&[usize; 2]> {
@@ -28,11 +28,5 @@ impl PathParams {
 impl Debug for PathParams {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         Debug::fmt(&self.data, f)
-    }
-}
-
-impl Default for PathParams {
-    fn default() -> Self {
-        Self::new()
     }
 }

--- a/src/request/params/path_params.rs
+++ b/src/request/params/path_params.rs
@@ -1,8 +1,8 @@
 use std::fmt::{self, Debug, Formatter};
-use via_router::ParamName;
+use via_router::Param;
 
 pub struct PathParams {
-    data: Vec<(ParamName, [usize; 2])>,
+    data: Vec<(Param, [usize; 2])>,
 }
 
 impl PathParams {
@@ -20,7 +20,7 @@ impl PathParams {
         })
     }
 
-    pub fn push(&mut self, param: (ParamName, [usize; 2])) {
+    pub fn push(&mut self, param: (Param, [usize; 2])) {
         self.data.push(param);
     }
 }

--- a/src/request/params/path_params.rs
+++ b/src/request/params/path_params.rs
@@ -1,7 +1,8 @@
 use std::fmt::{self, Debug, Formatter};
+use via_router::ParamName;
 
 pub struct PathParams {
-    data: Vec<(String, [usize; 2])>,
+    data: Vec<(ParamName, [usize; 2])>,
 }
 
 impl PathParams {
@@ -10,12 +11,16 @@ impl PathParams {
     }
 
     pub fn get(&self, predicate: &str) -> Option<&[usize; 2]> {
-        self.data
-            .iter()
-            .find_map(|(name, at)| if *name == predicate { Some(at) } else { None })
+        self.data.iter().find_map(|(name, at)| {
+            if predicate == name.as_str() {
+                Some(at)
+            } else {
+                None
+            }
+        })
     }
 
-    pub fn push(&mut self, param: (String, [usize; 2])) {
+    pub fn push(&mut self, param: (ParamName, [usize; 2])) {
         self.data.push(param);
     }
 }

--- a/src/request/request.rs
+++ b/src/request/request.rs
@@ -170,13 +170,18 @@ impl<State> Request<State> {
 }
 
 impl<State> Request<State> {
-    pub(crate) fn new(parts: Box<Parts>, body: RequestBody, state: Arc<State>) -> Self {
+    pub(crate) fn new(
+        parts: Box<Parts>,
+        body: RequestBody,
+        state: Arc<State>,
+        params: PathParams,
+    ) -> Self {
         Self {
+            cookies: None,
             parts,
             body,
             state,
-            cookies: None,
-            params: PathParams::new(),
+            params,
         }
     }
 

--- a/src/router.rs
+++ b/src/router.rs
@@ -42,8 +42,8 @@ impl<'a, State> Endpoint<'a, State> {
         self
     }
 
-    pub fn param(&self) -> Option<&'static str> {
-        self.inner.param()
+    pub fn param(&self) -> Option<&str> {
+        self.inner.param().map(|name| name.as_str())
     }
 
     pub fn include<T>(&mut self, middleware: T) -> &mut Self
@@ -104,7 +104,7 @@ where
             // build a tuple containing the name and the range of the parameter
             // value in the request's path.
             if let Some(name) = param {
-                params.push((name.to_owned(), visited.range));
+                params.push((name.clone(), visited.range));
             }
 
             let middlewares = match route {

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,8 +1,9 @@
+use std::iter::Rev;
 use std::sync::Arc;
 use via_router::Visit;
 
+use crate::middleware::{ArcMiddleware, Middleware};
 use crate::request::PathParams;
-use crate::{Middleware, Next};
 
 /// An enum that wraps middleware before it's added to the router, specifying
 /// whether the middleware should apply to partial or exact matches of a
@@ -25,6 +26,46 @@ pub struct Endpoint<'a, State> {
 
 pub struct Router<State> {
     inner: via_router::Router<Vec<MatchWhen<State>>>,
+}
+
+pub fn resolve<'a, State>(
+    stack: &mut Vec<ArcMiddleware<State>>,
+    params: &mut PathParams,
+    visited: &mut Rev<Visit<'a, Vec<MatchWhen<State>>>>,
+) {
+    // Iterate over the routes that match the request's path.
+    for found in visited {
+        // If there is a dynamic parameter name associated with the route,
+        // build a tuple containing the name and the range of the parameter
+        // value in the request's path.
+        if let Some(param) = found.param {
+            params.push((param.clone(), found.at));
+        }
+
+        let middlewares = match found.route {
+            Some(vec) => vec,
+            None => continue,
+        };
+
+        // Extend `stack` with middleware in `matched` depending on whether
+        // or not the middleware expects a partial or exact match.
+        for middleware in middlewares.iter().rev().filter_map(|when| match when {
+            // Include this middleware in `stack` because it expects an exact
+            // match and the visited node is considered a leaf in this
+            // context.
+            MatchWhen::Exact(exact) if found.is_leaf => Some(exact),
+
+            // Include this middleware in `stack` unconditionally because it
+            // targets partial matches.
+            MatchWhen::Partial(partial) => Some(partial),
+
+            // Exclude this middleware from `stack` because it expects an
+            // exact match and the visited node is not a leaf.
+            MatchWhen::Exact(_) => None,
+        }) {
+            stack.push(Arc::clone(middleware));
+        }
+    }
 }
 
 impl<'a, State> Endpoint<'a, State> {
@@ -89,49 +130,5 @@ where
 
     pub fn lookup<'a>(&'a self, path: &str) -> Visit<'a, Vec<MatchWhen<State>>> {
         self.inner.visit(path)
-    }
-
-    pub fn resolve<'a>(
-        &'a self,
-        params: &mut PathParams,
-        routes: Visit<'a, Vec<MatchWhen<State>>>,
-    ) -> Next<State> {
-        let mut stack = Vec::new();
-
-        // Iterate over the routes that match the request's path.
-        for found in routes.rev() {
-            // If there is a dynamic parameter name associated with the route,
-            // build a tuple containing the name and the range of the parameter
-            // value in the request's path.
-            if let Some(param) = found.param {
-                params.push((param, found.at));
-            }
-
-            let middlewares = match found.route {
-                Some(vec) => vec,
-                None => continue,
-            };
-
-            // Extend `stack` with middleware in `matched` depending on whether
-            // or not the middleware expects a partial or exact match.
-            for middleware in middlewares.iter().rev().filter_map(|when| match when {
-                // Include this middleware in `stack` because it expects an exact
-                // match and the visited node is considered a leaf in this
-                // context.
-                MatchWhen::Exact(exact) if found.is_leaf => Some(exact),
-
-                // Include this middleware in `stack` unconditionally because it
-                // targets partial matches.
-                MatchWhen::Partial(partial) => Some(partial),
-
-                // Exclude this middleware from `stack` because it expects an
-                // exact match and the visited node is not a leaf.
-                MatchWhen::Exact(_) => None,
-            }) {
-                stack.push(Arc::clone(middleware));
-            }
-        }
-
-        Next::new(stack)
     }
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -103,8 +103,8 @@ where
             // If there is a dynamic parameter name associated with the route,
             // build a tuple containing the name and the range of the parameter
             // value in the request's path.
-            if let Some(param_name) = found.param_name {
-                params.push((param_name.clone(), found.at));
+            if let Some(param) = found.param {
+                params.push((param, found.at));
             }
 
             let middlewares = match found.route {
@@ -118,7 +118,7 @@ where
                 // Include this middleware in `stack` because it expects an exact
                 // match and the visited node is considered a leaf in this
                 // context.
-                MatchWhen::Exact(exact) if found.is_leaf_match => Some(exact),
+                MatchWhen::Exact(exact) if found.is_leaf => Some(exact),
 
                 // Include this middleware in `stack` unconditionally because it
                 // targets partial matches.

--- a/src/router.rs
+++ b/src/router.rs
@@ -99,15 +99,15 @@ where
         let mut stack = Vec::new();
 
         // Iterate over the routes that match the request's path.
-        for (route, param, visited) in routes.rev() {
+        for found in routes.rev() {
             // If there is a dynamic parameter name associated with the route,
             // build a tuple containing the name and the range of the parameter
             // value in the request's path.
-            if let Some(name) = param {
-                params.push((name.clone(), visited.range));
+            if let Some(param_name) = found.param_name {
+                params.push((param_name.clone(), found.at));
             }
 
-            let middlewares = match route {
+            let middlewares = match found.route {
                 Some(vec) => vec,
                 None => continue,
             };
@@ -118,7 +118,7 @@ where
                 // Include this middleware in `stack` because it expects an exact
                 // match and the visited node is considered a leaf in this
                 // context.
-                MatchWhen::Exact(exact) if visited.was_leaf => Some(exact),
+                MatchWhen::Exact(exact) if found.is_leaf_match => Some(exact),
 
                 // Include this middleware in `stack` unconditionally because it
                 // targets partial matches.

--- a/src/router.rs
+++ b/src/router.rs
@@ -28,10 +28,10 @@ pub struct Router<State> {
     inner: via_router::Router<Vec<MatchWhen<State>>>,
 }
 
-pub fn resolve<'a, State>(
+pub fn resolve<State>(
     stack: &mut Vec<ArcMiddleware<State>>,
     params: &mut PathParams,
-    visited: &mut Rev<Visit<'a, Vec<MatchWhen<State>>>>,
+    visited: &mut Rev<Visit<Vec<MatchWhen<State>>>>,
 ) {
     // Iterate over the routes that match the request's path.
     for found in visited {


### PR DESCRIPTION
Refactors via-router to avoid storing static references for param names in favor of a newtype around `Box<str>`. This is a security fix that also stabilizes memory usage.