### PR TITLE
chore(via): bump the version to 2.0.0-beta.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-beta.3"
+version = "2.0.0-beta.4"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Bumps the crate version to `2.0.0-beta.4` in preparation for release. To upgrade from `2.0.0-beta.3` change any imports of `via::error::BoxError` to `via::BoxError`.