### PR TITLE
chore(via): bump the version to 2.0.0-beta.27

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ hyper-util = { version = "0.1", features = ["tokio"] }
 percent-encoding = "2.3"
 serde = "1"
 serde_json = "1"
-tinyvec = { version = "1.8", features = ["alloc"] }
 tokio = { version = "1", features = ["macros", "signal"] }
 via-router = "3.0.0-beta.10"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-beta.26"
+version = "2.0.0-beta.27"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ async fn hello(request: Request, _: Next) -> via::Result {
 #[tokio::main]
 async fn main() -> Result<ExitCode, Error> {
     // Create a new application.
-    let mut app = via::new(());
+    let mut app = via::app(());
 
     // Include an error boundary to catch any errors that occur downstream.
     app.include(error_boundary::catch(|_, error| {
@@ -60,7 +60,7 @@ async fn main() -> Result<ExitCode, Error> {
 
 1. **Define a Handler**: The `hello` function is an asynchronous handler that receives a `Request` and a `Next` middleware chain. It extracts the `name` parameter from the URL and returns a `Response` with a personalized greeting.
 
-2. **Create the Application**: Using `via::new(())`, you can create a new instance of the application. This function can also accept shared state.
+2. **Create the Application**: Using `via::app(())`, you can create a new instance of the application. This function can also accept shared state.
 
 3. **Define an ErrorBoundary**: Define an `ErrorBoundary` middleware to catch errors that occur downstream and convert them to a response. Middleware can be added at any depth of the route tree with the `.include(middleware)` method.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following to dependencies section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-via = "2.0.0-beta.26"
+via = "2.0.0-beta.27"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 

--- a/examples/blog-api/src/main.rs
+++ b/examples/blog-api/src/main.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<ExitCode, Error> {
     dotenvy::dotenv()?;
 
     // Create a new app with our shared state that contains a database pool.
-    let mut app = via::new(State {
+    let mut app = via::app(State {
         pool: database::pool().await?,
     });
 

--- a/examples/cookies/src/main.rs
+++ b/examples/cookies/src/main.rs
@@ -96,7 +96,7 @@ async fn main() -> Result<ExitCode, Error> {
     dotenvy::dotenv().ok();
 
     // Create a new app by calling the `via::app` function.
-    let mut app = via::new(State {
+    let mut app = via::app(State {
         secret: get_secret_from_env(),
     });
 

--- a/examples/echo-server/src/main.rs
+++ b/examples/echo-server/src/main.rs
@@ -19,7 +19,7 @@ async fn echo(request: Request, _: Next) -> via::Result {
 
 #[tokio::main]
 async fn main() -> Result<ExitCode, Error> {
-    let mut app = via::new(());
+    let mut app = via::app(());
 
     // Include an error boundary to catch any errors that occur downstream.
     app.include(error_boundary::catch(|_, error| {

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -15,7 +15,7 @@ async fn hello(request: Request, _: Next) -> via::Result {
 #[tokio::main]
 async fn main() -> Result<ExitCode, Error> {
     // Create a new application.
-    let mut app = via::new(());
+    let mut app = via::app(());
 
     // Include an error boundary to catch any errors that occur downstream.
     app.include(error_boundary::catch(|_, error| {

--- a/examples/shared-state/src/main.rs
+++ b/examples/shared-state/src/main.rs
@@ -74,7 +74,7 @@ async fn totals(request: Request<State>, _: Next<State>) -> via::Result {
 #[tokio::main]
 async fn main() -> Result<ExitCode, Error> {
     // Create a new application with a `Counter` as state.
-    let mut app = via::new(State {
+    let mut app = via::app(State {
         errors: Arc::new(AtomicU32::new(0)),
         sucesses: Arc::new(AtomicU32::new(0)),
     });

--- a/examples/static-files/src/main.rs
+++ b/examples/static-files/src/main.rs
@@ -31,7 +31,7 @@ async fn not_found(request: Request, _: Next) -> via::Result {
 
 #[tokio::main]
 async fn main() -> Result<ExitCode, Error> {
-    let mut app = via::new(());
+    let mut app = via::app(());
 
     // Include an error boundary to catch any errors that occur downstream.
     app.include(error_boundary::catch(|_, error| {

--- a/examples/tls-rustls/src/main.rs
+++ b/examples/tls-rustls/src/main.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<ExitCode, Error> {
     let tls_config = tls::server_config().expect("tls config is invalid or missing");
 
     // Create a new app by calling the `via::app` function.
-    let mut app = via::new(());
+    let mut app = via::app(());
 
     // Include an error boundary to catch any errors that occur downstream.
     app.include(error_boundary::catch(|_, error| {

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,7 +10,7 @@ pub struct App<T> {
 
 /// Constructs a new [`App`] with the provided `state` argument.
 ///
-pub fn new<T>(state: T) -> App<T> {
+pub fn app<T>(state: T) -> App<T> {
     App {
         state: Arc::new(state),
         router: Router::new(),

--- a/src/body/http_body.rs
+++ b/src/body/http_body.rs
@@ -30,11 +30,11 @@ where
 
     fn poll_frame(
         self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
+        context: &mut Context<'_>,
     ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
         match self.get_mut() {
-            Self::Original(ptr) => Pin::new(ptr).poll_frame(cx),
-            Self::Mapped(ptr) => Pin::new(ptr).poll_frame(cx),
+            Self::Original(ptr) => Pin::new(ptr).poll_frame(context),
+            Self::Mapped(ptr) => Pin::new(ptr).poll_frame(context),
         }
     }
 

--- a/src/body/http_body.rs
+++ b/src/body/http_body.rs
@@ -21,6 +21,19 @@ pub enum HttpBody<T> {
     Mapped(BoxBody),
 }
 
+impl<T> HttpBody<T>
+where
+    T: Body<Data = Bytes, Error = BoxError> + Send + Sync + 'static,
+{
+    #[inline]
+    pub fn boxed(self) -> BoxBody {
+        match self {
+            Self::Original(body) => BoxBody::new(body),
+            Self::Mapped(body) => body,
+        }
+    }
+}
+
 impl<T> Body for HttpBody<T>
 where
     T: Body<Data = Bytes, Error = BoxError> + Unpin,

--- a/src/body/pipe.rs
+++ b/src/body/pipe.rs
@@ -36,10 +36,7 @@ impl Pipe for HttpBody<RequestBody> {
     fn pipe(self, response: Builder) -> Result<Response, Error> {
         response
             .header(TRANSFER_ENCODING, "chunked")
-            .body(HttpBody::Mapped(match self {
-                HttpBody::Original(body) => BoxBody::new(body),
-                HttpBody::Mapped(body) => body,
-            }))
+            .body(HttpBody::Mapped(self.boxed()))
     }
 }
 

--- a/src/body/request_body.rs
+++ b/src/body/request_body.rs
@@ -6,8 +6,8 @@ use std::task::{Context, Poll};
 
 use super::body_reader::{BodyData, BodyReader};
 use super::body_stream::BodyStream;
+use super::http_body::HttpBody;
 use super::limit_error::LimitError;
-use crate::body::HttpBody;
 use crate::error::{BoxError, Error};
 
 /// A length-limited request body. The default limit is `10MB`.

--- a/src/body/response_body.rs
+++ b/src/body/response_body.rs
@@ -99,8 +99,8 @@ impl Body for ResponseBody {
 }
 
 impl Debug for ResponseBody {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.debug_struct("BufferBody").finish()
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.debug_struct("ResponseBody").finish()
     }
 }
 

--- a/src/body/response_body.rs
+++ b/src/body/response_body.rs
@@ -4,7 +4,7 @@ use std::fmt::{self, Debug, Formatter};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use super::HttpBody;
+use super::http_body::HttpBody;
 use crate::error::BoxError;
 
 /// The maximum amount of data that can be read from a buffered body per frame.

--- a/src/body/stream_body.rs
+++ b/src/body/stream_body.rs
@@ -73,7 +73,7 @@ where
 }
 
 impl<T> Debug for StreamBody<T> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         f.debug_struct("StreamBody").finish()
     }
 }

--- a/src/body/stream_body.rs
+++ b/src/body/stream_body.rs
@@ -28,6 +28,7 @@ impl<T> StreamBody<T> {
 }
 
 impl<T> StreamBody<T> {
+    #[inline]
     fn project(self: Pin<&mut Self>) -> Pin<&mut T> {
         unsafe { Pin::map_unchecked_mut(self, |this| &mut this.stream) }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -65,7 +65,7 @@ impl Error {
     ///
     /// #[tokio::main(flavor = "current_thread")]
     /// async fn main() -> Result<(), Error> {
-    ///     let mut app = via::new(());
+    ///     let mut app = via::app(());
     ///
     ///     // Add an `ErrorBoundary` middleware to the route tree that maps
     ///     // errors that occur in subsequent middleware by calling the `redact`
@@ -137,7 +137,7 @@ impl Error {
     ///
     /// #[tokio::main(flavor = "current_thread")]
     /// async fn main() -> Result<(), Error> {
-    ///     let mut app = via::new(());
+    ///     let mut app = via::app(());
     ///
     ///     // Add an `ErrorBoundary` middleware to the route tree that maps
     ///     // errors that occur in subsequent middleware by calling the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@
 //! #[tokio::main(flavor = "current_thread")]
 //! async fn main() -> Result<ExitCode, Error> {
 //!     // Create a new application.
-//!     let mut app = via::new(());
+//!     let mut app = via::app(());
 //!
 //!     // Include an error boundary to catch any errors that occur downstream.
 //!     app.include(error_boundary::catch(|_, error| {
@@ -64,7 +64,7 @@ mod error;
 mod router;
 mod server;
 
-pub use app::{new, App};
+pub use app::{app, App};
 pub use body::Pipe;
 pub use error::Error;
 pub use middleware::filter_method::{connect, delete, get, head, options, patch, post, put, trace};

--- a/src/request/param/path_params.rs
+++ b/src/request/param/path_params.rs
@@ -2,16 +2,15 @@
 
 use std::fmt::{self, Debug, Formatter};
 use std::slice;
-use tinyvec::TinyVec;
 use via_router::Param;
 
 pub struct PathParams {
-    data: TinyVec<[(Param, (usize, usize)); 1]>,
+    data: Vec<(Param, (usize, usize))>,
 }
 
 impl PathParams {
     #[inline]
-    pub fn new(data: TinyVec<[(Param, (usize, usize)); 1]>) -> Self {
+    pub const fn new(data: Vec<(Param, (usize, usize))>) -> Self {
         Self { data }
     }
 

--- a/src/request/request.rs
+++ b/src/request/request.rs
@@ -9,7 +9,8 @@ use super::param::{PathParam, PathParams};
 use crate::body::{BoxBody, HttpBody, RequestBody};
 
 pub struct Request<T = ()> {
-    /// The shared application state passed to the [`via::new`](crate::app::new)
+    /// The shared application state passed to the
+    /// [`via::app`](crate::app::app)
     /// function.
     ///
     state: Arc<T>,
@@ -134,7 +135,8 @@ impl<T> Request<T> {
     }
 
     /// Returns a thread-safe reference-counting pointer to the application
-    /// state that was passed as an argument to the [`via::new`](crate::app::new)
+    /// state that was passed as an argument to the
+    /// [`via::app`](crate::app::app)
     /// function.
     ///
     #[inline]

--- a/src/response/response.rs
+++ b/src/response/response.rs
@@ -39,7 +39,7 @@ impl Response {
     ///
     #[inline]
     pub fn map(self, map: impl FnOnce(HttpBody<ResponseBody>) -> BoxBody) -> Self {
-        if cfg!(debug_assertions) && matches!(self.body(), HttpBody::Mapped(_)) {
+        if cfg!(debug_assertions) && matches!(self.response.body(), HttpBody::Mapped(_)) {
             // TODO: Replace this with tracing and a proper logger.
             eprintln!("calling response.map() more than once can create a reference cycle.");
         }
@@ -48,16 +48,6 @@ impl Response {
             cookies: self.cookies,
             response: self.response.map(|body| HttpBody::Mapped(map(body))),
         }
-    }
-
-    #[inline]
-    pub fn body(&self) -> &HttpBody<ResponseBody> {
-        self.response.body()
-    }
-
-    #[inline]
-    pub fn body_mut(&mut self) -> &mut HttpBody<ResponseBody> {
-        self.response.body_mut()
     }
 
     /// Returns a reference to the response cookies.
@@ -113,10 +103,12 @@ impl Response {
     /// final processing that may be required before the response is sent to the
     /// client.
     ///
+    #[inline]
     pub(crate) fn into_inner(self) -> http::Response<HttpBody<ResponseBody>> {
         self.response
     }
 
+    #[inline]
     pub(crate) fn set_cookie_headers(&mut self) {
         let cookies = match &self.cookies {
             Some(jar) => jar,
@@ -150,7 +142,7 @@ impl Debug for Response {
             .field("status", &self.status())
             .field("headers", self.headers())
             .field("cookies", &self.cookies)
-            .field("body", self.body())
+            .field("body", self.response.body())
             .finish()
     }
 }

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -242,9 +242,9 @@ fn serve_request<T>(
     let body = HttpBody::Original(RequestBody::new(max_request_size, body));
 
     // Route the request to the corrosponding middleware stack.
-    let fut = match router.lookup(&mut params, head.uri.path()) {
+    let future = match router.lookup(&mut params, head.uri.path()) {
         // Call the middleware stack for the matched routes.
-        Ok(next) => next.call(Request::new(Arc::clone(state), head, params, body)),
+        Ok(next) => next.call(Request::new(Arc::clone(state), head, body, params)),
 
         // An error occurred while routing the request.
         Err(error) => {
@@ -261,7 +261,7 @@ fn serve_request<T>(
     async {
         // Await the response future. If an error occurs, generate a response
         // from the error.
-        let mut response = fut.await.unwrap_or_else(|e| e.into());
+        let mut response = future.await.unwrap_or_else(|e| e.into());
 
         // If any cookies changed during the request, serialize them to
         // Set-Cookie headers and include them in the response.

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -23,17 +23,17 @@ use crate::error::{BoxError, Error};
 use crate::request::{PathParams, Request};
 use crate::router::Router;
 
-pub async fn serve<State, A>(
+pub async fn serve<T, A>(
     listener: TcpListener,
     acceptor: A,
-    state: Arc<State>,
-    router: Arc<Router<State>>,
+    state: Arc<T>,
+    router: Arc<Router<T>>,
     max_connections: usize,
     max_request_size: usize,
     shutdown_timeout: Duration,
 ) -> Result<ExitCode, BoxError>
 where
-    State: Send + Sync + 'static,
+    T: Send + Sync + 'static,
     A: Acceptor + Send + Sync + 'static,
 {
     let (shutdown_tx, shutdown_rx, shutdown_task) = wait_for_shutdown();

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -27,9 +27,9 @@ const DEFAULT_SHUTDOWN_TIMEOUT: u64 = 30;
 
 /// Serve an app over HTTP.
 ///
-pub struct Server<State> {
-    state: Arc<State>,
-    router: Arc<Router<State>>,
+pub struct Server<T> {
+    state: Arc<T>,
+    router: Arc<Router<T>>,
     max_connections: Option<usize>,
     max_request_size: Option<usize>,
     shutdown_timeout: Option<u64>,
@@ -38,17 +38,17 @@ pub struct Server<State> {
     rustls_config: Option<rustls::ServerConfig>,
 }
 
-async fn listen<State, A>(
+async fn listen<T, A>(
     acceptor: A,
     address: impl ToSocketAddrs,
-    state: Arc<State>,
-    router: Arc<Router<State>>,
+    state: Arc<T>,
+    router: Arc<Router<T>>,
     max_connections: Option<usize>,
     max_request_size: Option<usize>,
     shutdown_timeout: Option<u64>,
 ) -> Result<ExitCode, BoxError>
 where
-    State: Send + Sync + 'static,
+    T: Send + Sync + 'static,
     A: Acceptor + Send + Sync + 'static,
 {
     let listener = TcpListener::bind(address).await?;


### PR DESCRIPTION
Yet another release with more API changes and improvements. This is the last set of breaking changes before a release candidate is cut.


- `via::new` was renamed to `via::app`.
- API consistency improvements (mostly non-breaking internal name changes).
- The total size of arguments passed to a middleware functions does not exceed 128.
- HttpBody now has a boxed method to make it easy to box request or response bodies with a 1 line middleware fn if that is important to you.