### PR TITLE
fix(via): use published version of via-router

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ percent-encoding = "2.3"
 serde = "1"
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "signal"] }
-via-router = { path = "./crates/via-router" }
+via-router = "2"
 
 [dependencies.cookie]
 version = "0.18"


### PR DESCRIPTION
Switches to use the published version of `via-router` in preparation for release.