### PR TITLE
deps(via): upgrade bytes to 1.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-beta.6"
+version = "2.0.0-beta.7"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ http2 = ["hyper/http2"]
 rustls = ["dep:tokio-rustls"]
 
 [dependencies]
-bytes = "=1.7.2"
+bytes = "1.8"
 futures-core = { version = "0.3", default-features = false }
 http = "1"
 http-body = "1"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following to dependencies section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-via = "2.0.0-beta.6"
+via = "2.0.0-beta.7"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 


### PR DESCRIPTION
The changes introduced in this branch can be tested in version `2.0.0-beta.7`.

---

Updates the bytes crate to version `1.8` which contains a change that guarantees stable memory addresses for instances of `Bytes`. This change may result in reduced memory usage for servers under heavy load.