### PR TITLE
feat(via): compatibility with REST

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-beta.5"
+version = "2.0.0-beta.2"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -16,7 +16,7 @@ http2 = ["hyper/http2"]
 rustls = ["dep:tokio-rustls"]
 
 [dependencies]
-bytes = "=1.7.2"
+bytes = "1.7"
 futures-core = { version = "0.3", default-features = false }
 http = "1"
 http-body = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-beta.2"
+version = "2.0.0-beta.5"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -27,7 +27,7 @@ percent-encoding = "2.3"
 serde = "1"
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "signal"] }
-via-router = { path = "./crates/via-router" }
+via-router = "3.0.0-beta.1"
 
 [dependencies.cookie]
 version = "0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-beta.5"
+version = "2.0.0-beta.6"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -16,7 +16,7 @@ http2 = ["hyper/http2"]
 rustls = ["dep:tokio-rustls"]
 
 [dependencies]
-bytes = "1.7"
+bytes = "=1.7.2"
 futures-core = { version = "0.3", default-features = false }
 http = "1"
 http-body = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ percent-encoding = "2.3"
 serde = "1"
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "signal"] }
-via-router = "2"
+via-router = { path = "./crates/via-router" }
 
 [dependencies.cookie]
 version = "0.18"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following to dependencies section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-via = "2.0.0-beta.5"
+via = "2.0.0-beta.6"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 

--- a/crates/via-router/Cargo.toml
+++ b/crates/via-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via-router"
-version = "2.0.1"
+version = "3.0.0"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/crates/via-router/Cargo.toml
+++ b/crates/via-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via-router"
-version = "3.0.0"
+version = "3.0.0-beta.1"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/examples/blog-api/src/main.rs
+++ b/examples/blog-api/src/main.rs
@@ -1,6 +1,7 @@
 mod api;
 mod database;
 
+use std::process::ExitCode;
 use std::time::Duration;
 use via::middleware::Timeout;
 use via::{BoxError, ErrorBoundary, Response, Server};
@@ -26,7 +27,7 @@ async fn log_request(request: Request, next: Next) -> via::Result<Response> {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), BoxError> {
+async fn main() -> Result<ExitCode, BoxError> {
     dotenvy::dotenv()?;
 
     // Create a new app with our shared state that contains a database pool.

--- a/examples/cookies/src/main.rs
+++ b/examples/cookies/src/main.rs
@@ -1,4 +1,5 @@
 use cookie::{Cookie, Key};
+use std::process::ExitCode;
 use via::middleware::CookieParser;
 use via::{BoxError, Response, Server};
 
@@ -88,7 +89,7 @@ fn get_secret_from_env() -> Key {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), BoxError> {
+async fn main() -> Result<ExitCode, BoxError> {
     // Load the environment variables from the ".env" file. This is where we
     // keep the secret key in development. In production, you may want to
     // configure the secret key using a different method. For example, using

--- a/examples/echo-server/src/main.rs
+++ b/examples/echo-server/src/main.rs
@@ -1,3 +1,4 @@
+use std::process::ExitCode;
 use via::http::header::CONTENT_TYPE;
 use via::{BoxError, Next, Request, Response, Server};
 
@@ -15,7 +16,7 @@ async fn echo(request: Request, _: Next) -> via::Result<Response> {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), BoxError> {
+async fn main() -> Result<ExitCode, BoxError> {
     let mut app = via::new(());
 
     // Add our echo responder to the endpoint /echo.

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -1,3 +1,4 @@
+use std::process::ExitCode;
 use via::{BoxError, Next, Request, Server};
 
 async fn hello(request: Request, _: Next) -> via::Result<String> {
@@ -9,7 +10,7 @@ async fn hello(request: Request, _: Next) -> via::Result<String> {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), BoxError> {
+async fn main() -> Result<ExitCode, BoxError> {
     // Create a new application.
     let mut app = via::new(());
 

--- a/examples/shared-state/src/main.rs
+++ b/examples/shared-state/src/main.rs
@@ -1,4 +1,5 @@
 use std::fmt::Write;
+use std::process::ExitCode;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use via::http::StatusCode;
@@ -76,7 +77,7 @@ async fn totals(request: Request, _: Next) -> via::Result<String> {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), BoxError> {
+async fn main() -> Result<ExitCode, BoxError> {
     // Create a new application with a `Counter` as state.
     let mut app = via::new(Counter {
         errors: Arc::new(AtomicU32::new(0)),

--- a/examples/static-files/src/main.rs
+++ b/examples/static-files/src/main.rs
@@ -1,3 +1,4 @@
+use std::process::ExitCode;
 use via::{BoxError, Next, Request, Response, Server};
 use via_serve_static::serve_static;
 
@@ -27,7 +28,7 @@ async fn not_found(request: Request, _: Next) -> via::Result<Response> {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), BoxError> {
+async fn main() -> Result<ExitCode, BoxError> {
     let mut app = via::new(());
 
     // Add the serve_static middleware to the endpoint /*path.

--- a/examples/tls-rustls/src/main.rs
+++ b/examples/tls-rustls/src/main.rs
@@ -1,5 +1,6 @@
 mod tls;
 
+use std::process::ExitCode;
 use via::{BoxError, Next, Request, Server};
 
 async fn hello(request: Request, _: Next) -> via::Result<String> {
@@ -11,7 +12,7 @@ async fn hello(request: Request, _: Next) -> via::Result<String> {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), BoxError> {
+async fn main() -> Result<ExitCode, BoxError> {
     // Confirm that our certificate and private key exist and are valid before
     // doing anything else.
     let tls_config = tls::server_config().expect("tls config is invalid or missing");

--- a/src/response/response.rs
+++ b/src/response/response.rs
@@ -20,92 +20,6 @@ pub struct Response {
 }
 
 impl Response {
-    pub fn new(body: ResponseBody) -> Self {
-        Self {
-            did_map: false,
-            cookies: Box::new(CookieJar::new()),
-            response: http::Response::new(body),
-        }
-    }
-
-    pub fn new_with_status(body: ResponseBody, status: StatusCode) -> Self {
-        let mut response = Self::new(body);
-
-        response.set_status(status);
-        response
-    }
-
-    pub fn html(body: String) -> Self {
-        let len = body.len();
-
-        let mut response = Self::new(body.into());
-        let headers = response.headers_mut();
-
-        headers.insert(CONTENT_TYPE, TEXT_HTML);
-        headers.insert(CONTENT_LENGTH, len.into());
-
-        response
-    }
-
-    pub fn text(body: String) -> Self {
-        let len = body.len();
-
-        let mut response = Self::new(body.into());
-        let headers = response.headers_mut();
-
-        headers.insert(CONTENT_TYPE, TEXT_PLAIN);
-        headers.insert(CONTENT_LENGTH, len.into());
-
-        response
-    }
-
-    pub fn json<T>(body: &T) -> Result<Response, Error>
-    where
-        T: Serialize,
-    {
-        let json = serde_json::to_string(body)?;
-        let len = json.len();
-
-        let mut response = Self::new(json.into());
-        let headers = response.headers_mut();
-
-        headers.insert(CONTENT_TYPE, APPLICATION_JSON);
-        headers.insert(CONTENT_LENGTH, len.into());
-
-        Ok(response)
-    }
-
-    /// Create a response from a stream of `Result<Frame<Bytes>, Error>`.
-    ///
-    pub fn stream<T, E>(body: T) -> Self
-    where
-        T: Body<Data = Bytes, Error = BoxError> + Send + Sync + 'static,
-    {
-        let mut response = Self::new(BoxBody::new(body).into());
-
-        response.set_header(TRANSFER_ENCODING, CHUNKED_ENCODING);
-        response
-    }
-
-    pub fn not_found() -> Self {
-        let mut response = Response::text("Not Found".to_string());
-
-        response.set_status(StatusCode::NOT_FOUND);
-        response
-    }
-
-    pub fn build() -> ResponseBuilder {
-        ResponseBuilder::new()
-    }
-
-    pub fn from_parts(parts: Parts, body: ResponseBody) -> Self {
-        Self {
-            did_map: false,
-            cookies: Box::new(CookieJar::new()),
-            response: http::Response::from_parts(parts, body),
-        }
-    }
-
     /// Consumes the response and returns a tuple containing the component
     /// parts of the response and the response body.
     ///
@@ -185,6 +99,516 @@ impl Response {
 
     pub fn version(&self) -> Version {
         self.response.version()
+    }
+}
+
+impl Response {
+    #[inline]
+    pub fn new(body: ResponseBody) -> Self {
+        Self {
+            did_map: false,
+            cookies: Box::new(CookieJar::new()),
+            response: http::Response::new(body),
+        }
+    }
+
+    #[inline]
+    pub fn build() -> ResponseBuilder {
+        ResponseBuilder::new()
+    }
+
+    #[inline]
+    pub fn html(body: String) -> Self {
+        let len = body.len();
+
+        let mut response = Self::new(body.into());
+        let headers = response.headers_mut();
+
+        headers.insert(CONTENT_TYPE, TEXT_HTML);
+        headers.insert(CONTENT_LENGTH, len.into());
+
+        response
+    }
+
+    #[inline]
+    pub fn text(body: String) -> Self {
+        let len = body.len();
+
+        let mut response = Self::new(body.into());
+        let headers = response.headers_mut();
+
+        headers.insert(CONTENT_TYPE, TEXT_PLAIN);
+        headers.insert(CONTENT_LENGTH, len.into());
+
+        response
+    }
+
+    #[inline]
+    pub fn json<T>(body: &T) -> Result<Response, Error>
+    where
+        T: Serialize,
+    {
+        let json = serde_json::to_string(body)?;
+        let len = json.len();
+
+        let mut response = Self::new(json.into());
+        let headers = response.headers_mut();
+
+        headers.insert(CONTENT_TYPE, APPLICATION_JSON);
+        headers.insert(CONTENT_LENGTH, len.into());
+
+        Ok(response)
+    }
+
+    /// Create a response from a stream of `Result<Frame<Bytes>, Error>`.
+    ///
+    #[inline]
+    pub fn stream<T, E>(body: T) -> Self
+    where
+        T: Body<Data = Bytes, Error = BoxError> + Send + Sync + 'static,
+    {
+        let mut response = Self::new(BoxBody::new(body).into());
+
+        response.set_header(TRANSFER_ENCODING, CHUNKED_ENCODING);
+        response
+    }
+
+    #[inline]
+    pub fn from_parts(parts: Parts, body: ResponseBody) -> Self {
+        Self {
+            did_map: false,
+            cookies: Box::new(CookieJar::new()),
+            response: http::Response::from_parts(parts, body),
+        }
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `400 Bad Request` status.
+    ///
+    #[inline]
+    pub fn bad_request() -> Self {
+        let mut this = Self::text("Bad Request".to_owned());
+
+        *this.response.status_mut() = StatusCode::BAD_REQUEST;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `401 Unauthorized` status.
+    ///
+    #[inline]
+    pub fn unauthorized() -> Self {
+        let mut this = Self::text("Unauthorized".to_owned());
+
+        *this.response.status_mut() = StatusCode::UNAUTHORIZED;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `402 Payment Required` status.
+    ///
+    #[inline]
+    pub fn payment_required() -> Self {
+        let mut this = Self::text("Payment Required".to_owned());
+
+        *this.response.status_mut() = StatusCode::PAYMENT_REQUIRED;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `403 Forbidden` status.
+    ///
+    #[inline]
+    pub fn forbidden() -> Self {
+        let mut this = Self::text("Forbidden".to_owned());
+
+        *this.response.status_mut() = StatusCode::FORBIDDEN;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `404 Not Found` status.
+    ///
+    #[inline]
+    pub fn not_found() -> Self {
+        let mut this = Self::text("Not Found".to_owned());
+
+        *this.response.status_mut() = StatusCode::NOT_FOUND;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `405 Method Not Allowed` status.
+    ///
+    #[inline]
+    pub fn method_not_allowed() -> Self {
+        let mut this = Self::text("Method Not Allowed".to_owned());
+
+        *this.response.status_mut() = StatusCode::METHOD_NOT_ALLOWED;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `406 Not Acceptable` status.
+    ///
+    #[inline]
+    pub fn not_acceptable() -> Self {
+        let mut this = Self::text("Not Acceptable".to_owned());
+
+        *this.response.status_mut() = StatusCode::NOT_ACCEPTABLE;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `407 Proxy Authentication Required` status.
+    ///
+    #[inline]
+    pub fn proxy_authentication_required() -> Self {
+        let mut this = Self::text("Proxy Authentication Required".to_owned());
+
+        *this.response.status_mut() = StatusCode::PROXY_AUTHENTICATION_REQUIRED;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `408 Request Timeout` status.
+    ///
+    #[inline]
+    pub fn request_timeout() -> Self {
+        let mut this = Self::text("Request Timeout".to_owned());
+
+        *this.response.status_mut() = StatusCode::REQUEST_TIMEOUT;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `409 Conflict` status.
+    ///
+    #[inline]
+    pub fn conflict() -> Self {
+        let mut this = Self::text("Conflict".to_owned());
+
+        *this.response.status_mut() = StatusCode::CONFLICT;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `410 Gone` status.
+    ///
+    #[inline]
+    pub fn gone() -> Self {
+        let mut this = Self::text("Gone".to_owned());
+
+        *this.response.status_mut() = StatusCode::GONE;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `411 Length Required` status.
+    ///
+    #[inline]
+    pub fn length_required() -> Self {
+        let mut this = Self::text("Length Required".to_owned());
+
+        *this.response.status_mut() = StatusCode::LENGTH_REQUIRED;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `412 Precondition Failed` status.
+    ///
+    #[inline]
+    pub fn precondition_failed() -> Self {
+        let mut this = Self::text("Precondition Failed".to_owned());
+
+        *this.response.status_mut() = StatusCode::PRECONDITION_FAILED;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `413 Payload Too Large` status.
+    ///
+    #[inline]
+    pub fn payload_too_large() -> Self {
+        let mut this = Self::text("Payload Too Large".to_owned());
+
+        *this.response.status_mut() = StatusCode::PAYLOAD_TOO_LARGE;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `414 URI Too Long` status.
+    ///
+    #[inline]
+    pub fn uri_too_long() -> Self {
+        let mut this = Self::text("URI Too Long".to_owned());
+
+        *this.response.status_mut() = StatusCode::URI_TOO_LONG;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `415 Unsupported Media Type` status.
+    ///
+    #[inline]
+    pub fn unsupported_media_type() -> Self {
+        let mut this = Self::text("Unsupported Media Type".to_owned());
+
+        *this.response.status_mut() = StatusCode::UNSUPPORTED_MEDIA_TYPE;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `416 Range Not Satisfiable` status.
+    ///
+    #[inline]
+    pub fn range_not_satisfiable() -> Self {
+        let mut this = Self::text("Range Not Satisfiable".to_owned());
+
+        *this.response.status_mut() = StatusCode::RANGE_NOT_SATISFIABLE;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `417 Expectation Failed` status.
+    ///
+    #[inline]
+    pub fn expectation_failed() -> Self {
+        let mut this = Self::text("Expectation Failed".to_owned());
+
+        *this.response.status_mut() = StatusCode::EXPECTATION_FAILED;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `418 I'm a teapot` status.
+    ///
+    #[inline]
+    pub fn im_a_teapot() -> Self {
+        let mut this = Self::text("Im A Teapot".to_owned());
+
+        *this.response.status_mut() = StatusCode::IM_A_TEAPOT;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `421 Misdirected Request` status.
+    ///
+    #[inline]
+    pub fn misdirected_request() -> Self {
+        let mut this = Self::text("Misdirected Request".to_owned());
+
+        *this.response.status_mut() = StatusCode::MISDIRECTED_REQUEST;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `422 Unprocessable Entity` status.
+    ///
+    #[inline]
+    pub fn unprocessable_entity() -> Self {
+        let mut this = Self::text("Unprocessable Entity".to_owned());
+
+        *this.response.status_mut() = StatusCode::UNPROCESSABLE_ENTITY;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `423 Locked` status.
+    ///
+    #[inline]
+    pub fn locked() -> Self {
+        let mut this = Self::text("Locked".to_owned());
+
+        *this.response.status_mut() = StatusCode::LOCKED;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `424 Failed Dependency` status.
+    ///
+    #[inline]
+    pub fn failed_dependency() -> Self {
+        let mut this = Self::text("Failed Dependency".to_owned());
+
+        *this.response.status_mut() = StatusCode::FAILED_DEPENDENCY;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `426 Upgrade Required` status.
+    ///
+    #[inline]
+    pub fn upgrade_required() -> Self {
+        let mut this = Self::text("Upgrade Required".to_owned());
+
+        *this.response.status_mut() = StatusCode::UPGRADE_REQUIRED;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `428 Precondition Required` status.
+    ///
+    #[inline]
+    pub fn precondition_required() -> Self {
+        let mut this = Self::text("Precondition Required".to_owned());
+
+        *this.response.status_mut() = StatusCode::PRECONDITION_REQUIRED;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `429 Too Many Requests` status.
+    ///
+    #[inline]
+    pub fn too_many_requests() -> Self {
+        let mut this = Self::text("Too Many Requests".to_owned());
+
+        *this.response.status_mut() = StatusCode::TOO_MANY_REQUESTS;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `431 Request Header Fields Too Large` status.
+    ///
+    #[inline]
+    pub fn request_header_fields_too_large() -> Self {
+        let mut this = Self::text("Request Header Fields Too Large".to_owned());
+
+        *this.response.status_mut() = StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `451 Unavailable For Legal Reasons` status.
+    ///
+    #[inline]
+    pub fn unavailable_for_legal_reasons() -> Self {
+        let mut this = Self::text("Unavailable For Legal Reasons".to_owned());
+
+        *this.response.status_mut() = StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `500 Internal Server Error` status.
+    ///
+    #[inline]
+    pub fn internal_server_error() -> Self {
+        let mut this = Self::text("Internal Server Error".to_owned());
+
+        *this.response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `501 Not Implemented` status.
+    ///
+    #[inline]
+    pub fn not_implemented() -> Self {
+        let mut this = Self::text("Not Implemented".to_owned());
+
+        *this.response.status_mut() = StatusCode::NOT_IMPLEMENTED;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `502 Bad Gateway` status.
+    ///
+    #[inline]
+    pub fn bad_gateway() -> Self {
+        let mut this = Self::text("Bad Gateway".to_owned());
+
+        *this.response.status_mut() = StatusCode::BAD_GATEWAY;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `503 Service Unavailable` status.
+    ///
+    #[inline]
+    pub fn service_unavailable() -> Self {
+        let mut this = Self::text("Service Unavailable".to_owned());
+
+        *this.response.status_mut() = StatusCode::SERVICE_UNAVAILABLE;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `504 Gateway Timeout` status.
+    ///
+    #[inline]
+    pub fn gateway_timeout() -> Self {
+        let mut this = Self::text("Gateway Timeout".to_owned());
+
+        *this.response.status_mut() = StatusCode::GATEWAY_TIMEOUT;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `505 HTTP Version Not Supported` status.
+    ///
+    #[inline]
+    pub fn http_version_not_supported() -> Self {
+        let mut this = Self::text("HTTP Version Not Supported".to_owned());
+
+        *this.response.status_mut() = StatusCode::HTTP_VERSION_NOT_SUPPORTED;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `506 Variant Also Negotiates` status.
+    ///
+    #[inline]
+    pub fn variant_also_negotiates() -> Self {
+        let mut this = Self::text("Variant Also Negotiates".to_owned());
+
+        *this.response.status_mut() = StatusCode::VARIANT_ALSO_NEGOTIATES;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `507 Insufficient Storage` status.
+    ///
+    #[inline]
+    pub fn insufficient_storage() -> Self {
+        let mut this = Self::text("Insufficient Storage".to_owned());
+
+        *this.response.status_mut() = StatusCode::INSUFFICIENT_STORAGE;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `508 Loop Detected` status.
+    ///
+    #[inline]
+    pub fn loop_detected() -> Self {
+        let mut this = Self::text("Loop Detected".to_owned());
+
+        *this.response.status_mut() = StatusCode::LOOP_DETECTED;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `510 Not Extended` status.
+    ///
+    #[inline]
+    pub fn not_extended() -> Self {
+        let mut this = Self::text("Not Extended".to_owned());
+
+        *this.response.status_mut() = StatusCode::NOT_EXTENDED;
+        this
+    }
+
+    /// Returns a new [`Error`] from the provided source that will generate a
+    /// [`Response`] with a `511 Network Authentication Required` status.
+    ///
+    #[inline]
+    pub fn network_authentication_required() -> Self {
+        let mut this = Self::text("Network Authentication Required".to_owned());
+
+        *this.response.status_mut() = StatusCode::NETWORK_AUTHENTICATION_REQUIRED;
+        this
     }
 }
 

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -109,7 +109,7 @@ where
                         .timer(TokioTimer::new())
                         .serve_connection(
                             TokioIo::new(stream),
-                            Service::new(max_request_size, router, state),
+                            Service::new(max_request_size, shutdown_tx, router, state),
                         )
                         .with_upgrades();
 

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -1,4 +1,5 @@
 use std::future::Future;
+use std::process::ExitCode;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::net::{TcpListener, ToSocketAddrs};
@@ -45,7 +46,7 @@ async fn listen<State, A>(
     max_connections: Option<usize>,
     max_request_size: Option<usize>,
     shutdown_timeout: Option<u64>,
-) -> Result<(), BoxError>
+) -> Result<ExitCode, BoxError>
 where
     State: Send + Sync + 'static,
     A: Acceptor + Send + Sync + 'static,
@@ -114,8 +115,9 @@ where
     pub fn listen<A: ToSocketAddrs>(
         self,
         address: A,
-    ) -> impl Future<Output = Result<(), BoxError>> {
+    ) -> impl Future<Output = Result<ExitCode, BoxError>> {
         // Confirm that rustls_config exists before proceeding.
+
         let tls_config = match self.rustls_config {
             Some(config) => Arc::new(config),
             None => panic!("rustls_config is required to use the 'rustls' feature"),
@@ -155,7 +157,7 @@ where
     pub fn listen<A: ToSocketAddrs>(
         self,
         address: A,
-    ) -> impl Future<Output = Result<(), BoxError>> {
+    ) -> impl Future<Output = Result<ExitCode, BoxError>> {
         // Create a HttpAcceptor to serve connections over HTTP.
         let acceptor = acceptor::http::HttpAcceptor;
 

--- a/src/server/service.rs
+++ b/src/server/service.rs
@@ -12,12 +12,15 @@ use crate::request::{Request, RequestBody};
 use crate::response::{Response, ResponseBody};
 use crate::router::Router;
 
+use super::shutdown::ShutdownTx;
+
 pub struct FutureResponse {
     future: BoxFuture<Result<Response, Error>>,
 }
 
 pub struct Service<State> {
     max_request_size: usize,
+    shutdown_tx: ShutdownTx,
     router: Arc<Router<State>>,
     state: Arc<State>,
 }
@@ -39,9 +42,15 @@ impl Future for FutureResponse {
 }
 
 impl<State> Service<State> {
-    pub fn new(max_request_size: usize, router: Arc<Router<State>>, state: Arc<State>) -> Self {
+    pub fn new(
+        max_request_size: usize,
+        shutdown_tx: ShutdownTx,
+        router: Arc<Router<State>>,
+        state: Arc<State>,
+    ) -> Self {
         Self {
             max_request_size,
+            shutdown_tx,
             router,
             state,
         }

--- a/src/server/shutdown.rs
+++ b/src/server/shutdown.rs
@@ -2,29 +2,97 @@ use tokio::signal;
 use tokio::sync::watch;
 use tokio::task::{self, JoinHandle};
 
-use crate::error::BoxError;
+pub type ShutdownTx = watch::Sender<Option<bool>>;
+pub type ShutdownRx = watch::Receiver<Option<bool>>;
 
-pub fn wait_for_shutdown() -> (JoinHandle<Result<(), BoxError>>, watch::Receiver<bool>) {
+pub fn wait_for_shutdown() -> (ShutdownTx, ShutdownRx, JoinHandle<()>) {
+    // Create a watch channel to notify the main thread to shutdown if
+    // a connection task encounters an unrecoverable error.
+    let (conn_error_tx, mut conn_error_rx) = watch::channel(None);
+
     // Create a watch channel to notify the connections to initiate a
     // graceful shutdown process when the `ctrl_c` future resolves.
-    let (tx, rx) = watch::channel(false);
+    let (shutdown_tx, shutdown_rx) = watch::channel(None);
 
-    // Spawn a task to wait for a "Ctrl-C" signal to be sent to the process.
-    let task = task::spawn(async move {
-        match signal::ctrl_c().await {
-            Ok(_) => tx.send(true).map_err(|_| {
-                let message = "unable to notify connections to shutdown.";
-                message.to_owned().into()
-            }),
-            Err(error) => {
-                if cfg!(debug_assertions) {
-                    eprintln!("unable to register the 'Ctrl-C' signal.");
-                }
+    let shutdown_task = task::spawn(async move {
+        //
+        // TODO:
+        //
+        // Replace `eprintln` this with tracing. Once tracing is implemented,
+        // the `debug_assertions` flags can be removed.
+        //
+        tokio::select! {
+            ctrl_c_result = signal::ctrl_c() => match ctrl_c_result {
+                // A scheduled shutdown was requested.
+                //
+                Ok(_) => match shutdown_tx.send(Some(true)) {
+                    Err(send_error) if cfg!(debug_assertions) => {
+                        let _ = send_error; // Placeholder for tracing...
+                        eprintln!("unable to notify connections to shutdown.");
+                    },
+                    Err(_) | Ok(_) => {},
+                },
 
-                Err(error.into())
+                // Placeholder for tracing...
+                //
+                // Ok(_) => if let Err(send_error) = shutdown_tx.send(Some(true)) {
+                //     error!("unable to notify connections to shutdown.");
+                //     error!("reason: {}", send_error);
+                // },
+
+                // Graceful shutdown is either not supported on the host os or
+                // an unlikely error occurred at the os level when attempting to
+                // register the signal. The server can continue to operate as
+                // usual but connections may be closed before responses are
+                // sent.
+                //
+                Err(ctrl_c_error) => {
+                    let _ = ctrl_c_error; // Placeholder for tracing...
+                    if cfg!(debug_assertions) {
+                        eprintln!("unable to register the 'Ctrl-C' signal.");
+                    }
+                },
+            },
+
+            // An error occurred in a connection task that should result in
+            // shutting down or restarting the server. If you deploy your app in
+            // a cluster with a load balancer, we recommend that you immutably
+            // replace the node. Otherwise, you can run Via as a daemon with the
+            // appropriate configuration to restart if the main process exits
+            // with an error.
+            //
+            conn_error_result = conn_error_rx.changed() => match conn_error_result {
+                // A connection task encountered an unrecoverable error.
+                Ok(()) => match *conn_error_rx.borrow_and_update() {
+                    None => {
+                        // We are only concerned with Some(_) values here.
+                    },
+
+                    Some(true) => match shutdown_tx.send(Some(true)) {
+                        Err(send_error) if cfg!(debug_assertions) => {
+                            let _ = send_error; // Placeholder for tracing...
+                            eprintln!("unable to notify connections to shutdown.");
+                        }
+                        Err(_) | Ok(_) => {}
+                    },
+
+                    Some(false) => {
+                        // TODO: Replace this with tracing...
+                        if cfg!(debug_assertions) {
+                            eprintln!("connections cannot request a scheduled shutdown");
+                        }
+                    },
+                },
+
+                // The sender was dropped. This branch is likely unreachable on
+                // most platforms.
+                //
+                Err(recv_error) => {
+                    let _ = recv_error; // Placeholder for tracing...
+                },
             }
         }
     });
 
-    (task, rx)
+    (conn_error_tx, shutdown_rx, shutdown_task)
 }


### PR DESCRIPTION
The changes introduced in this branch can be tested in version `2.0.0-beta.6`.

---

Addresses #51 by introducing an additional watch channel that allows connections to notify the main thread if a route that should exist is no longer available. Considering that Rust binaries have near-instantaneous start times, we chose to shutdown the server if such an error occurs.

If you are deploying Via as a monolith, please ensure that you are properly running your Via application as a daemon with the appropriate restart configuration before upgrading. If you are deploying Via in a cluster you will likely benefit from doing the same along with configuring health checks and node decommissioning / replacement logic in a way that does not contend with the restart configuration of the daemon.

