### PR TITLE
chore(via): bump the version to 2.0.0-beta.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-beta.23"
+version = "2.0.0-beta.24"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -27,7 +27,7 @@ serde = "1"
 serde_json = "1"
 tinyvec = { version = "1.8", features = ["alloc"] }
 tokio = { version = "1", features = ["macros", "signal"] }
-via-router = "3.0.0-beta.8"
+via-router = "3.0.0-beta.9"
 
 [dependencies.cookie]
 version = "0.18"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following to dependencies section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-via = "2.0.0-beta.23"
+via = "2.0.0-beta.24"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@
 //!     Response::build().text(format!("Hello, {}!", name))
 //! }
 //!
-//! #[tokio::main]
+//! #[tokio::main(flavor = "current_thread")]
 //! async fn main() -> Result<ExitCode, Error> {
 //!     // Create a new application.
 //!     let mut app = via::new(());


### PR DESCRIPTION
Bumps the version to `2.0.0-beta.24` in preparation for release.