### PR TITLE
chore(via): bump the version to 2.0.0-beta.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-beta.18"
+version = "2.0.0-beta.19"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following to dependencies section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-via = "2.0.0-beta.18"
+via = "2.0.0-beta.19"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 


### PR DESCRIPTION
Bumps the crate version in README.md and Cargo.toml in preparation for release.