### PR TITLE
refactor(via): build next before request

### DIFF
--- a/src/request/request.rs
+++ b/src/request/request.rs
@@ -189,11 +189,6 @@ impl<State> Request<State> {
     pub(crate) fn cookies_mut(&mut self) -> &mut CookieJar {
         self.cookies.get_or_insert_with(Default::default)
     }
-
-    /// Returns a mutable reference to the cookies associated with the request.
-    pub(crate) fn params_mut(&mut self) -> &mut PathParams {
-        &mut self.params
-    }
 }
 
 impl<State> Debug for Request<State> {

--- a/src/router.rs
+++ b/src/router.rs
@@ -31,7 +31,7 @@ pub struct Router<State> {
 pub fn resolve<State>(
     stack: &mut Vec<ArcMiddleware<State>>,
     params: &mut PathParams,
-    visited: &mut Rev<Visit<Vec<MatchWhen<State>>>>,
+    visited: Rev<Visit<Vec<MatchWhen<State>>>>,
 ) {
     // Iterate over the routes that match the request's path.
     for found in visited {

--- a/src/server/service.rs
+++ b/src/server/service.rs
@@ -65,15 +65,15 @@ where
 
         // Build the middleware stack for the request.
         let next = {
-            // Allocate a vec to store the middleware associated with the
-            // request.
-            let mut stack = Vec::new();
-
             // Get an iterator of matched nodes for the uri path.
             let visited = {
                 let path = incoming.uri().path();
                 self.router.lookup(path).rev()
             };
+
+            // Allocate a vec to store the middleware associated with the
+            // request.
+            let mut stack = Vec::new();
 
             // Populate the path params and build middleware stack.
             router::resolve(&mut stack, &mut params, visited);


### PR DESCRIPTION
Builds the arguments passed to middleware functions in reverse order to make the movement of data more efficient.