### PR TITLE
refactor(via-router): rename SegmentAt to Span

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ percent-encoding = "2.3"
 serde = "1"
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "signal"] }
-via-router = "1"
+via-router = { path = "./crates/via-router" }
 
 [dependencies.cookie]
 version = "0.18"

--- a/crates/via-router/Cargo.toml
+++ b/crates/via-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via-router"
-version = "1.0.1"
+version = "2.0.0"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT"

--- a/crates/via-router/src/lib.rs
+++ b/crates/via-router/src/lib.rs
@@ -5,7 +5,7 @@ mod routes;
 mod stack_vec;
 mod visitor;
 
-pub use path::{Param, SegmentAt};
+pub use path::{Param, Span};
 pub use visitor::Found;
 
 use path::{Pattern, SplitPath};

--- a/crates/via-router/src/path/mod.rs
+++ b/crates/via-router/src/path/mod.rs
@@ -2,4 +2,4 @@ mod pattern;
 mod split_path;
 
 pub use pattern::{patterns, Param, Pattern};
-pub use split_path::{SegmentAt, SplitPath};
+pub use split_path::{Span, SplitPath};

--- a/crates/via-router/src/path/split_path.rs
+++ b/crates/via-router/src/path/split_path.rs
@@ -4,7 +4,7 @@ use core::str::Bytes;
 /// A matched range in the url path.
 ///
 #[derive(Debug, PartialEq)]
-pub struct SegmentAt {
+pub struct Span {
     start: usize,
     end: usize,
 }
@@ -17,7 +17,7 @@ pub struct SplitPath<'a> {
     value: &'a str,
 }
 
-impl SegmentAt {
+impl Span {
     /// Returns the start offset of the matched range.
     ///
     pub fn start(&self) -> usize {
@@ -31,13 +31,13 @@ impl SegmentAt {
     }
 }
 
-impl SegmentAt {
+impl Span {
     pub(crate) fn new(start: usize, end: usize) -> Self {
         Self { start, end }
     }
 }
 
-impl Clone for SegmentAt {
+impl Clone for Span {
     fn clone(&self) -> Self {
         Self {
             start: self.start,
@@ -88,7 +88,7 @@ impl<'a> SplitPath<'a> {
 }
 
 impl<'a> Iterator for SplitPath<'a> {
-    type Item = SegmentAt;
+    type Item = Span;
 
     fn next(&mut self) -> Option<Self::Item> {
         // Set the start index to the next character that is not a `/`.
@@ -97,13 +97,13 @@ impl<'a> Iterator for SplitPath<'a> {
         let end = self.next_terminator().unwrap_or(self.value.len());
 
         // Return the start and end offset of the current path segment.
-        Some(SegmentAt { start, end })
+        Some(Span { start, end })
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{SegmentAt, SplitPath};
+    use super::{Span, SplitPath};
 
     const PATHS: [&str; 15] = [
         "/home/about",
@@ -123,53 +123,33 @@ mod tests {
         "/services/contact//us",
     ];
 
-    fn get_expected_results() -> [Vec<SegmentAt>; 15] {
+    fn get_expected_results() -> [Vec<Span>; 15] {
         [
-            vec![SegmentAt::new(1, 5), SegmentAt::new(6, 11)],
+            vec![Span::new(1, 5), Span::new(6, 11)],
+            vec![Span::new(1, 9), Span::new(10, 14), Span::new(15, 18)],
             vec![
-                SegmentAt::new(1, 9),
-                SegmentAt::new(10, 14),
-                SegmentAt::new(15, 18),
+                Span::new(1, 5),
+                Span::new(6, 11),
+                Span::new(12, 16),
+                Span::new(17, 21),
             ],
+            vec![Span::new(1, 5), Span::new(6, 13), Span::new(14, 22)],
+            vec![Span::new(1, 9), Span::new(10, 17)],
+            vec![Span::new(1, 7), Span::new(8, 23)],
+            vec![Span::new(1, 5), Span::new(6, 12)],
+            vec![Span::new(1, 10), Span::new(11, 18)],
+            vec![Span::new(1, 4)],
+            vec![Span::new(1, 8), Span::new(9, 16)],
+            vec![Span::new(2, 6), Span::new(8, 13)],
+            vec![Span::new(1, 9), Span::new(11, 15), Span::new(16, 19)],
             vec![
-                SegmentAt::new(1, 5),
-                SegmentAt::new(6, 11),
-                SegmentAt::new(12, 16),
-                SegmentAt::new(17, 21),
+                Span::new(1, 5),
+                Span::new(6, 11),
+                Span::new(12, 16),
+                Span::new(18, 22),
             ],
-            vec![
-                SegmentAt::new(1, 5),
-                SegmentAt::new(6, 13),
-                SegmentAt::new(14, 22),
-            ],
-            vec![SegmentAt::new(1, 9), SegmentAt::new(10, 17)],
-            vec![SegmentAt::new(1, 7), SegmentAt::new(8, 23)],
-            vec![SegmentAt::new(1, 5), SegmentAt::new(6, 12)],
-            vec![SegmentAt::new(1, 10), SegmentAt::new(11, 18)],
-            vec![SegmentAt::new(1, 4)],
-            vec![SegmentAt::new(1, 8), SegmentAt::new(9, 16)],
-            vec![SegmentAt::new(2, 6), SegmentAt::new(8, 13)],
-            vec![
-                SegmentAt::new(1, 9),
-                SegmentAt::new(11, 15),
-                SegmentAt::new(16, 19),
-            ],
-            vec![
-                SegmentAt::new(1, 5),
-                SegmentAt::new(6, 11),
-                SegmentAt::new(12, 16),
-                SegmentAt::new(18, 22),
-            ],
-            vec![
-                SegmentAt::new(1, 5),
-                SegmentAt::new(7, 14),
-                SegmentAt::new(15, 23),
-            ],
-            vec![
-                SegmentAt::new(1, 9),
-                SegmentAt::new(10, 17),
-                SegmentAt::new(19, 21),
-            ],
+            vec![Span::new(1, 5), Span::new(7, 14), Span::new(15, 23)],
+            vec![Span::new(1, 9), Span::new(10, 17), Span::new(19, 21)],
         ]
     }
 

--- a/crates/via-router/src/visitor.rs
+++ b/crates/via-router/src/visitor.rs
@@ -1,4 +1,4 @@
-use crate::path::{Param, Pattern, SegmentAt};
+use crate::path::{Param, Pattern, Span};
 use crate::routes::{Node, RouteStore};
 use crate::stack_vec::StackVec;
 
@@ -25,17 +25,13 @@ pub struct Found {
 
     /// The range of the path segment that matched the node.
     ///
-    pub at: SegmentAt,
+    pub at: Span,
 }
 
-pub fn visit<T>(
-    path: &str,
-    store: &RouteStore<T>,
-    segments: &StackVec<SegmentAt, 5>,
-) -> Vec<Found> {
+pub fn visit<T>(path: &str, store: &RouteStore<T>, segments: &StackVec<Span, 5>) -> Vec<Found> {
     let mut results = Vec::new();
     let root = store.get(0);
-    let at = SegmentAt::new(0, 0);
+    let at = Span::new(0, 0);
 
     match segments.get(0) {
         Some(range) => {
@@ -60,7 +56,7 @@ pub fn visit<T>(
 }
 
 impl Found {
-    fn new(route: Option<usize>, param: Option<Param>, at: SegmentAt) -> Self {
+    fn new(route: Option<usize>, param: Option<Param>, at: Span) -> Self {
         Self {
             is_leaf: false,
             route,
@@ -69,7 +65,7 @@ impl Found {
         }
     }
 
-    fn leaf(route: Option<usize>, param: Option<Param>, at: SegmentAt) -> Self {
+    fn leaf(route: Option<usize>, param: Option<Param>, at: Span) -> Self {
         Self {
             is_leaf: true,
             route,
@@ -97,11 +93,11 @@ fn visit_node<T>(
     // The url path that we are attempting to match against the route tree.
     path: &str,
 
-    segments: &StackVec<SegmentAt, 5>,
+    segments: &StackVec<Span, 5>,
 
     // The start and end offset of the path segment at `index` in
     // `self.path_value`.
-    range: &SegmentAt,
+    range: &Span,
 
     // The index of the path segment in `self.segments` that we are matching
     // against the node at `key`.
@@ -186,7 +182,7 @@ fn visit_node<T>(
                 results.push(Found::leaf(
                     entry.route,
                     Some(param.clone()),
-                    SegmentAt::new(range.start(), path.len()),
+                    Span::new(range.start(), path.len()),
                 ));
             }
 
@@ -223,7 +219,7 @@ fn visit_index<T>(
             results.push(Found::leaf(
                 entry.route,
                 Some(param.clone()),
-                SegmentAt::new(0, 0),
+                Span::new(0, 0),
             ));
         }
     }

--- a/src/request/params/path_params.rs
+++ b/src/request/params/path_params.rs
@@ -1,12 +1,12 @@
 use std::fmt::{self, Debug, Formatter};
-use via_router::{Param, SegmentAt};
+use via_router::{Param, Span};
 
 pub struct PathParams {
-    data: Vec<(Param, SegmentAt)>,
+    data: Vec<(Param, Span)>,
 }
 
 impl PathParams {
-    pub fn new(data: Vec<(Param, SegmentAt)>) -> Self {
+    pub fn new(data: Vec<(Param, Span)>) -> Self {
         Self { data }
     }
 
@@ -20,7 +20,7 @@ impl PathParams {
         })
     }
 
-    pub fn push(&mut self, param: (Param, SegmentAt)) {
+    pub fn push(&mut self, param: (Param, Span)) {
         self.data.push(param);
     }
 }


### PR DESCRIPTION
Renames SegmentAt to Span. I think the name is more meaningful and descriptive for Rust developers.