### PR TITLE
refactor(via): remove the result type alias

### DIFF
--- a/crates/via-serve-static/src/lib.rs
+++ b/crates/via-serve-static/src/lib.rs
@@ -5,7 +5,7 @@ mod stream_file;
 
 use bitflags::bitflags;
 use std::{path::Path, sync::Arc};
-use via::{Endpoint, Error, Result};
+use via::{Endpoint, Error};
 
 use crate::respond::{respond_to_get_request, respond_to_head_request};
 
@@ -87,7 +87,7 @@ where
     /// the provided `public_dir` is a relative path, it will be resolved relative to
     /// the current working directory. If the `public_dir` is not a directory or the
     /// `location` does not have a path parameter, an error will be returned.
-    pub fn serve<P>(mut self, public_dir: P) -> Result<()>
+    pub fn serve<P>(mut self, public_dir: P) -> Result<(), Error>
     where
         P: AsRef<Path>,
     {

--- a/crates/via-serve-static/src/respond.rs
+++ b/crates/via-serve-static/src/respond.rs
@@ -3,7 +3,7 @@ use httpdate::HttpDate;
 use std::path::PathBuf;
 use via::{
     http::{header, HeaderName},
-    Next, Request, Response, Result,
+    Error, Next, Request, Response,
 };
 
 use crate::{static_file::StaticFile, stream_file::StreamFile, Flags, ServerConfig};
@@ -52,7 +52,7 @@ pub async fn respond_to_head_request<State>(
     config: ServerConfig,
     request: Request<State>,
     next: Next<State>,
-) -> Result<Response>
+) -> Result<Response, Error>
 where
     State: Send + Sync + 'static,
 {
@@ -73,7 +73,7 @@ pub async fn respond_to_get_request<State>(
     config: ServerConfig,
     request: Request<State>,
     next: Next<State>,
-) -> Result<Response>
+) -> Result<Response, Error>
 where
     State: Send + Sync + 'static,
 {
@@ -115,7 +115,7 @@ where
 fn build_path_from_request<State>(
     request: &Request<State>,
     config: &ServerConfig,
-) -> Result<PathBuf> {
+) -> Result<PathBuf, Error> {
     let path_param = request.param(&config.path_param).into_result()?;
     Ok(config.public_dir.join(path_param.trim_end_matches('/')))
 }

--- a/crates/via-serve-static/src/stream_file.rs
+++ b/crates/via-serve-static/src/stream_file.rs
@@ -9,7 +9,6 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::{Duration, SystemTime};
 use tokio::{runtime::Handle, sync::mpsc, task};
-use via::Result;
 
 /// The amount of `ReadChunkResult` that can be stored in the channel buffer.
 const CHANNEL_CAPACITY: usize = 16;

--- a/examples/blog-api/src/api/posts.rs
+++ b/examples/blog-api/src/api/posts.rs
@@ -1,23 +1,23 @@
 use via::http::StatusCode;
-use via::{Response, Result};
+use via::{Error, Response};
 
 use super::{deserialize, Payload};
 use crate::database::models::post::*;
 use crate::{Next, Request};
 
-pub async fn authenticate(request: Request, next: Next) -> Result<Response> {
+pub async fn authenticate(request: Request, next: Next) -> Result<Response, Error> {
     println!("authenticate");
     next.call(request).await
 }
 
-pub async fn index(request: Request, _: Next) -> Result<Response> {
+pub async fn index(request: Request, _: Next) -> Result<Response, Error> {
     let state = request.state();
     let posts = Post::public(&state.pool).await?;
 
     Response::json(&Payload { data: posts })
 }
 
-pub async fn create(request: Request, _: Next) -> Result<Response> {
+pub async fn create(request: Request, _: Next) -> Result<Response, Error> {
     let state = request.state().clone();
     let new_post = deserialize::<NewPost>(request.into_body()).await?;
     let post = new_post.insert(&state.pool).await?;
@@ -28,7 +28,7 @@ pub async fn create(request: Request, _: Next) -> Result<Response> {
         .finish()
 }
 
-pub async fn show(request: Request, _: Next) -> Result<Response> {
+pub async fn show(request: Request, _: Next) -> Result<Response, Error> {
     let id = request.param("id").parse::<i32>()?;
     let state = request.state();
     let post = Post::find(&state.pool, id).await?;
@@ -36,7 +36,7 @@ pub async fn show(request: Request, _: Next) -> Result<Response> {
     Response::json(&Payload { data: post })
 }
 
-pub async fn update(request: Request, _: Next) -> Result<Response> {
+pub async fn update(request: Request, _: Next) -> Result<Response, Error> {
     let id = request.param("id").parse::<i32>()?;
     let state = request.state().clone();
     let change_set = deserialize::<ChangeSet>(request.into_body()).await?;
@@ -45,7 +45,7 @@ pub async fn update(request: Request, _: Next) -> Result<Response> {
     Response::json(&Payload { data: post })
 }
 
-pub async fn destroy(request: Request, _: Next) -> Result<Response> {
+pub async fn destroy(request: Request, _: Next) -> Result<Response, Error> {
     let id = request.param("id").parse::<i32>()?;
     let state = request.state();
 

--- a/examples/blog-api/src/api/users.rs
+++ b/examples/blog-api/src/api/users.rs
@@ -1,18 +1,18 @@
 use via::http::StatusCode;
-use via::{Response, Result};
+use via::{Error, Response};
 
 use super::{deserialize, Payload};
 use crate::database::models::user::*;
 use crate::{Next, Request};
 
-pub async fn index(request: Request, _: Next) -> Result<Response> {
+pub async fn index(request: Request, _: Next) -> Result<Response, Error> {
     let state = request.state();
     let users = User::all(&state.pool).await?;
 
     Response::json(&Payload { data: users })
 }
 
-pub async fn create(request: Request, _: Next) -> Result<Response> {
+pub async fn create(request: Request, _: Next) -> Result<Response, Error> {
     let state = request.state().clone();
     let new_user = deserialize::<NewUser>(request.into_body()).await?;
     let user = new_user.insert(&state.pool).await?;
@@ -23,7 +23,7 @@ pub async fn create(request: Request, _: Next) -> Result<Response> {
         .finish()
 }
 
-pub async fn show(request: Request, _: Next) -> Result<Response> {
+pub async fn show(request: Request, _: Next) -> Result<Response, Error> {
     let id = request.param("id").parse::<i32>()?;
     let state = request.state();
     let user = User::find(&state.pool, id).await?;
@@ -31,7 +31,7 @@ pub async fn show(request: Request, _: Next) -> Result<Response> {
     Response::json(&Payload { data: user })
 }
 
-pub async fn update(request: Request, _: Next) -> Result<Response> {
+pub async fn update(request: Request, _: Next) -> Result<Response, Error> {
     let id = request.param("id").parse::<i32>()?;
     let state = request.state().clone();
     let change_set = deserialize::<ChangeSet>(request.into_body()).await?;
@@ -40,7 +40,7 @@ pub async fn update(request: Request, _: Next) -> Result<Response> {
     Response::json(&Payload { data: user })
 }
 
-pub async fn destroy(request: Request, _: Next) -> Result<Response> {
+pub async fn destroy(request: Request, _: Next) -> Result<Response, Error> {
     let id = request.param("id").parse::<i32>()?;
     let state = request.state();
 

--- a/examples/blog-api/src/database/mod.rs
+++ b/examples/blog-api/src/database/mod.rs
@@ -8,15 +8,15 @@ pub mod prelude {
     pub use diesel_async::RunQueryDsl;
 }
 
+use diesel_async::{pooled_connection::AsyncDieselConnectionManager, AsyncPgConnection};
 use std::env;
 
-use diesel_async::{pooled_connection::AsyncDieselConnectionManager, AsyncPgConnection};
-use via::Result;
-
 type ConnectionManager = AsyncDieselConnectionManager<AsyncPgConnection>;
+
+pub type Error = Box<dyn std::error::Error + Send + Sync>;
 pub type Pool = bb8::Pool<ConnectionManager>;
 
-pub async fn pool() -> Result<Pool> {
+pub async fn pool() -> Result<Pool, Error> {
     let config = ConnectionManager::new(env::var("DATABASE_URL")?);
     Ok(Pool::builder().build(config).await?)
 }

--- a/examples/blog-api/src/database/models/user.rs
+++ b/examples/blog-api/src/database/models/user.rs
@@ -1,8 +1,8 @@
-use crate::database::prelude::*;
-use serde::{Deserialize, Serialize};
-use via::Result;
-
 pub use schema::users;
+
+use serde::{Deserialize, Serialize};
+
+use crate::database::{prelude::*, Error};
 
 #[derive(Clone, Debug, Deserialize, AsChangeset)]
 #[diesel(table_name = users)]
@@ -28,7 +28,7 @@ pub struct User {
 }
 
 impl ChangeSet {
-    pub async fn apply(self, pool: &Pool, id: i32) -> Result<User> {
+    pub async fn apply(self, pool: &Pool, id: i32) -> Result<User, Error> {
         let post = diesel::update(users::table.filter(users::id.eq(id)))
             .set(self)
             .returning(users::all_columns)
@@ -40,7 +40,7 @@ impl ChangeSet {
 }
 
 impl NewUser {
-    pub async fn insert(self, pool: &Pool) -> Result<User> {
+    pub async fn insert(self, pool: &Pool) -> Result<User, Error> {
         let insert = diesel::insert_into(users::table);
         Ok(insert
             .values(self)
@@ -50,14 +50,14 @@ impl NewUser {
 }
 
 impl User {
-    pub async fn all(pool: &Pool) -> Result<Vec<User>> {
+    pub async fn all(pool: &Pool) -> Result<Vec<User>, Error> {
         Ok(users::table
             .select(users::all_columns)
             .load(&mut pool.get().await?)
             .await?)
     }
 
-    pub async fn delete(pool: &Pool, id: i32) -> Result<()> {
+    pub async fn delete(pool: &Pool, id: i32) -> Result<(), Error> {
         diesel::delete(users::table.filter(users::id.eq(id)))
             .execute(&mut pool.get().await?)
             .await?;
@@ -65,7 +65,7 @@ impl User {
         Ok(())
     }
 
-    pub async fn find(pool: &Pool, id: i32) -> Result<User> {
+    pub async fn find(pool: &Pool, id: i32) -> Result<User, Error> {
         Ok(users::table
             .filter(users::id.eq(id))
             .first(&mut pool.get().await?)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ mod server;
 pub use http;
 
 pub use app::{new, App};
-pub use error::{Error, Result};
+pub use error::Error;
 pub use middleware::allow_method::{connect, delete, get, head, options, patch, post, put};
 pub use middleware::{ErrorBoundary, Middleware, Next};
 pub use request::Request;

--- a/src/middleware/allow_method.rs
+++ b/src/middleware/allow_method.rs
@@ -1,7 +1,7 @@
 use http::Method;
 
 use super::{BoxFuture, Middleware, Next};
-use crate::{Request, Response, Result};
+use crate::{Error, Request, Response};
 
 pub struct AllowMethod<T> {
     middleware: T,
@@ -85,7 +85,11 @@ where
     T: Middleware<State>,
     State: Send + Sync + 'static,
 {
-    fn call(&self, request: Request<State>, next: Next<State>) -> BoxFuture<Result<Response>> {
+    fn call(
+        &self,
+        request: Request<State>,
+        next: Next<State>,
+    ) -> BoxFuture<Result<Response, Error>> {
         if self.predicate == request.method() {
             self.middleware.call(request, next)
         } else {

--- a/src/middleware/error_boundary.rs
+++ b/src/middleware/error_boundary.rs
@@ -1,5 +1,5 @@
 use crate::middleware::BoxFuture;
-use crate::{Error, Middleware, Next, Request, Response, Result};
+use crate::{Error, Middleware, Next, Request, Response};
 
 /// Middleware that catches errors that occur in downstream middleware and
 /// converts the error into a response. Middleware that is upstream from a
@@ -65,7 +65,11 @@ impl<State> Middleware<State> for ErrorBoundary
 where
     State: Send + Sync + 'static,
 {
-    fn call(&self, request: Request<State>, next: Next<State>) -> BoxFuture<Result<Response>> {
+    fn call(
+        &self,
+        request: Request<State>,
+        next: Next<State>,
+    ) -> BoxFuture<Result<Response, Error>> {
         Box::pin(async {
             // Yield control to the next middleware in the stack.
             let result = next.call(request).await;
@@ -81,7 +85,11 @@ where
     F: Fn(&Error, &State) + Copy + Send + Sync + 'static,
     State: Send + Sync + 'static,
 {
-    fn call(&self, request: Request<State>, next: Next<State>) -> BoxFuture<Result<Response>> {
+    fn call(
+        &self,
+        request: Request<State>,
+        next: Next<State>,
+    ) -> BoxFuture<Result<Response, Error>> {
         // Copy the `inspect` function so it can be moved in the async block.
         let inspect = self.inspect;
         // Clone `request.state` so it can be used after ownership of `request`
@@ -107,7 +115,11 @@ where
     F: Fn(Error, &State) -> Error + Copy + Send + Sync + 'static,
     State: Send + Sync + 'static,
 {
-    fn call(&self, request: Request<State>, next: Next<State>) -> BoxFuture<Result<Response>> {
+    fn call(
+        &self,
+        request: Request<State>,
+        next: Next<State>,
+    ) -> BoxFuture<Result<Response, Error>> {
         // Copy the `map` function so it can be moved in the async block.
         let map = self.map;
         // Clone `request.state` so it can be used after ownership of `request`
@@ -137,7 +149,11 @@ where
     F: Fn(Error, &State) -> Result<Response, Error> + Copy + Send + Sync + 'static,
     State: Send + Sync + 'static,
 {
-    fn call(&self, request: Request<State>, next: Next<State>) -> BoxFuture<Result<Response>> {
+    fn call(
+        &self,
+        request: Request<State>,
+        next: Next<State>,
+    ) -> BoxFuture<Result<Response, Error>> {
         // Copy the `or_else` function so it can be moved in the async block.
         let or_else = self.or_else;
         // Clone `request.state` so it can be used after ownership of `request`

--- a/src/middleware/middleware.rs
+++ b/src/middleware/middleware.rs
@@ -1,13 +1,20 @@
-use std::{future::Future, pin::Pin, sync::Arc};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
 
 use super::Next;
-use crate::{response::IntoResponse, Request, Response, Result};
+use crate::response::{IntoResponse, Response};
+use crate::{Error, Request};
 
 pub(crate) type ArcMiddleware<State> = Arc<dyn Middleware<State>>;
 pub type BoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send + 'static>>;
 
 pub trait Middleware<State>: Send + Sync {
-    fn call(&self, request: Request<State>, next: Next<State>) -> BoxFuture<Result<Response>>;
+    fn call(
+        &self,
+        request: Request<State>,
+        next: Next<State>,
+    ) -> BoxFuture<Result<Response, Error>>;
 }
 
 impl<State, T, F> Middleware<State> for T
@@ -16,7 +23,11 @@ where
     F: Future + Send + 'static,
     F::Output: IntoResponse,
 {
-    fn call(&self, request: Request<State>, next: Next<State>) -> BoxFuture<Result<Response>> {
+    fn call(
+        &self,
+        request: Request<State>,
+        next: Next<State>,
+    ) -> BoxFuture<Result<Response, Error>> {
         let future = self(request, next);
         Box::pin(async { future.await.into_response() })
     }

--- a/src/middleware/next.rs
+++ b/src/middleware/next.rs
@@ -1,5 +1,5 @@
 use super::{ArcMiddleware, BoxFuture};
-use crate::{Error, Request, Response, Result};
+use crate::{Error, Request, Response};
 
 pub struct Next<State = ()> {
     stack: Vec<ArcMiddleware<State>>,

--- a/src/middleware/timeout.rs
+++ b/src/middleware/timeout.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use tokio::time;
 
 use super::{BoxFuture, Middleware, Next};
-use crate::{Error, Request, Response, Result};
+use crate::{Error, Request, Response};
 
 /// A type alias for the default `or_else` function.
 type RespondWithTimeout<State> = fn(&State) -> Result<Response, Error>;
@@ -62,7 +62,11 @@ where
     F: Fn(&State) -> Result<Response, Error> + Copy + Send + Sync + 'static,
     State: Send + Sync + 'static,
 {
-    fn call(&self, request: Request<State>, next: Next<State>) -> BoxFuture<Result<Response>> {
+    fn call(
+        &self,
+        request: Request<State>,
+        next: Next<State>,
+    ) -> BoxFuture<Result<Response, Error>> {
         let duration = self.duration;
         let or_else = self.or_else;
         let state = request.state().clone();

--- a/src/request/params/param.rs
+++ b/src/request/params/param.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 use std::str::FromStr;
 
 use super::{DecodeParam, NoopDecode, PercentDecode};
-use crate::{Error, Result};
+use crate::Error;
 
 pub struct Param<'a, 'b, T = NoopDecode> {
     at: Option<Option<(usize, usize)>>,

--- a/src/request/request.rs
+++ b/src/request/request.rs
@@ -109,8 +109,8 @@ impl<State> Request<State> {
     /// # Example
     ///
     /// ```
-    /// use via::{Error, Next, Request};
     /// use std::borrow::Cow;
+    /// use via::{Error, Next, Request};
     ///
     /// async fn hello(request: Request, _: Next) -> Result<String, Error> {
     ///     let name: Result<Cow<str>, Error> = request.param("name").into_result();
@@ -134,9 +134,9 @@ impl<State> Request<State> {
     /// # Example
     ///
     /// ```
-    /// use via::{Next, Request, Result};
+    /// use via::{Error, Next, Request};
     ///
-    /// async fn hello(request: Request, _: Next) -> Result<String> {
+    /// async fn hello(request: Request, _: Next) -> Result<String, Error> {
     ///     // Attempt to parse the first query parameter named `n` to a `usize`
     ///     // no greater than 1000. If the query parameter doesn't exist or
     ///     // can't be converted to a `usize`, default to 1.

--- a/src/response/builder.rs
+++ b/src/response/builder.rs
@@ -8,10 +8,10 @@ use serde::Serialize;
 use super::{Response, ResponseBody};
 use super::{APPLICATION_JSON, CHUNKED_ENCODING, TEXT_HTML, TEXT_PLAIN};
 use crate::error::AnyError;
-use crate::{Error, Result};
+use crate::Error;
 
 pub struct ResponseBuilder {
-    body: Option<Result<ResponseBody>>,
+    body: Option<Result<ResponseBody, Error>>,
     inner: Builder,
 }
 

--- a/src/response/redirect.rs
+++ b/src/response/redirect.rs
@@ -1,7 +1,6 @@
-use crate::{
-    http::{header, StatusCode},
-    Error, Response, Result,
-};
+use http::{header, StatusCode};
+
+use crate::{Error, Response};
 
 /// A collection of functions used to generate redirect responses.
 pub struct Redirect;
@@ -14,7 +13,7 @@ impl Redirect {
     ///
     /// This function may return an error if the provided `location` cannot be
     /// parsed into an HTTP header value.
-    pub fn found(location: &str) -> Result<Response> {
+    pub fn found(location: &str) -> Result<Response, Error> {
         Self::with_status(location, StatusCode::FOUND)
     }
 
@@ -25,7 +24,7 @@ impl Redirect {
     ///
     /// This function may return an error if the provided `location` cannot be
     /// parsed into an HTTP header value.
-    pub fn see_other(location: &str) -> Result<Response> {
+    pub fn see_other(location: &str) -> Result<Response, Error> {
         Self::with_status(location, StatusCode::SEE_OTHER)
     }
 
@@ -36,7 +35,7 @@ impl Redirect {
     ///
     /// This function may return an error if the provided `location` cannot be
     /// parsed into an HTTP header value.
-    pub fn temporary(location: &str) -> Result<Response> {
+    pub fn temporary(location: &str) -> Result<Response, Error> {
         Self::with_status(location, StatusCode::TEMPORARY_REDIRECT)
     }
 
@@ -47,7 +46,7 @@ impl Redirect {
     ///
     /// This function may return an error if the provided `location` cannot be
     /// parsed into an HTTP header value.
-    pub fn permanent(location: &str) -> Result<Response> {
+    pub fn permanent(location: &str) -> Result<Response, Error> {
         Self::with_status(location, StatusCode::PERMANENT_REDIRECT)
     }
 
@@ -59,7 +58,7 @@ impl Redirect {
     /// This function may return an error if the provided `location` cannot be
     /// parsed into an HTTP header value or if provided `status` would not
     /// result in a redirect.
-    pub fn with_status<T>(location: &str, status: T) -> Result<Response>
+    pub fn with_status<T>(location: &str, status: T) -> Result<Response, Error>
     where
         StatusCode: TryFrom<T>,
         <StatusCode as TryFrom<T>>::Error: Into<http::Error>,


### PR DESCRIPTION
Removes the `Result` alias type.