### PR TITLE
fix(via): use charset=utf-8 in From<Error> for Response

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -494,7 +494,7 @@ impl From<Error> for Response {
                 .and_then(|json| {
                     Response::build()
                         .status(error.status)
-                        .header(CONTENT_TYPE, "application/json; charset=utf8")
+                        .header(CONTENT_TYPE, "application/json; charset=utf-8")
                         .body(json.into())
                 }) {
                 Ok(response) => break response,


### PR DESCRIPTION
Fixes a bug resulting from a typo in the latest beta release.