### PR TITLE
chore(via): bump the version to 2.0.0-beta.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-beta.7"
+version = "2.0.0-beta.8"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -27,7 +27,7 @@ percent-encoding = "2.3"
 serde = "1"
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "signal"] }
-via-router = "3.0.0-beta.1"
+via-router = "3.0.0-beta.2"
 
 [dependencies.cookie]
 version = "0.18"

--- a/crates/via-router/Cargo.toml
+++ b/crates/via-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via-router"
-version = "3.0.0-beta.1"
+version = "3.0.0-beta.2"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Bumps the crate version to `v2.0.0-beta.8`. There should be no breaking changes associated with this release. It includes the changes from #65 which should improve the performance, stability, and security of any via application. Regardless, it is recommended that you review the changes in #65 and proceed with caution before upgrading as it is a beta release.