### PR TITLE
fix(via): use UnsyncBoxBody instead of BoxBody

### DIFF
--- a/src/body/any.rs
+++ b/src/body/any.rs
@@ -1,6 +1,6 @@
 use bytes::Bytes;
 use http_body::{Body, Frame, SizeHint};
-use http_body_util::combinators::BoxBody;
+use http_body_util::combinators::UnsyncBoxBody;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -18,7 +18,7 @@ use crate::Error;
 pub enum AnyBody<T> {
     /// A dynamically dispatched `dyn Body + Send + Sync`.
     ///
-    Box(BoxBody<Bytes, Error>),
+    Box(UnsyncBoxBody<Bytes, Error>),
 
     /// A statically dispatched `impl Body + Send + Sync`.
     ///
@@ -26,7 +26,7 @@ pub enum AnyBody<T> {
 }
 
 enum AnyBodyProjection<'a, T> {
-    Box(Pin<&'a mut BoxBody<Bytes, Error>>),
+    Box(Pin<&'a mut UnsyncBoxBody<Bytes, Error>>),
     Inline(Pin<&'a mut T>),
 }
 

--- a/src/request/request.rs
+++ b/src/request/request.rs
@@ -3,7 +3,7 @@ use cookie::CookieJar;
 use http::request::Parts;
 use http::{HeaderMap, Method, Uri, Version};
 use http_body::Body;
-use http_body_util::combinators::BoxBody;
+use http_body_util::combinators::UnsyncBoxBody;
 use hyper::body::Incoming;
 use std::fmt::{self, Debug};
 use std::sync::Arc;
@@ -70,7 +70,7 @@ impl<State> Request<State> {
     {
         let input = self.body.into_inner();
         let output = map(input);
-        let box_body = AnyBody::Box(BoxBody::new(output));
+        let box_body = AnyBody::Box(UnsyncBoxBody::new(output));
 
         Self {
             body: RequestBody::new(box_body),

--- a/src/response/body.rs
+++ b/src/response/body.rs
@@ -1,6 +1,6 @@
 use bytes::Bytes;
 use http_body::Body;
-use http_body_util::combinators::BoxBody;
+use http_body_util::combinators::UnsyncBoxBody;
 use std::fmt::{self, Debug, Formatter};
 
 use crate::body::{AnyBody, ByteBuffer};
@@ -23,10 +23,10 @@ impl ResponseBody {
 
     pub fn from_dyn<T>(body: T) -> Self
     where
-        T: Body<Data = Bytes, Error = Error> + Send + Sync + 'static,
+        T: Body<Data = Bytes, Error = Error> + Send + 'static,
     {
         Self {
-            body: AnyBody::Box(BoxBody::new(body)),
+            body: AnyBody::Box(UnsyncBoxBody::new(body)),
         }
     }
 }
@@ -65,8 +65,8 @@ impl Default for ResponseBody {
     }
 }
 
-impl From<BoxBody<Bytes, Error>> for ResponseBody {
-    fn from(body: BoxBody<Bytes, Error>) -> Self {
+impl From<UnsyncBoxBody<Bytes, Error>> for ResponseBody {
+    fn from(body: UnsyncBoxBody<Bytes, Error>) -> Self {
         Self {
             body: AnyBody::Box(body),
         }

--- a/src/response/builder.rs
+++ b/src/response/builder.rs
@@ -86,7 +86,7 @@ impl ResponseBuilder {
     ///
     pub fn stream<S, E>(self, stream: S) -> Self
     where
-        S: Stream<Item = Result<Frame<Bytes>, E>> + Send + Sync + Unpin + 'static,
+        S: Stream<Item = Result<Frame<Bytes>, E>> + Send + Unpin + 'static,
         Error: From<E>,
     {
         let mut builder = self.inner;

--- a/src/response/response.rs
+++ b/src/response/response.rs
@@ -74,7 +74,7 @@ impl Response {
     ///
     pub fn stream<T, E>(stream: T) -> Self
     where
-        T: Stream<Item = Result<Frame<Bytes>, E>> + Send + Sync + Unpin + 'static,
+        T: Stream<Item = Result<Frame<Bytes>, E>> + Send + Unpin + 'static,
         Error: From<E>,
     {
         let stream_body = StreamAdapter::new(stream);

--- a/src/response/stream_adapter.rs
+++ b/src/response/stream_adapter.rs
@@ -16,7 +16,7 @@ pub struct StreamAdapter<T> {
 
 impl<T, E> StreamAdapter<T>
 where
-    T: Stream<Item = Result<Frame<Bytes>, E>> + Send + Sync + Unpin,
+    T: Stream<Item = Result<Frame<Bytes>, E>> + Send + Unpin,
 {
     pub fn new(stream: T) -> Self {
         Self { stream }
@@ -34,7 +34,7 @@ impl<T: Unpin> StreamAdapter<T> {
 
 impl<T, E> Body for StreamAdapter<T>
 where
-    T: Stream<Item = Result<Frame<Bytes>, E>> + Send + Sync + Unpin,
+    T: Stream<Item = Result<Frame<Bytes>, E>> + Send + Unpin,
     Error: From<E>,
 {
     type Data = Bytes;


### PR DESCRIPTION
Uses UnsyncBoxBody instead of BoxBody to keep the body types `!Sync`.