### PR TITLE
fix(via-router): use str::match_indices in path::split_into

### DIFF
--- a/crates/via-router/Cargo.toml
+++ b/crates/via-router/Cargo.toml
@@ -7,6 +7,3 @@ license = "MIT OR Apache-2.0"
 description = "A fast and flexible http router."
 homepage = "https://github.com/zacharygolba/via"
 repository = "https://github.com/zacharygolba/via"
-
-[dependencies]
-smallvec = "1.13"

--- a/crates/via-router/benches/bench.rs
+++ b/crates/via-router/benches/bench.rs
@@ -79,7 +79,7 @@ static ROUTES: [&str; 100] = [
     "/api/:version/:resource/:resource_id",
     "/api/:version/:resource/:resource_id/edit",
     "/api/:version/:resource/:resource_id/comments/:comment_id",
-    "/api/:version/:resource/:resource_id/delete",
+    "/api/:version/:resource/:resource_id/comments/:comment_id/edit",
     "/checkout",
     "/checkout/cart",
     "/checkout/payment",
@@ -108,7 +108,20 @@ static ROUTES: [&str; 100] = [
 ];
 
 #[bench]
-fn find_matches_simple(b: &mut Bencher) {
+fn find_matches_2(b: &mut Bencher) {
+    let mut router: Router<()> = Router::new();
+
+    for path in ROUTES {
+        let _ = router.at(path).get_or_insert_route_with(|| ());
+    }
+
+    b.iter(|| {
+        router.visit("/dashboard/overview");
+    });
+}
+
+#[bench]
+fn find_matches_3(b: &mut Bencher) {
     let mut router: Router<()> = Router::new();
 
     for path in ROUTES {
@@ -121,7 +134,7 @@ fn find_matches_simple(b: &mut Bencher) {
 }
 
 #[bench]
-fn find_matches_nested_stack(b: &mut Bencher) {
+fn find_matches_4(b: &mut Bencher) {
     let mut router: Router<()> = Router::new();
 
     for path in ROUTES {
@@ -129,12 +142,12 @@ fn find_matches_nested_stack(b: &mut Bencher) {
     }
 
     b.iter(|| {
-        router.visit("/api/v1/products/12345678987654321/edit");
+        router.visit("/api/v1/products/12345678987654321");
     });
 }
 
 #[bench]
-fn find_matches_nested_heap(b: &mut Bencher) {
+fn find_matches_5(b: &mut Bencher) {
     let mut router: Router<()> = Router::new();
 
     for path in ROUTES {
@@ -143,5 +156,31 @@ fn find_matches_nested_heap(b: &mut Bencher) {
 
     b.iter(|| {
         router.visit("/api/v1/products/12345678987654321/comments/12345678987654321");
+    });
+}
+
+#[bench]
+fn find_matches_6(b: &mut Bencher) {
+    let mut router: Router<()> = Router::new();
+
+    for path in ROUTES {
+        let _ = router.at(path).get_or_insert_route_with(|| ());
+    }
+
+    b.iter(|| {
+        router.visit("/api/v1/products/12345678987654321/comments/12345678987654321");
+    });
+}
+
+#[bench]
+fn find_matches_7(b: &mut Bencher) {
+    let mut router: Router<()> = Router::new();
+
+    for path in ROUTES {
+        let _ = router.at(path).get_or_insert_route_with(|| ());
+    }
+
+    b.iter(|| {
+        router.visit("/api/v1/products/12345678987654321/comments/12345678987654321/edit");
     });
 }

--- a/crates/via-router/src/lib.rs
+++ b/crates/via-router/src/lib.rs
@@ -7,8 +7,6 @@ mod visitor;
 pub use path::{Param, Span};
 pub use visitor::{Found, VisitError};
 
-use smallvec::SmallVec;
-
 use path::Pattern;
 use routes::{Node, RouteEntry};
 
@@ -49,11 +47,10 @@ impl<T> Router<T> {
     }
 
     pub fn visit(&self, path: &str) -> Vec<Result<Found, VisitError>> {
-        let mut segments = SmallVec::new();
-        let nodes = &self.nodes;
+        let mut segments = vec![];
 
-        path::split_into(&mut segments, path);
-        visitor::visit(path, nodes, &segments)
+        path::split(&mut segments, path);
+        visitor::visit(path, &self.nodes, &segments)
     }
 }
 

--- a/crates/via-router/src/lib.rs
+++ b/crates/via-router/src/lib.rs
@@ -47,7 +47,7 @@ impl<T> Router<T> {
     }
 
     pub fn visit(&self, path: &str) -> Vec<Result<Found, VisitError>> {
-        let mut segments = vec![];
+        let mut segments = Vec::with_capacity(8);
 
         path::split(&mut segments, path);
         visitor::visit(path, &self.nodes, &segments)

--- a/crates/via-router/src/lib.rs
+++ b/crates/via-router/src/lib.rs
@@ -104,7 +104,7 @@ impl<T> Default for Router<T> {
     }
 }
 
-impl<'a, T> Endpoint<'a, T> {
+impl<T> Endpoint<'_, T> {
     pub fn at(&mut self, path: &'static str) -> Endpoint<T> {
         let mut segments = path::patterns(path);
         let key = insert(self.router, &mut segments, self.key);

--- a/crates/via-router/src/lib.rs
+++ b/crates/via-router/src/lib.rs
@@ -48,9 +48,13 @@ impl<T> Router<T> {
 
     pub fn visit(&self, path: &str) -> Vec<Result<Found, VisitError>> {
         let mut segments = Vec::with_capacity(8);
+        let mut results = Vec::with_capacity(8);
+        let nodes = &self.nodes;
 
         path::split(&mut segments, path);
-        visitor::visit(path, &self.nodes, &segments)
+        visitor::visit(&mut results, nodes, &segments, path);
+
+        results
     }
 }
 

--- a/crates/via-router/src/path/mod.rs
+++ b/crates/via-router/src/path/mod.rs
@@ -2,4 +2,4 @@ mod pattern;
 mod span;
 
 pub use pattern::{patterns, Param, Pattern};
-pub use span::{split, split_into, Span};
+pub use span::{split_into, Span};

--- a/crates/via-router/src/path/mod.rs
+++ b/crates/via-router/src/path/mod.rs
@@ -2,4 +2,4 @@ mod pattern;
 mod span;
 
 pub use pattern::{patterns, Param, Pattern};
-pub use span::{split_into, Span};
+pub use span::{split, Span};

--- a/crates/via-router/src/path/pattern.rs
+++ b/crates/via-router/src/path/pattern.rs
@@ -1,5 +1,4 @@
 use std::fmt::{self, Debug, Display};
-use std::sync::Arc;
 
 #[derive(PartialEq)]
 pub enum Pattern {
@@ -13,7 +12,7 @@ pub enum Pattern {
 ///
 #[derive(Debug, PartialEq)]
 pub struct Param {
-    ident: Arc<str>,
+    ident: Box<str>,
 }
 
 /// Returns an iterator that yields a `Pattern` for each segment in the uri path.
@@ -80,9 +79,10 @@ impl Param {
 }
 
 impl Clone for Param {
+    #[inline]
     fn clone(&self) -> Self {
         Self {
-            ident: Arc::clone(&self.ident),
+            ident: self.ident.clone(),
         }
     }
 }

--- a/crates/via-router/src/path/pattern.rs
+++ b/crates/via-router/src/path/pattern.rs
@@ -21,7 +21,7 @@ pub struct Param {
 pub fn patterns(path: &'static str) -> impl Iterator<Item = Pattern> {
     let mut segments = vec![];
 
-    super::split_into(&mut segments, path);
+    super::split(&mut segments, path);
     segments.into_iter().map(|at| {
         let end = at.end();
         let start = at.start();

--- a/crates/via-router/src/visitor.rs
+++ b/crates/via-router/src/visitor.rs
@@ -1,4 +1,3 @@
-use smallvec::SmallVec;
 use std::error::Error;
 use std::fmt::{self, Display};
 
@@ -60,11 +59,7 @@ pub struct Found {
     pub at: Option<Span>,
 }
 
-pub fn visit(
-    path: &str,
-    nodes: &[Node],
-    segments: &SmallVec<[Span; 5]>,
-) -> Vec<Result<Found, VisitError>> {
+pub fn visit(path: &str, nodes: &[Node], segments: &[Span]) -> Vec<Result<Found, VisitError>> {
     let mut results = Vec::new();
     let root = match nodes.first() {
         Some(node) => node,
@@ -149,7 +144,7 @@ fn visit_node(
     // The url path that we are attempting to match against the route tree.
     path: &str,
 
-    segments: &SmallVec<[Span; 5]>,
+    segments: &[Span],
 
     // The start and end offset of the path segment at `index` in
     // `self.path_value`.

--- a/crates/via-router/src/visitor.rs
+++ b/crates/via-router/src/visitor.rs
@@ -59,13 +59,17 @@ pub struct Found {
     pub at: Option<Span>,
 }
 
-pub fn visit(path: &str, nodes: &[Node], segments: &[Span]) -> Vec<Result<Found, VisitError>> {
-    let mut results = Vec::new();
+pub fn visit(
+    results: &mut Vec<Result<Found, VisitError>>,
+    nodes: &[Node],
+    segments: &[Span],
+    path: &str,
+) {
     let root = match nodes.first() {
         Some(node) => node,
         None => {
             results.push(Err(VisitError::NodeNotFound));
-            return results;
+            return;
         }
     };
 
@@ -76,7 +80,7 @@ pub fn visit(path: &str, nodes: &[Node], segments: &[Span]) -> Vec<Result<Found,
 
             // Begin the search for matches recursively starting with descendants of
             // the root node.
-            visit_node(&mut results, nodes, root, path, segments, range, 0);
+            visit_node(results, nodes, root, path, segments, range, 0);
         }
         None => {
             // Append the root match to the results vector.
@@ -84,11 +88,9 @@ pub fn visit(path: &str, nodes: &[Node], segments: &[Span]) -> Vec<Result<Found,
 
             // Perform a shallow search for descendants of the root node that have a
             // `CatchAll` pattern.
-            visit_index(&mut results, nodes, root);
+            visit_index(results, nodes, root);
         }
     }
-
-    results
 }
 
 impl Display for VisitError {


### PR DESCRIPTION
Simplifies the logic used to accumulate path segment ranges in via-router. Also refactors via-router to store path segment ranges in a `Vec` rather than a `SmallVec`. This changes brings a significant performance improvement to via-router and also reduces stack usage in `Router::visit`.

### Benchmarks

The benchmarks are apples to apples. The only difference is that I added additional test cases to see how the router performs as the complexity of the url path increases. 

*Before:*

```
test find_matches_simple       ... bench:         118.79 ns/iter (+/- 2.97)
test find_matches_nested_stack ... bench:         240.54 ns/iter (+/- 12.51)
test find_matches_nested_heap  ... bench:         289.47 ns/iter (+/- 12.16)
```

*After:*

```
test find_matches_2            ... bench:         117.23 ns/iter (+/- 3.17)
test find_matches_3            ... bench:         146.60 ns/iter (+/- 2.76)
test find_matches_4            ... bench:         194.86 ns/iter (+/- 2.38)
test find_matches_5            ... bench:         237.18 ns/iter (+/- 9.49)
test find_matches_6            ... bench:         233.41 ns/iter (+/- 6.69)
test find_matches_7            ... bench:         251.43 ns/iter (+/- 7.11)
```
