### PR TITLE
refactor(via-router): store param names in Arc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-beta.24"
+version = "2.0.0-beta.25"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -27,7 +27,7 @@ serde = "1"
 serde_json = "1"
 tinyvec = { version = "1.8", features = ["alloc"] }
 tokio = { version = "1", features = ["macros", "signal"] }
-via-router = { path = "crates/via-router" }
+via-router = "3.0.0-beta.10"
 
 [dependencies.cookie]
 version = "0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ serde = "1"
 serde_json = "1"
 tinyvec = { version = "1.8", features = ["alloc"] }
 tokio = { version = "1", features = ["macros", "signal"] }
-via-router = "3.0.0-beta.9"
+via-router = { path = "crates/via-router" }
 
 [dependencies.cookie]
 version = "0.18"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following to dependencies section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-via = "2.0.0-beta.24"
+via = "2.0.0-beta.25"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 

--- a/crates/via-router/Cargo.toml
+++ b/crates/via-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via-router"
-version = "3.0.0-beta.9"
+version = "3.0.0-beta.10"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/crates/via-router/src/routes.rs
+++ b/crates/via-router/src/routes.rs
@@ -1,16 +1,16 @@
 use crate::path::Pattern;
-use crate::Router;
+use crate::{Param, Router};
 
 /// A node in the route tree that represents a single path segment.
 pub struct Node {
-    /// The pattern used to match the node against a path segment.
-    pub pattern: Pattern,
-
     /// The index of the route in the route store associated with the node.
     pub route: Option<usize>,
 
+    /// The pattern used to match the node against a path segment.
+    pub pattern: Pattern,
+
     /// The indices of the nodes that are reachable from the current node.
-    pub entries: Vec<usize>,
+    pub children: Option<Vec<usize>>,
 }
 
 /// A mutable representation of a single node the route store. This type is used
@@ -27,16 +27,16 @@ pub struct RouteEntry<'a, T> {
 impl Node {
     pub fn new(pattern: Pattern) -> Self {
         Self {
-            pattern,
-            entries: Vec::new(),
+            children: None,
             route: None,
+            pattern,
         }
     }
 
     /// Returns an optional reference to the name of the dynamic parameter
     /// associated with the node. The returned value will be `None` if the
     /// node has a `Root` or `Static` pattern.
-    pub fn param(&self) -> Option<&str> {
+    pub fn param(&self) -> Option<&Param> {
         match &self.pattern {
             Pattern::Wildcard(param) | Pattern::Dynamic(param) => Some(param),
             _ => None,
@@ -47,7 +47,7 @@ impl Node {
 impl Node {
     /// Pushes a new key into the entries of the node and return it.
     fn push(&mut self, key: usize) -> usize {
-        self.entries.push(key);
+        self.children.get_or_insert_default().push(key);
         key
     }
 }

--- a/crates/via-serve-static/src/lib.rs
+++ b/crates/via-serve-static/src/lib.rs
@@ -106,7 +106,7 @@ where
                 let message = "The provided endpoint does not have a path parameter.";
                 Err(Error::from(message.to_owned()))
             },
-            |value| Ok(value.to_owned().into_boxed_str()),
+            |value| Ok(value.to_string().into_boxed_str()),
         )?;
 
         if public_dir.is_relative() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,10 @@
 //!     Response::build().text(format!("Hello, {}!", name))
 //! }
 //!
+//! // For the sake of simplifying doctests, we're specifying that we want to
+//! // use the "current_thread" runtime flavor. You'll most likely not want to
+//! // specify a runtime flavor and simpy use #[tokio::main] if your deployment
+//! // target has more than one CPU core.
 //! #[tokio::main(flavor = "current_thread")]
 //! async fn main() -> Result<ExitCode, Error> {
 //!     // Create a new application.

--- a/src/request/param/decode.rs
+++ b/src/request/param/decode.rs
@@ -25,6 +25,7 @@ impl DecodeParam for NoopDecode {
 }
 
 impl DecodeParam for PercentDecode {
+    #[inline]
     fn decode(encoded: &str) -> Result<Cow<str>, Error> {
         Ok(percent_decode_str(encoded).decode_utf8()?)
     }

--- a/src/request/param/path_param.rs
+++ b/src/request/param/path_param.rs
@@ -13,7 +13,8 @@ pub struct PathParam<'a, 'b, T = NoopDecode> {
 }
 
 impl<'a, 'b, T: DecodeParam> PathParam<'a, 'b, T> {
-    pub(crate) fn new(at: Option<(usize, usize)>, name: &'b str, source: &'a str) -> Self {
+    #[inline]
+    pub(crate) fn new(name: &'b str, source: &'a str, at: Option<(usize, usize)>) -> Self {
         Self {
             at,
             name,
@@ -25,6 +26,7 @@ impl<'a, 'b, T: DecodeParam> PathParam<'a, 'b, T> {
     /// Returns a new `Param` that will percent-decode the parameter value with
     /// when the parameter is converted to a result.
     ///
+    #[inline]
     pub fn percent_decode(self) -> PathParam<'a, 'b, PercentDecode> {
         PathParam {
             at: self.at,
@@ -37,6 +39,7 @@ impl<'a, 'b, T: DecodeParam> PathParam<'a, 'b, T> {
     /// Calls [`str::parse`] on the parameter value if it exists and returns the
     /// result. If the param is encoded, it will be decoded before it is parsed.
     ///
+    #[inline]
     pub fn parse<U>(self) -> Result<U, Error>
     where
         U: FromStr,
@@ -60,6 +63,7 @@ impl<'a, 'b, T: DecodeParam> PathParam<'a, 'b, T> {
     /// implementation of `T::decode`, an error is returned with a 400 Bad
     /// Request status code.
     ///
+    #[inline]
     pub fn into_result(self) -> Result<Cow<'a, str>, Error> {
         match self.at.and_then(|at| {
             let (start, end) = at;

--- a/src/request/param/path_params.rs
+++ b/src/request/param/path_params.rs
@@ -2,26 +2,26 @@
 
 use std::fmt::{self, Debug, Formatter};
 use std::slice;
-use std::sync::Arc;
 use tinyvec::TinyVec;
+use via_router::Param;
 
 pub struct PathParams {
-    data: TinyVec<[(Arc<str>, (usize, usize)); 1]>,
+    data: TinyVec<[(Param, (usize, usize)); 1]>,
 }
 
 impl PathParams {
     #[inline]
-    pub fn new(data: TinyVec<[(Arc<str>, (usize, usize)); 1]>) -> Self {
+    pub fn new(data: TinyVec<[(Param, (usize, usize)); 1]>) -> Self {
         Self { data }
     }
 
     #[inline]
-    pub fn iter(&self) -> slice::Iter<(Arc<str>, (usize, usize))> {
+    pub fn iter(&self) -> slice::Iter<(Param, (usize, usize))> {
         self.data.iter()
     }
 
     #[inline]
-    pub fn push(&mut self, param: (Arc<str>, (usize, usize))) {
+    pub fn push(&mut self, param: (Param, (usize, usize))) {
         if self.data.len() == 1 {
             self.data.reserve(7);
         }

--- a/src/request/request.rs
+++ b/src/request/request.rs
@@ -38,6 +38,7 @@ pub struct Request<T = ()> {
 impl<T> Request<T> {
     /// Consumes the request and returns the body.
     ///
+    #[inline]
     pub fn into_body(self) -> HttpBody<RequestBody> {
         self.body
     }
@@ -45,6 +46,7 @@ impl<T> Request<T> {
     /// Consumes the request returning a new request with body mapped to the
     /// return type of the provided closure `map`.
     ///
+    #[inline]
     pub fn map(self, map: impl FnOnce(HttpBody<RequestBody>) -> BoxBody) -> Self {
         if cfg!(debug_assertions) && self.body.is_dyn() {
             // TODO: Replace this with tracing and a proper logger.
@@ -59,18 +61,21 @@ impl<T> Request<T> {
 
     /// Returns an optional reference to the cookie with the provided `name`.
     ///
+    #[inline]
     pub fn cookie(&self, name: &str) -> Option<&Cookie<'static>> {
         self.cookies.as_ref()?.get(name)
     }
 
     /// Returns an optional reference to the cookies associated with the request.
     ///
+    #[inline]
     pub fn cookies(&self) -> Option<&CookieJar> {
         self.cookies.as_deref()
     }
 
     /// Returns a reference to the header value associated with the key.
     ///
+    #[inline]
     pub fn header<K: AsHeaderName>(&self, key: K) -> Option<&HeaderValue> {
         self.parts.headers.get(key)
     }
@@ -78,12 +83,14 @@ impl<T> Request<T> {
     /// Returns a reference to a map that contains the headers associated with
     /// the request.
     ///
+    #[inline]
     pub fn headers(&self) -> &HeaderMap {
         &self.parts.headers
     }
 
     /// Returns a reference to the HTTP method associated with the request.
     ///
+    #[inline]
     pub fn method(&self) -> &Method {
         &self.parts.method
     }
@@ -102,35 +109,40 @@ impl<T> Request<T> {
     /// }
     /// ```
     ///
+    #[inline]
     pub fn param<'a>(&self, name: &'a str) -> PathParam<'_, 'a> {
-        let path = self.parts.uri.path();
-        let at = self.params.iter().rev().find_map(|(param, at)| {
-            if &**param == name {
-                Some((at.0, at.1))
-            } else {
-                None
-            }
-        });
-
-        PathParam::new(at, name, path)
+        PathParam::new(
+            name,
+            self.parts.uri.path(),
+            self.params.iter().rev().find_map(|(param, at)| {
+                if param == name {
+                    Some((at.0, at.1))
+                } else {
+                    None
+                }
+            }),
+        )
     }
 
     /// Returns a thread-safe reference-counting pointer to the application
     /// state that was passed as an argument to the [`via::new`](crate::app::new)
     /// function.
     ///
+    #[inline]
     pub fn state(&self) -> &Arc<T> {
         &self.state
     }
 
     /// Returns a reference to the uri associated with the request.
     ///
+    #[inline]
     pub fn uri(&self) -> &Uri {
         &self.parts.uri
     }
 
     /// Returns the HTTP version associated with the request.
     ///
+    #[inline]
     pub fn version(&self) -> Version {
         self.parts.version
     }

--- a/src/router/route.rs
+++ b/src/router/route.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use via_router::Param;
 
 use crate::middleware::Middleware;
 
@@ -36,7 +37,7 @@ impl<T> Route<'_, T> {
         self
     }
 
-    pub fn param(&self) -> Option<&str> {
+    pub fn param(&self) -> Option<&Param> {
         self.inner.param()
     }
 

--- a/src/router/router.rs
+++ b/src/router/router.rs
@@ -31,7 +31,7 @@ impl<T> Router<T> {
             // build a tuple containing the name and the range of the parameter
             // value in the request's path.
             if let Some((name, Some(at))) = found.param {
-                params.push((Arc::clone(name), at));
+                params.push((name, at));
             }
 
             let route = match found.route.and_then(|key| self.inner.get(key)) {

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -249,16 +249,8 @@ fn serve_request<T>(
                 let parts = Box::new(parts);
 
                 // Limit the length of the incoming request body to the configured max.
-                let body = if parts.method.is_safe() {
-                    // The request method implies no body. Do not allocate.
-                    HttpBody::Inline(RequestBody::new(max_request_size, None))
-                } else {
-                    // Allocate the request body on the heap.
-                    HttpBody::Inline(RequestBody::new(
-                        max_request_size,
-                        Some(BoxBody::new(incoming)),
-                    ))
-                };
+                let body =
+                    HttpBody::Inline(RequestBody::new(max_request_size, BoxBody::new(incoming)));
 
                 // Call the middleware stack for the matched routes.
                 Some(next.call(Request::new(state, parts, params, body)))


### PR DESCRIPTION
Refactors via-router to store params in an `Arc<str>`. I've been going back and forth quite a bit with regards to how params are stored in via-router. The reason being is that I would prefer to not return any references from the router for the sake of security. Previously, we returned a reference to a String for param names that we would later clone when processing results. Rather than refactoring the router to return an owned `String` for param names, I realized that Arc<str> cannot be used to get a memory address that points back to the router since it is allocated on the heap. This is no less secure that returning an owned string from the router and avoids an additional allocation for every matched route. Since we no longer need to perform a heap allocation for every route that is matched during a request, I'm also switching the request body to allocate unconditionally on the heap to make a potential use-after-free impossible as well as making it impossible for a request body to be read partially due to environmental entropy.

