### PR TITLE
chore(examples/blog-api): change the crate name to blog-api

### DIFF
--- a/examples/blog-api/Cargo.toml
+++ b/examples/blog-api/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "advanced-blog"
+name = "blog-api"
 version = "0.1.0"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"

--- a/examples/blog-api/README.md
+++ b/examples/blog-api/README.md
@@ -1,7 +1,4 @@
-# advanced-blog
-
-A not so advanced blog example that demonstrates how nesting services can be useful for
-code organization and separating concerns.
+# blog-api
 
 ### Initial Setup
 


### PR DESCRIPTION
Changes `advanced-blog` to `blog-api` where applicable.