### PR TITLE
refactor(via): reduce allocations when possible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,9 @@ hyper-util = { version = "0.1", features = ["tokio"] }
 percent-encoding = "2.3"
 serde = "1"
 serde_json = "1"
+tinyvec = { version = "1.8", features = ["alloc"] }
 tokio = { version = "1", features = ["macros", "signal"] }
-via-router = "3.0.0-beta.6"
+via-router = { path = "crates/via-router" }
 
 [dependencies.cookie]
 version = "0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-beta.22"
+version = "2.0.0-beta.23"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -27,7 +27,7 @@ serde = "1"
 serde_json = "1"
 tinyvec = { version = "1.8", features = ["alloc"] }
 tokio = { version = "1", features = ["macros", "signal"] }
-via-router = { path = "crates/via-router" }
+via-router = "3.0.0-beta.7"
 
 [dependencies.cookie]
 version = "0.18"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following to dependencies section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-via = "2.0.0-beta.22"
+via = "2.0.0-beta.23"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 

--- a/crates/via-router/Cargo.toml
+++ b/crates/via-router/Cargo.toml
@@ -7,3 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "A fast and flexible http router."
 homepage = "https://github.com/zacharygolba/via"
 repository = "https://github.com/zacharygolba/via"
+
+[dependencies]
+tinyvec = { version = "1.8", features = ["alloc"] }
+

--- a/crates/via-router/Cargo.toml
+++ b/crates/via-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via-router"
-version = "3.0.0-beta.6"
+version = "3.0.0-beta.7"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/crates/via-router/benches/bench.rs
+++ b/crates/via-router/benches/bench.rs
@@ -108,6 +108,19 @@ static ROUTES: [&str; 100] = [
 ];
 
 #[bench]
+fn find_matches_1(b: &mut Bencher) {
+    let mut router: Router<()> = Router::new();
+
+    for path in ROUTES {
+        let _ = router.at(path).get_or_insert_route_with(|| ());
+    }
+
+    b.iter(|| {
+        router.visit("/dashboard");
+    });
+}
+
+#[bench]
 fn find_matches_2(b: &mut Bencher) {
     let mut router: Router<()> = Router::new();
 

--- a/crates/via-router/src/path.rs
+++ b/crates/via-router/src/path.rs
@@ -1,11 +1,12 @@
+use std::sync::Arc;
 use tinyvec::TinyVec;
 
 #[derive(PartialEq)]
 pub enum Pattern {
     Root,
-    Static(String),
-    Dynamic(String),
-    Wildcard(String),
+    Static(Arc<str>),
+    Dynamic(Arc<str>),
+    Wildcard(Arc<str>),
 }
 
 pub struct Segments<'a> {

--- a/crates/via-router/src/routes.rs
+++ b/crates/via-router/src/routes.rs
@@ -1,5 +1,3 @@
-use core::slice::Iter;
-
 use crate::path::Pattern;
 use crate::Router;
 
@@ -12,7 +10,7 @@ pub struct Node {
     pub route: Option<usize>,
 
     /// The indices of the nodes that are reachable from the current node.
-    entries: Vec<usize>,
+    pub entries: Vec<usize>,
 }
 
 /// A mutable representation of a single node the route store. This type is used
@@ -33,12 +31,6 @@ impl Node {
             entries: Vec::new(),
             route: None,
         }
-    }
-
-    /// Returns an iterator that yields the indices of the nodes that are
-    /// reachable from `self`.
-    pub fn entries(&self) -> Iter<usize> {
-        self.entries.iter()
     }
 
     /// Returns an optional reference to the name of the dynamic parameter

--- a/crates/via-router/src/visitor.rs
+++ b/crates/via-router/src/visitor.rs
@@ -155,19 +155,19 @@ pub fn visit_node<'a>(
         // Append the match to the results vector.
         results.push(Ok(found));
 
-        match (next, &child.pattern) {
+        match (&child.pattern, next) {
             // Wildcard patterns consume the remainder of the path. Continue matching
             // adjacent nodes.
-            (_, Pattern::Wildcard(_)) => {}
+            (Pattern::Wildcard(_), _) => {}
 
             // Perform a recursive search for descendants of `child` that match the next
             // path segment.
-            (Some(range), _) => {
+            (_, Some(range)) => {
                 visit_node(results, nodes, child, path, segments, range, index + 1);
             }
 
             // Perform a shallow search for descendants of `child` with a wildcard pattern.
-            (None, _) => {
+            (_, None) => {
                 visit_wildcard(results, nodes, child);
             }
         }

--- a/crates/via-router/src/visitor.rs
+++ b/crates/via-router/src/visitor.rs
@@ -2,6 +2,7 @@
 
 use std::error::Error;
 use std::fmt::{self, Display};
+use std::sync::Arc;
 
 use crate::path::{Pattern, Segments};
 use crate::routes::Node;
@@ -37,7 +38,8 @@ pub struct Found<'a> {
 
     /// The name of the dynamic parameter that matched the path segment.
     ///
-    pub param: Option<(&'a str, Option<(usize, usize)>)>,
+    #[allow(clippy::type_complexity)]
+    pub param: Option<(&'a Arc<str>, Option<(usize, usize)>)>,
 
     /// The key of the route associated with the node that matched the path
     /// segment.
@@ -96,7 +98,7 @@ pub fn visit_node<'a>(
         let (child, found) = match nodes.get(*key) {
             // The node has a static pattern. Attempt to match the pattern value against
             // the current path segment.
-            Some(node @ Node { pattern: Pattern::Static(value), .. }) if value == segment => (
+            Some(node @ Node { pattern: Pattern::Static(value), .. }) if &**value == segment => (
                 node,
                 Found {
                     exact: next_segment.is_none(),

--- a/src/request/body/request_body.rs
+++ b/src/request/body/request_body.rs
@@ -12,12 +12,12 @@ use crate::error::{BoxError, Error};
 #[derive(Debug)]
 pub struct RequestBody {
     remaining: usize,
-    body: BoxBody<Bytes, hyper::Error>,
+    body: Option<BoxBody<Bytes, hyper::Error>>,
 }
 
 impl RequestBody {
     #[inline]
-    pub(crate) fn new(remaining: usize, body: BoxBody<Bytes, hyper::Error>) -> Self {
+    pub(crate) fn new(remaining: usize, body: Option<BoxBody<Bytes, hyper::Error>>) -> Self {
         Self { remaining, body }
     }
 }
@@ -41,8 +41,12 @@ impl Body for RequestBody {
         context: &mut Context<'_>,
     ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
         let this = self.get_mut();
+        let body = match &mut this.body {
+            Some(body) => body,
+            None => return Poll::Ready(None),
+        };
 
-        match Pin::new(&mut this.body).poll_frame(context)? {
+        match Pin::new(body).poll_frame(context)? {
             Poll::Pending => Poll::Pending,
             Poll::Ready(None) => Poll::Ready(None),
             Poll::Ready(Some(frame)) => {
@@ -63,10 +67,16 @@ impl Body for RequestBody {
     }
 
     fn is_end_stream(&self) -> bool {
-        self.body.is_end_stream()
+        match &self.body {
+            Some(body) => body.is_end_stream(),
+            None => true,
+        }
     }
 
     fn size_hint(&self) -> SizeHint {
-        self.body.size_hint()
+        match &self.body {
+            Some(body) => body.size_hint(),
+            None => SizeHint::new(),
+        }
     }
 }

--- a/src/request/param/path_params.rs
+++ b/src/request/param/path_params.rs
@@ -1,24 +1,27 @@
+#![allow(clippy::type_complexity)]
+
 use std::fmt::{self, Debug, Formatter};
 use std::slice;
+use std::sync::Arc;
 use tinyvec::TinyVec;
 
 pub struct PathParams {
-    data: TinyVec<[(String, (usize, usize)); 1]>,
+    data: TinyVec<[(Arc<str>, (usize, usize)); 1]>,
 }
 
 impl PathParams {
     #[inline]
-    pub fn new(data: TinyVec<[(String, (usize, usize)); 1]>) -> Self {
+    pub fn new(data: TinyVec<[(Arc<str>, (usize, usize)); 1]>) -> Self {
         Self { data }
     }
 
     #[inline]
-    pub fn iter(&self) -> slice::Iter<(String, (usize, usize))> {
+    pub fn iter(&self) -> slice::Iter<(Arc<str>, (usize, usize))> {
         self.data.iter()
     }
 
     #[inline]
-    pub fn push(&mut self, param: (String, (usize, usize))) {
+    pub fn push(&mut self, param: (Arc<str>, (usize, usize))) {
         if self.data.len() == 1 {
             self.data.reserve(7);
         }

--- a/src/request/param/path_params.rs
+++ b/src/request/param/path_params.rs
@@ -1,23 +1,28 @@
 use std::fmt::{self, Debug, Formatter};
-use std::slice::Iter;
+use std::slice;
+use tinyvec::TinyVec;
 
 pub struct PathParams {
-    data: Vec<(String, (usize, usize))>,
+    data: TinyVec<[(String, (usize, usize)); 1]>,
 }
 
 impl PathParams {
     #[inline]
-    pub fn new(data: Vec<(String, (usize, usize))>) -> Self {
+    pub fn new(data: TinyVec<[(String, (usize, usize)); 1]>) -> Self {
         Self { data }
     }
 
     #[inline]
-    pub fn iter(&self) -> Iter<(String, (usize, usize))> {
+    pub fn iter(&self) -> slice::Iter<(String, (usize, usize))> {
         self.data.iter()
     }
 
     #[inline]
     pub fn push(&mut self, param: (String, (usize, usize))) {
+        if self.data.len() == 1 {
+            self.data.reserve(7);
+        }
+
         self.data.push(param);
     }
 }

--- a/src/request/request.rs
+++ b/src/request/request.rs
@@ -105,7 +105,7 @@ impl<T> Request<T> {
     pub fn param<'a>(&self, name: &'a str) -> PathParam<'_, 'a> {
         let path = self.parts.uri.path();
         let at = self.params.iter().rev().find_map(|(param, at)| {
-            if name == param {
+            if &**param == name {
                 Some((at.0, at.1))
             } else {
                 None

--- a/src/router/router.rs
+++ b/src/router/router.rs
@@ -30,8 +30,8 @@ impl<T> Router<T> {
             // If there is a dynamic parameter name associated with the route,
             // build a tuple containing the name and the range of the parameter
             // value in the request's path.
-            if let (Some(param), Some(at)) = (found.param, found.at) {
-                params.push((param.to_owned(), at));
+            if let Some((name, Some(at))) = found.param {
+                params.push((name.to_owned(), at));
             }
 
             let route = match found.route.and_then(|key| self.inner.get(key)) {
@@ -45,7 +45,7 @@ impl<T> Router<T> {
                 // Include this middleware in `stack` because it expects an exact
                 // match and the visited node is considered a leaf in this
                 // context.
-                MatchWhen::Exact(exact) if found.is_leaf => Some(exact),
+                MatchWhen::Exact(exact) if found.exact => Some(exact),
 
                 // Include this middleware in `stack` unconditionally because it
                 // targets partial matches.

--- a/src/router/router.rs
+++ b/src/router/router.rs
@@ -31,7 +31,7 @@ impl<T> Router<T> {
             // build a tuple containing the name and the range of the parameter
             // value in the request's path.
             if let Some((name, Some(at))) = found.param {
-                params.push((name.to_owned(), at));
+                params.push((Arc::clone(name), at));
             }
 
             let route = match found.route.and_then(|key| self.inner.get(key)) {


### PR DESCRIPTION
Reduces allocations when possible by allowing at most 1 path param on the stack before moving to the heap. Also conditionally allocates request bodies on the heap based on the request method.