### PR TITLE
Refactor error boundary arg order

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-beta.16"
+version = "2.0.0-beta.17"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following to dependencies section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-via = "2.0.0-beta.16"
+via = "2.0.0-beta.17"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 

--- a/examples/blog-api/src/main.rs
+++ b/examples/blog-api/src/main.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<ExitCode, Error> {
 
         // Catch any errors that occur in the API namespace and generate a
         // JSON response from a redacted version of the original error.
-        api.include(error_boundary::map(|error, _| {
+        api.include(error_boundary::map(|_, error| {
             eprintln!("Error: {}", error); // Placeholder for tracing...
             util::map_error(error)
         }));

--- a/examples/cookies/src/main.rs
+++ b/examples/cookies/src/main.rs
@@ -101,7 +101,7 @@ async fn main() -> Result<ExitCode, Error> {
     });
 
     // Include an error boundary to catch any errors that occur downstream.
-    app.include(error_boundary::catch(|error, _| {
+    app.include(error_boundary::catch(|_, error| {
         eprintln!("Error: {}", error);
     }));
 

--- a/examples/echo-server/src/main.rs
+++ b/examples/echo-server/src/main.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<ExitCode, Error> {
     let mut app = via::new(());
 
     // Include an error boundary to catch any errors that occur downstream.
-    app.include(error_boundary::catch(|error, _| {
+    app.include(error_boundary::catch(|_, error| {
         eprintln!("Error: {}", error);
     }));
 

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<ExitCode, Error> {
     let mut app = via::new(());
 
     // Include an error boundary to catch any errors that occur downstream.
-    app.include(error_boundary::catch(|error, _| {
+    app.include(error_boundary::catch(|_, error| {
         eprintln!("Error: {}", error);
     }));
 

--- a/examples/shared-state/src/main.rs
+++ b/examples/shared-state/src/main.rs
@@ -80,7 +80,7 @@ async fn main() -> Result<ExitCode, Error> {
     });
 
     // Include an error boundary to catch any errors that occur downstream.
-    app.include(error_boundary::catch(|error, _| {
+    app.include(error_boundary::catch(|_, error| {
         eprintln!("Error: {}", error);
     }));
 

--- a/examples/static-files/src/main.rs
+++ b/examples/static-files/src/main.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<ExitCode, Error> {
     let mut app = via::new(());
 
     // Include an error boundary to catch any errors that occur downstream.
-    app.include(error_boundary::catch(|error, _| {
+    app.include(error_boundary::catch(|_, error| {
         eprintln!("Error: {}", error);
     }));
 

--- a/examples/tls-rustls/src/main.rs
+++ b/examples/tls-rustls/src/main.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<ExitCode, Error> {
     let mut app = via::new(());
 
     // Include an error boundary to catch any errors that occur downstream.
-    app.include(error_boundary::catch(|error, _| {
+    app.include(error_boundary::catch(|_, error| {
         eprintln!("Error: {}", error);
     }));
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -70,7 +70,7 @@ impl Error {
     ///     // Add an `ErrorBoundary` middleware to the route tree that maps
     ///     // errors that occur in subsequent middleware by calling the `redact`
     ///     // function.
-    ///     app.include(error_boundary::map(|error, _| {
+    ///     app.include(error_boundary::map(|_, error| {
     ///         error.redact(|message| {
     ///             if message.contains("password") {
     ///                 // If password is even mentioned in the error, return an
@@ -142,7 +142,7 @@ impl Error {
     ///     // Add an `ErrorBoundary` middleware to the route tree that maps
     ///     // errors that occur in subsequent middleware by calling the
     ///     // `use_canonical_reason` function.
-    ///     app.include(error_boundary::map(|error, _| {
+    ///     app.include(error_boundary::map(|_, error| {
     ///         // Prevent error messages that occur in downstream middleware from
     ///         // leaking into the response body by using the reason phrase of
     ///         // the status code associated with the error.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@
 //!     let mut app = via::new(());
 //!
 //!     // Include an error boundary to catch any errors that occur downstream.
-//!     app.include(error_boundary::catch(|error, _| {
+//!     app.include(error_boundary::catch(|_, error| {
 //!         eprintln!("Error: {}", error);
 //!     }));
 //!


### PR DESCRIPTION
Reverses the argument order for error boundaries. This gives precedence to shared references. A pattern common throughout the code in this repo.