### PR TITLE
docs(via): define the meaning of ExitCode

### DIFF
--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -136,7 +136,7 @@ where
                         }
                     };
 
-                    // Return the permits back to the semaphore.
+                    // Return the permit back to the semaphore.
                     drop(permit);
 
                     if let Err(error) = result {
@@ -151,10 +151,17 @@ where
                 // NOOP
                 None => {},
 
-                // An unrecoverable error occurred.
+                // An unrecoverable error occurred. An `ExitCode::FAILURE` can be
+                // used to initiate restart logic configured in a process
+                // supervisor such as upstart or systemd.
                 Some(true) => break ExitCode::FAILURE,
 
-                // A scheduled shutdown was requested.
+                // A scheduled shutdown was requested. An `ExitCode::SUCCESS` can
+                // be viewed as a confirmation that every request was served
+                // before exiting the event loop. Restart logic configured in a
+                // process manager such as upstart or systemd should be
+                // circumvented if the main process exits with
+                // `ExitCode::SUCCESS`.
                 Some(false) => break ExitCode::SUCCESS,
             }
         }

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -97,7 +97,8 @@ where
     }
 
     /// Starts the server and listens for incoming connections at the provided
-    /// address. Returns a future that resolves when the server is shutdown.
+    /// address. Returns a future that resolves with an [`ExitCode`] when the
+    /// server is shutdown.
     ///
     /// # Errors
     ///
@@ -110,6 +111,36 @@ where
     ///
     /// If [`rustls_config`](Self::rustls_config)
     /// was not provided prior to calling this method.
+    ///
+    /// # Exit Codes
+    ///
+    /// An [`ExitCode::SUCCESS`] can be viewed as a confirmation that every
+    /// request was served before exiting the accept loop.
+    ///
+    /// An [`ExitCode::FAILURE`] is an indicator that an unrecoverable error
+    /// occured which requires that the server be restarted in order to function
+    /// as intended.
+    ///
+    /// If you are running your Via application as a daemon with a process
+    /// supervisor such as upstart or systemd, you can use the exit code to
+    /// determine whether or not the process should restart.
+    ///
+    /// If you are running your Via application in a cluster behind a load
+    /// balancer you can use the exit code to properly configure node replacement
+    /// and / or decommissioning logic.
+    ///
+    /// When high availability is mission-critical, and you are scaling your Via
+    /// application both horizontally and vertically using a combination of the
+    /// aforementioned deployment strategies, we recommend configuring a temporal
+    /// threshold for the number of restarts caused by an [`ExitCode::FAILURE`].
+    /// If the threshold is exceeded the cluster should immutably replace the
+    /// node and the process supervisor should not make further attempts to
+    /// restart the process.
+    ///
+    /// This approach significantly reduces the impact of environmental entropy
+    /// on your application's availability while preventing conflicts between the
+    /// process supervisor of an individual node and the replacement and
+    /// decommissioning logic of the cluster.
     ///
     #[cfg(feature = "rustls")]
     pub fn listen<A: ToSocketAddrs>(
@@ -152,6 +183,36 @@ where
     /// finish serving all of the inflight connections within the specified
     /// [shutdown timeout](Self::shutdown_timeout)
     /// when a shutdown signal is received.
+    ///
+    /// # Exit Codes
+    ///
+    /// An [`ExitCode::SUCCESS`] can be viewed as a confirmation that every
+    /// request was served before exiting the accept loop.
+    ///
+    /// An [`ExitCode::FAILURE`] is an indicator that an unrecoverable error
+    /// occured which requires that the server be restarted in order to function
+    /// as intended.
+    ///
+    /// If you are running your Via application as a daemon with a process
+    /// supervisor such as upstart or systemd, you can use the exit code to
+    /// determine whether or not the process should restart.
+    ///
+    /// If you are running your Via application in a cluster behind a load
+    /// balancer you can use the exit code to properly configure node replacement
+    /// and / or decommissioning logic.
+    ///
+    /// When high availability is mission-critical, and you are scaling your Via
+    /// application both horizontally and vertically using a combination of the
+    /// aforementioned deployment strategies, we recommend configuring a temporal
+    /// threshold for the number of restarts caused by an [`ExitCode::FAILURE`].
+    /// If the threshold is exceeded the cluster should immutably replace the
+    /// node and the process supervisor should not make further attempts to
+    /// restart the process.
+    ///
+    /// This approach significantly reduces the impact of environmental entropy
+    /// on your application's availability while preventing conflicts between the
+    /// process supervisor of an individual node and the replacement and
+    /// decommissioning logic of the cluster.
     ///
     #[cfg(not(feature = "rustls"))]
     pub fn listen<A: ToSocketAddrs>(


### PR DESCRIPTION
This PR defines the meaning of the `ExitCode` type returned from `Server::listen`. A change that was introduced in #59. We also provide additional guidance on how the `ExitCode` return type can be used to ensure maximum availability in production.