### PR TITLE
fix(via-router): use Arc<str> instead of Box<str>

### DIFF
--- a/crates/via-router/src/path/pattern.rs
+++ b/crates/via-router/src/path/pattern.rs
@@ -1,4 +1,5 @@
 use std::fmt::{self, Debug, Display};
+use std::sync::Arc;
 
 use super::SplitPath;
 
@@ -14,7 +15,7 @@ pub enum Pattern {
 ///
 #[derive(Debug, PartialEq)]
 pub struct Param {
-    ident: Box<str>,
+    ident: Arc<str>,
 }
 
 /// Returns an iterator that yields a `Pattern` for each segment in the uri path.


### PR DESCRIPTION
A placeholder PR for testing the performance differences between copying a Box<str> and cloning an Arc<str> in the context of path parameters.