### PR TITLE
chore(via): bump the version to 2.0.0-beta.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-beta.1"
+version = "2.0.0-beta.2"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Bumps the version to `2.0.0-beta.2`. I'll be more organized about releases in the future when life settles down a bit. I definitely want to start tracking releases with a changelog soon.