### PR TITLE
chore(via): bump the version to 2.0.0-beta.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-beta.2"
+version = "2.0.0-beta.3"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Bumps the crate version to `2.0.0-beta.3` in preparation for release. Changes include the improved `Error` type API. Also a friendly reminder that I'm going to start to keep a formal changelog before the official version `2` is released.