### PR TITLE
refactor(via-router): rename CatchAll to Wildcard

### DIFF
--- a/crates/via-router/src/lib.rs
+++ b/crates/via-router/src/lib.rs
@@ -100,7 +100,7 @@ where
     // In the future we may want to panic if the caller tries to insert a node
     // into a catch-all node rather than silently ignoring the rest of the
     // segments.
-    if let Pattern::CatchAll(_) = routes.get(into_index).pattern {
+    if let Pattern::Wildcard(_) = routes.get(into_index).pattern {
         for _ in segments {}
         return into_index;
     }

--- a/crates/via-router/src/path/pattern.rs
+++ b/crates/via-router/src/path/pattern.rs
@@ -7,7 +7,7 @@ pub enum Pattern {
     Root,
     Static(Param),
     Dynamic(Param),
-    CatchAll(Param),
+    Wildcard(Param),
 }
 
 /// An identifier for a named path segment.
@@ -66,7 +66,7 @@ pub fn patterns(path: &'static str) -> impl Iterator<Item = Pattern> {
                 let rest = rest_or!(segment, "Wildcard parameters must be named. Found '*'.");
                 let param = Param::new(rest);
 
-                Pattern::CatchAll(param)
+                Pattern::Wildcard(param)
             }
 
             // The segment does not start with a reserved character. We will

--- a/crates/via-router/src/routes.rs
+++ b/crates/via-router/src/routes.rs
@@ -55,7 +55,7 @@ impl Node {
     /// node has a `Root` or `Static` pattern.
     pub fn param(&self) -> Option<&Param> {
         match &self.pattern {
-            Pattern::CatchAll(param) | Pattern::Dynamic(param) => Some(param),
+            Pattern::Wildcard(param) | Pattern::Dynamic(param) => Some(param),
             _ => None,
         }
     }

--- a/crates/via-router/src/visitor.rs
+++ b/crates/via-router/src/visitor.rs
@@ -178,7 +178,7 @@ fn visit_node<T>(
             // an exact match. Due to the nature of `CatchAll` patterns, we
             // do not have to continue searching for descendants of this
             // node that match the remaining path segments.
-            Pattern::CatchAll(param) => {
+            Pattern::Wildcard(param) => {
                 results.push(Found::leaf(
                     entry.route,
                     Some(param.clone()),
@@ -214,7 +214,7 @@ fn visit_index<T>(
         let entry = store.get(key);
 
         // Check if `descendant` has a `CatchAll` pattern.
-        if let Pattern::CatchAll(param) = &entry.pattern {
+        if let Pattern::Wildcard(param) = &entry.pattern {
             // Append the match as a leaf to the results vector.
             results.push(Found::leaf(
                 entry.route,


### PR DESCRIPTION
Renames `CatchAll` to `Wildcard` as it is a more descriptive name.