### PR TITLE
refactor(via): make error module private

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 Below is a basic example to demonstrate how to use Via to create a simple web server that responds to requests at `/hello/:name` with a personalized greeting.
 
 ```rust
-use via::error::BoxError;
-use via::{Next, Request, Server};
+use via::{BoxError, Next, Request, Server};
 
 async fn hello(request: Request, _: Next) -> via::Result<String> {
     // Get a reference to the path parameter `name` from the request uri.

--- a/crates/via-serve-static/src/lib.rs
+++ b/crates/via-serve-static/src/lib.rs
@@ -6,8 +6,7 @@ mod stream_file;
 use bitflags::bitflags;
 use std::path::Path;
 use std::sync::Arc;
-use via::error::BoxError;
-use via::Endpoint;
+use via::{BoxError, Endpoint};
 
 use crate::respond::{respond_to_get_request, respond_to_head_request};
 

--- a/examples/blog-api/src/database/mod.rs
+++ b/examples/blog-api/src/database/mod.rs
@@ -11,7 +11,7 @@ pub mod prelude {
 use std::env;
 
 use diesel_async::{pooled_connection::AsyncDieselConnectionManager, AsyncPgConnection};
-use via::error::BoxError;
+use via::BoxError;
 
 type ConnectionManager = AsyncDieselConnectionManager<AsyncPgConnection>;
 pub type Pool = bb8::Pool<ConnectionManager>;

--- a/examples/blog-api/src/main.rs
+++ b/examples/blog-api/src/main.rs
@@ -2,9 +2,8 @@ mod api;
 mod database;
 
 use std::time::Duration;
-use via::error::BoxError;
 use via::middleware::Timeout;
-use via::{ErrorBoundary, Response, Server};
+use via::{BoxError, ErrorBoundary, Response, Server};
 
 use database::Pool;
 

--- a/examples/cookies/src/main.rs
+++ b/examples/cookies/src/main.rs
@@ -1,7 +1,6 @@
 use cookie::{Cookie, Key};
-use via::error::BoxError;
 use via::middleware::CookieParser;
-use via::{Response, Server};
+use via::{BoxError, Response, Server};
 
 type Request = via::Request<CookiesExample>;
 type Next = via::Next<CookiesExample>;

--- a/examples/echo-server/src/main.rs
+++ b/examples/echo-server/src/main.rs
@@ -1,6 +1,5 @@
-use via::error::BoxError;
 use via::http::header::CONTENT_TYPE;
-use via::{Next, Request, Response, Server};
+use via::{BoxError, Next, Request, Response, Server};
 
 async fn echo(request: Request, _: Next) -> via::Result<Response> {
     // Get an owned copy of the request's Content-Type header.

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -1,5 +1,4 @@
-use via::error::BoxError;
-use via::{Next, Request, Server};
+use via::{BoxError, Next, Request, Server};
 
 async fn hello(request: Request, _: Next) -> via::Result<String> {
     // Get a reference to the path parameter `name` from the request uri.

--- a/examples/shared-state/src/main.rs
+++ b/examples/shared-state/src/main.rs
@@ -1,9 +1,8 @@
 use std::fmt::Write;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
-use via::error::BoxError;
 use via::http::StatusCode;
-use via::{Response, Server};
+use via::{BoxError, Response, Server};
 
 // Define a type alias for the `via::Request` to include the `Counter` state.
 // This is a convenience to avoid having to write out the full type signature.

--- a/examples/static-files/src/main.rs
+++ b/examples/static-files/src/main.rs
@@ -1,5 +1,4 @@
-use via::error::BoxError;
-use via::{Next, Request, Response, Server};
+use via::{BoxError, Next, Request, Response, Server};
 use via_serve_static::serve_static;
 
 async fn not_found(request: Request, _: Next) -> via::Result<Response> {

--- a/examples/tls-rustls/src/main.rs
+++ b/examples/tls-rustls/src/main.rs
@@ -1,7 +1,6 @@
 mod tls;
 
-use via::error::BoxError;
-use via::{Next, Request, Server};
+use via::{BoxError, Next, Request, Server};
 
 async fn hello(request: Request, _: Next) -> via::Result<String> {
     // Get a reference to the path parameter `name` from the request uri.

--- a/examples/tls-rustls/src/tls.rs
+++ b/examples/tls-rustls/src/tls.rs
@@ -7,7 +7,7 @@ use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
 use tokio_rustls::rustls;
-use via::error::BoxError;
+use via::BoxError;
 
 /// Load the certificate and private key from the file system and use them
 /// to create a rustls::ServerConfig.

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,14 +1,15 @@
 use std::sync::Arc;
 
-use crate::Middleware;
-use crate::{Endpoint, Router};
+use crate::middleware::Middleware;
+use crate::router::{Endpoint, Router};
 
 pub struct App<State> {
     pub(crate) state: Arc<State>,
     pub(crate) router: Router<State>,
 }
 
-/// Constructs a new `App` with the provided `state`.
+/// Constructs a new [`App`] with the provided `state` argument.
+///
 pub fn new<State>(state: State) -> App<State>
 where
     State: Send + Sync + 'static,

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,11 +9,14 @@ use std::fmt::{self, Debug, Display, Formatter};
 
 use crate::response::Response;
 
-/// A type alias for a boxed error type that is `Send + Sync`.
+/// A type alias for a boxed
+/// [`Error`](std::error::Error)
+/// that is `Send + Sync`.
 ///
 pub type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
-/// An error type that can be easily converted to a [`Response`].
+/// An error type that can act as a specialized version of a
+/// [`ResponseBuilder`](crate::response::ResponseBuilder).
 ///
 #[derive(Debug)]
 pub struct Error {
@@ -56,8 +59,7 @@ impl Error {
     /// # Example
     ///
     /// ```
-    /// use via::error::BoxError;
-    /// use via::{ErrorBoundary, Next, Request};
+    /// use via::{BoxError, ErrorBoundary, Next, Request};
     ///
     /// #[tokio::main(flavor = "current_thread")]
     /// async fn main() -> Result<(), BoxError> {
@@ -128,8 +130,7 @@ impl Error {
     /// # Example
     ///
     /// ```
-    /// use via::error::BoxError;
-    /// use via::{ErrorBoundary, Next, Request};
+    /// use via::{BoxError, ErrorBoundary, Next, Request};
     ///
     /// #[tokio::main(flavor = "current_thread")]
     /// async fn main() -> Result<(), BoxError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,29 +13,22 @@
 
 #![allow(clippy::module_inception)]
 
-pub mod error;
 pub mod middleware;
 pub mod request;
 pub mod response;
 
 mod app;
+mod error;
 mod router;
 mod server;
 
 pub use http;
 
 pub use app::{new, App};
-pub use error::Error;
+pub use error::{BoxError, Error};
 pub use middleware::allow_method::{connect, delete, get, head, options, patch, post, put};
-pub use middleware::{ErrorBoundary, Middleware, Next};
+pub use middleware::{ErrorBoundary, Middleware, Next, Result};
 pub use request::Request;
 pub use response::Response;
 pub use router::Endpoint;
 pub use server::Server;
-
-use router::Router;
-
-/// A type alias for [`std::result::Result`] that uses `Error` as the default
-/// error type.
-///
-pub type Result<T> = std::result::Result<T, Error>;

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -15,3 +15,9 @@ pub use next::Next;
 pub use timeout::{timeout, Timeout};
 
 pub(crate) use self::middleware::ArcMiddleware;
+
+use crate::Error;
+
+/// Shorthand for a `Result` returned from an async middleware function.
+///
+pub type Result<T> = std::result::Result<T, Error>;

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -8,8 +8,9 @@ use tokio_rustls::rustls;
 
 use super::acceptor::{self, Acceptor};
 use super::serve::serve;
+use crate::app::App;
 use crate::error::BoxError;
-use crate::{App, Router};
+use crate::router::Router;
 
 /// The default value of the maximum number of concurrent connections.
 ///
@@ -23,7 +24,7 @@ const DEFAULT_MAX_REQUEST_SIZE: usize = 104_576_000;
 ///
 const DEFAULT_SHUTDOWN_TIMEOUT: u64 = 30;
 
-/// Serve an [App] over HTTP or HTTPS.
+/// Serve an [`App`] over HTTP or HTTPS.
 ///
 pub struct Server<State> {
     state: Arc<State>,


### PR DESCRIPTION
Makes the `error` module private in favor of exporting the `BoxError` type alias from the crate root.