### PR TITLE
fix(via): server correctness improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-beta.27"
+version = "2.0.0-beta.28"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following to dependencies section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-via = "2.0.0-beta.27"
+via = "2.0.0-beta.28"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 

--- a/src/request/request.rs
+++ b/src/request/request.rs
@@ -11,7 +11,7 @@ use crate::body::{BoxBody, HttpBody, RequestBody};
 pub struct Request<T = ()> {
     /// The request's path and query parameters.
     ///
-    params: PathParams,
+    pub(crate) params: PathParams,
 
     /// The shared application state passed to the
     /// [`via::app`](crate::app::app)
@@ -21,7 +21,7 @@ pub struct Request<T = ()> {
 
     /// The component parts of the underlying HTTP request.
     ///
-    head: Box<Parts>,
+    pub(crate) head: Box<Parts>,
 
     /// The cookies associated with the request. If there is not a
     /// [CookieParser](crate::middleware::CookieParser)
@@ -161,18 +161,13 @@ impl<T> Request<T> {
 
 impl<T> Request<T> {
     #[inline]
-    pub(crate) fn new(
-        params: PathParams,
-        state: Arc<T>,
-        head: Box<Parts>,
-        body: HttpBody<RequestBody>,
-    ) -> Self {
+    pub(crate) fn new(state: Arc<T>, head: Box<Parts>, body: HttpBody<RequestBody>) -> Self {
         Self {
-            params,
             state,
             head,
             cookies: None,
             body,
+            params: PathParams::new(Vec::new()),
         }
     }
 

--- a/src/request/request.rs
+++ b/src/request/request.rs
@@ -9,6 +9,10 @@ use super::param::{PathParam, PathParams};
 use crate::body::{BoxBody, HttpBody, RequestBody};
 
 pub struct Request<T = ()> {
+    /// The request's path and query parameters.
+    ///
+    params: PathParams,
+
     /// The shared application state passed to the
     /// [`via::app`](crate::app::app)
     /// function.
@@ -19,20 +23,16 @@ pub struct Request<T = ()> {
     ///
     head: Box<Parts>,
 
-    /// A wrapper around the body of the request. This provides callers with
-    /// convienent methods for reading the request body.
-    ///
-    body: HttpBody<RequestBody>,
-
     /// The cookies associated with the request. If there is not a
     /// [CookieParser](crate::middleware::CookieParser)
     /// middleware in the middleware stack for the request, this will be empty.
     ///
     cookies: Option<Box<CookieJar>>,
 
-    /// The request's path and query parameters.
+    /// A wrapper around the body of the request. This provides callers with
+    /// convienent methods for reading the request body.
     ///
-    params: PathParams,
+    body: HttpBody<RequestBody>,
 }
 
 impl<T> Request<T> {
@@ -162,16 +162,16 @@ impl<T> Request<T> {
 impl<T> Request<T> {
     #[inline]
     pub(crate) fn new(
+        params: PathParams,
         state: Arc<T>,
         head: Box<Parts>,
         body: HttpBody<RequestBody>,
-        params: PathParams,
     ) -> Self {
         Self {
+            params,
             state,
             head,
             cookies: None,
-            params,
             body,
         }
     }
@@ -187,11 +187,11 @@ impl<T> Request<T> {
 impl<T> Debug for Request<T> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         f.debug_struct("Request")
+            .field("version", &self.version())
             .field("method", self.method())
             .field("uri", self.uri())
-            .field("params", &self.params)
-            .field("version", &self.version())
             .field("headers", self.headers())
+            .field("params", &self.params)
             .field("cookies", &self.cookies)
             .field("body", &self.body)
             .finish()

--- a/src/response/builder.rs
+++ b/src/response/builder.rs
@@ -65,8 +65,10 @@ impl Builder {
 
     #[inline]
     pub fn body(self, data: HttpBody<ResponseBody>) -> Result<Response, Error> {
-        let inner = self.inner.body(data)?;
-        Ok(Response::from_inner(inner))
+        Ok(Response {
+            cookies: None,
+            inner: self.inner.body(data)?,
+        })
     }
 
     pub fn json(self, data: &impl Serialize) -> Result<Response, Error> {

--- a/src/response/response.rs
+++ b/src/response/response.rs
@@ -7,7 +7,7 @@ use super::builder::Builder;
 use crate::body::{BoxBody, HttpBody, ResponseBody};
 
 pub struct Response {
-    pub(crate) cookies: Option<Box<CookieJar>>,
+    pub(crate) cookies: Option<CookieJar>,
     pub(crate) inner: http::Response<HttpBody<ResponseBody>>,
 }
 
@@ -53,7 +53,7 @@ impl Response {
     ///
     #[inline]
     pub fn cookies(&self) -> Option<&CookieJar> {
-        self.cookies.as_deref()
+        self.cookies.as_ref()
     }
 
     /// Returns a mutable reference to the response cookies.

--- a/src/router/router.rs
+++ b/src/router/router.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 use via_router::VisitError;
 
 use super::route::{MatchWhen, Route};
-use crate::middleware::Next;
 use crate::request::PathParams;
+use crate::Middleware;
 
 pub struct Router<T> {
     inner: via_router::Router<Vec<MatchWhen<T>>>,
@@ -20,9 +20,12 @@ impl<T> Router<T> {
         Route::new(self.inner.at(pattern))
     }
 
-    pub fn lookup(&self, params: &mut PathParams, path: &str) -> Result<Next<T>, VisitError> {
-        let mut stack = Vec::new();
-
+    pub fn lookup(
+        &self,
+        params: &mut PathParams,
+        stack: &mut Vec<Arc<dyn Middleware<T>>>,
+        path: &str,
+    ) -> Result<(), VisitError> {
         // Iterate over the routes that match the request's path.
         for result in self.inner.visit(path).into_iter().rev() {
             let found = result?;
@@ -59,6 +62,6 @@ impl<T> Router<T> {
             }
         }
 
-        Ok(Next::new(stack))
+        Ok(())
     }
 }

--- a/src/router/router.rs
+++ b/src/router/router.rs
@@ -22,8 +22,8 @@ impl<T> Router<T> {
 
     pub fn lookup(
         &self,
+        middlewares: &mut Vec<Arc<dyn Middleware<T>>>,
         params: &mut PathParams,
-        stack: &mut Vec<Arc<dyn Middleware<T>>>,
         path: &str,
     ) -> Result<(), VisitError> {
         // Iterate over the routes that match the request's path.
@@ -58,7 +58,7 @@ impl<T> Router<T> {
                 // exact match and the visited node is not a leaf.
                 MatchWhen::Exact(_) => None,
             }) {
-                stack.push(Arc::clone(middleware));
+                middlewares.push(Arc::clone(middleware));
             }
         }
 

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -161,16 +161,16 @@ where
                     // Return the permit back to the semaphore.
                     drop(permit);
 
+                    if let Err(error) = result {
+                        // Placeholder for tracing...
+                        let _ = error;
+                    }
+
                     // Assert that the connection did not move in debug mode by
                     // attempting to borrow it mutably.
                     if cfg!(debug_assertions) {
                         #[allow(clippy::let_underscore_future)]
                         let _ = &mut connection;
-                    }
-
-                    if let Err(error) = result {
-                        // Placeholder for tracing...
-                        let _ = error;
                     }
                 });
             }


### PR DESCRIPTION
A number of non-breaking changes that improve the stability and correctness of the server. Namely, allocations are hoisted in `serve_request`, there is less branching in `serve_request`, request is constructed before routes are matched, and an assertion that connections did not move after being polled in debug mode.