### PR TITLE
chore(via): bump the version to 2.0.0-rc.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ percent-encoding = "2.3"
 serde = "1"
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "signal"] }
-via-router = "3.0.0-beta.10"
+via-router = { path = "crates/via-router" }
 
 [dependencies.cookie]
 version = "0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -26,7 +26,7 @@ percent-encoding = "2.3"
 serde = "1"
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "signal"] }
-via-router = { path = "crates/via-router" }
+via-router = "3.0.0-beta.11"
 
 [dependencies.cookie]
 version = "0.18"

--- a/crates/via-router/Cargo.toml
+++ b/crates/via-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via-router"
-version = "3.0.0-beta.10"
+version = "3.0.0-beta.11"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -2,7 +2,7 @@ pub mod param;
 
 mod request;
 
-pub use param::PathParam;
+pub use param::{PathParam, QueryParam};
 pub use request::Request;
 
 pub(crate) use param::PathParams;

--- a/src/request/param/mod.rs
+++ b/src/request/param/mod.rs
@@ -1,8 +1,11 @@
 mod decode;
 mod path_param;
 mod path_params;
+mod query_param;
+mod query_parser;
 
 pub(crate) use path_params::PathParams;
 
 pub use decode::PercentDecode;
 pub use path_param::PathParam;
+pub use query_param::{QueryParam, QueryParamIter};

--- a/src/request/param/path_params.rs
+++ b/src/request/param/path_params.rs
@@ -5,22 +5,22 @@ use std::slice;
 use via_router::Param;
 
 pub struct PathParams {
-    data: Vec<(Param, (usize, usize))>,
+    data: Vec<(Param, Option<(usize, usize)>)>,
 }
 
 impl PathParams {
     #[inline]
-    pub const fn new(data: Vec<(Param, (usize, usize))>) -> Self {
+    pub const fn new(data: Vec<(Param, Option<(usize, usize)>)>) -> Self {
         Self { data }
     }
 
     #[inline]
-    pub fn iter(&self) -> slice::Iter<(Param, (usize, usize))> {
+    pub fn iter(&self) -> slice::Iter<(Param, Option<(usize, usize)>)> {
         self.data.iter()
     }
 
     #[inline]
-    pub fn push(&mut self, param: (Param, (usize, usize))) {
+    pub fn push(&mut self, param: (Param, Option<(usize, usize)>)) {
         self.data.push(param);
     }
 }

--- a/src/request/param/query_param.rs
+++ b/src/request/param/query_param.rs
@@ -1,0 +1,100 @@
+use std::borrow::Cow;
+use std::marker::PhantomData;
+
+use super::decode::{DecodeParam, NoopDecode, PercentDecode};
+use super::path_param::PathParam;
+use super::query_parser::QueryParser;
+
+pub struct QueryParam<'a, 'b, T = NoopDecode> {
+    name: &'b str,
+    parser: QueryParser<'a>,
+    _decode: PhantomData<T>,
+}
+
+pub struct QueryParamIter<'a, 'b, T> {
+    name: &'b str,
+    parser: QueryParser<'a>,
+    _decode: PhantomData<T>,
+}
+
+fn find_next(parser: &mut QueryParser, name: &str) -> Option<Option<(usize, usize)>> {
+    parser.find_map(|(n, at)| if n == name { Some(at) } else { None })
+}
+
+impl<'a, 'b, T: DecodeParam> QueryParam<'a, 'b, T> {
+    /// Returns a new `QueryParam` that will decode parameter values with
+    /// `U::decode` when an individual parameter is converted to a result.
+    ///
+    pub fn decode<U: DecodeParam>(self) -> QueryParam<'a, 'b, U> {
+        QueryParam {
+            name: self.name,
+            parser: self.parser,
+            _decode: PhantomData,
+        }
+    }
+
+    /// Returns a new `QueryParam` that will percent-decode parameter values
+    /// when an individual parameter is converted to a result.
+    ///
+    pub fn percent_decode(self) -> QueryParam<'a, 'b, PercentDecode> {
+        self.decode()
+    }
+
+    pub fn exists(mut self) -> bool {
+        self.parser.any(|(n, _)| n == self.name)
+    }
+
+    pub fn first(mut self) -> PathParam<'a, 'b, T> {
+        let name = self.name;
+        let query = self.parser.input();
+
+        PathParam::new(name, query, find_next(&mut self.parser, name))
+    }
+
+    pub fn last(self) -> PathParam<'a, 'b, T> {
+        let query = self.parser.input();
+        let name = self.name;
+
+        PathParam::new(
+            name,
+            query,
+            self.parser
+                .filter_map(|(n, at)| if n == name { Some(at) } else { None })
+                .last(),
+        )
+    }
+}
+
+impl<'a, 'b, T: DecodeParam> QueryParam<'a, 'b, T> {
+    pub(crate) fn new(name: &'b str, query: &'a str) -> Self {
+        Self {
+            name,
+            parser: QueryParser::new(query),
+            _decode: PhantomData,
+        }
+    }
+}
+
+impl<'a, 'b, T: DecodeParam> IntoIterator for QueryParam<'a, 'b, T> {
+    type Item = Cow<'a, str>;
+    type IntoIter = QueryParamIter<'a, 'b, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        QueryParamIter {
+            name: self.name,
+            parser: self.parser,
+            _decode: PhantomData,
+        }
+    }
+}
+
+impl<'a, T: DecodeParam> Iterator for QueryParamIter<'a, '_, T> {
+    type Item = Cow<'a, str>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let (start, end) = find_next(&mut self.parser, self.name)??;
+        let encoded = self.parser.input().get(start..end)?;
+
+        T::decode(encoded).ok()
+    }
+}

--- a/src/request/param/query_parser.rs
+++ b/src/request/param/query_parser.rs
@@ -1,0 +1,198 @@
+use percent_encoding::percent_decode_str;
+use std::borrow::Cow;
+
+type QueryParserOutput<'a> = (Cow<'a, str>, Option<(usize, usize)>);
+
+pub struct QueryParser<'a> {
+    input: &'a str,
+    from: usize,
+}
+
+fn decode(input: &str) -> Cow<str> {
+    percent_decode_str(input).decode_utf8_lossy()
+}
+
+fn take_name(input: &str, from: usize) -> (usize, Option<Cow<str>>) {
+    // Get the length of the input. We'll use this value as the end index if we
+    // reach the end of the input.
+    let len = input.len();
+    // Get the start index of the name by finding the next byte that is not an
+    // `&`. Then, map the index to a tuple containing both the start and end
+    // index of the query parameter name.
+    let at = take_while(input, from, |byte| byte == b'&').map(|start| {
+        // Continue consuming the input until we reach the terminating `=`.
+        match take_while(input, start, |byte| byte != b'=') {
+            // If we find the terminating `=`, return the complete range.
+            Some(end) => (start, end),
+            // Otherwise, return the start index and the length of the input.
+            None => (start, len),
+        }
+    });
+
+    match at {
+        Some((start, end)) => (end, input.get(start..end).map(decode)),
+        None => (len, None),
+    }
+}
+
+fn take_value(input: &str, from: usize) -> (usize, Option<(usize, usize)>) {
+    // Get the length of the input. We'll use this value as the end index if we
+    // reach the end of the input.
+    let len = input.len();
+    // Get the start index of the name by finding the next byte that is not an
+    // `=`. Then, map the index to a tuple containing both the start and end
+    // index of the query parameter value.
+    let at = take_while(input, from, |byte| byte == b'=').map(|start| {
+        // Continue consuming the input until we reach the terminating `&`.
+        match take_while(input, start, |byte| byte != b'&') {
+            // If we find the terminating `&`, return the complete range.
+            Some(end) => (start, end),
+            // Otherwise, return the start index and the length of the input.
+            None => (start, len),
+        }
+    });
+
+    match at {
+        Some((_, end)) => (end, at),
+        None => (len, None),
+    }
+}
+
+fn take_while(input: &str, from: usize, f: impl Fn(u8) -> bool) -> Option<usize> {
+    let rest = input.get(from..)?;
+
+    rest.bytes()
+        .enumerate()
+        .find_map(|(to, byte)| if !f(byte) { from.checked_add(to) } else { None })
+}
+
+impl<'a> QueryParser<'a> {
+    pub fn new(input: &'a str) -> Self {
+        Self { input, from: 0 }
+    }
+
+    pub fn input(&self) -> &'a str {
+        self.input
+    }
+}
+
+impl<'a> Iterator for QueryParser<'a> {
+    type Item = QueryParserOutput<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let (start, name) = take_name(self.input, self.from);
+        let (end, at) = take_value(self.input, start);
+
+        self.from = end;
+
+        name.zip(Some(at))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::QueryParser;
+
+    static QUERY_STRINGS: [&str; 21] = [
+        "query=books&category=fiction&sort=asc",
+        "query=hello%20world&category=%E2%9C%93",
+        "category=books&category=electronics&category=clothing",
+        "query=books&category=",
+        "query=100%25%20organic&category=food",
+        "query=books&filter={\"price\":\"low\",\"rating\":5}",
+        "items[]=book&items[]=pen&items[]=notebook",
+        "",
+        "data={\"name\":\"John\",\"age\":30,\"city\":\"New York\"}",
+        "query=books&category=fiction#section2",
+        // Invalid query strings
+        "query=books&&category=fiction", // Double ampersand
+        "query==books&category=fiction", // Double equal sign
+        "query=books&category",          // Key without value
+        "query=books&=fiction",          // Value without key
+        "query=books&category=fiction&", // Trailing ampersand
+        // Percent-encoded keys
+        "qu%65ry=books&ca%74egory=fiction",
+        "%71uery=books&%63ategory=fiction",
+        "query=books&ca%74egory=fic%74ion",
+        // Invalid UTF-8 characters (using percent-encoded bytes that don't form valid UTF-8 sequences)
+        "query=books&category=%80%80%80",    // Overlong encoding
+        "query=books&category=%C3%28",       // Invalid UTF-8 sequence in value
+        "query%C3%28=books&category=%C3%28", // Invalid UTF-8 sequence in key
+    ];
+
+    fn get_expected_results() -> [Vec<(&'static str, Option<(usize, usize)>)>; 21] {
+        [
+            vec![
+                ("query", Some((6, 11))),
+                ("category", Some((21, 28))),
+                ("sort", Some((34, 37))),
+            ],
+            vec![("query", Some((6, 19))), ("category", Some((29, 38)))],
+            vec![
+                ("category", Some((9, 14))),
+                ("category", Some((24, 35))),
+                ("category", Some((45, 53))),
+            ],
+            vec![("query", Some((6, 11))), ("category", None)],
+            vec![("query", Some((6, 22))), ("category", Some((32, 36)))],
+            vec![("query", Some((6, 11))), ("filter", Some((19, 45)))],
+            vec![
+                ("items[]", Some((8, 12))),
+                ("items[]", Some((21, 24))),
+                ("items[]", Some((33, 41))),
+            ],
+            vec![],
+            vec![("data", Some((5, 47)))],
+            vec![("query", Some((6, 11))), ("category", Some((21, 37)))],
+            vec![("query", Some((6, 11))), ("category", Some((22, 29)))],
+            vec![("query", Some((7, 12))), ("category", Some((22, 29)))],
+            vec![("query", Some((6, 11))), ("category", None)],
+            vec![("query", Some((6, 11))), ("", Some((13, 20)))],
+            vec![("query", Some((6, 11))), ("category", Some((21, 28)))],
+            vec![("query", Some((8, 13))), ("category", Some((25, 32)))],
+            vec![("query", Some((8, 13))), ("category", Some((25, 32)))],
+            vec![("query", Some((6, 11))), ("category", Some((23, 32)))],
+            vec![("query", Some((6, 11))), ("category", Some((21, 30)))],
+            vec![("query", Some((6, 11))), ("category", Some((21, 27)))],
+            vec![("query�(", Some((12, 17))), ("category", Some((27, 33)))],
+        ]
+    }
+
+    #[test]
+    fn parse_query_params_test() {
+        let expected_results = get_expected_results();
+
+        for (expected_result_index, query) in QUERY_STRINGS.iter().enumerate() {
+            let mut actual_result = vec![];
+            let expected_result = &expected_results[expected_result_index];
+
+            actual_result.extend(QueryParser::new(query));
+
+            assert_eq!(
+                actual_result.len(),
+                expected_result.len(),
+                "Expected {} to have {} entries. Got {} instead. Query: '{}'.",
+                expected_result_index,
+                expected_result.len(),
+                actual_result.len(),
+                query
+            );
+
+            for (entry_index, (name, at)) in actual_result.into_iter().enumerate() {
+                let expect = expected_result[entry_index];
+
+                assert_eq!(
+                    name, expect.0,
+                    "Expected name at index [{}, {}] to be {}. Got {} instead.",
+                    expected_result_index, entry_index, expect.0, name
+                );
+
+                assert_eq!(
+                    at, expect.1,
+                    "Expected range at index [{}, {}] to be {:?}. Got {:?} instead.",
+                    expected_result_index, entry_index, expect.1, at
+                );
+            }
+        }
+    }
+}

--- a/src/router/router.rs
+++ b/src/router/router.rs
@@ -33,8 +33,8 @@ impl<T> Router<T> {
             // If there is a dynamic parameter name associated with the route,
             // build a tuple containing the name and the range of the parameter
             // value in the request's path.
-            if let Some((name, Some(at))) = found.param {
-                params.push((name, at));
+            if let Some(name) = found.param {
+                params.push((name.clone(), found.range));
             }
 
             let route = match found.route.and_then(|key| self.inner.get(key)) {


### PR DESCRIPTION
Taking a break for a couple days after this. Brings back query params, fixes a bug where catch-all patterns at the root are not matched, avoids atomic operations in recursive contexts, and prefers constructing Request to prevent moving params around.