### PR TITLE
feat(via): boxed-request-head is a default feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,15 @@ homepage = "https://github.com/zacharygolba/via"
 repository = "https://github.com/zacharygolba/via"
 
 [features]
-default = ["http1"]
+default = ["box-request-head", "http1"]
+
+# Allocate the request head on the heap to reduce the size of Request. This is
+# an optimization.
+box-request-head = []
+
 http1 = ["hyper/http1"]
 http2 = ["hyper/http2"]
+
 rustls = ["dep:tokio-rustls"]
 
 [dependencies]
@@ -26,7 +32,7 @@ percent-encoding = "2.3"
 serde = "1"
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "signal"] }
-via-router = "3.0.0-beta.11"
+via-router = { path = "crates/via-router" }
 
 [dependencies.cookie]
 version = "0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-rc.6"
+version = "2.0.0-rc.7"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,13 +23,13 @@ http2 = ["hyper/http2"]
 rustls = ["dep:tokio-rustls"]
 
 [dependencies]
-bytes = "1.9"
+bytes = "1"
 futures-core = { version = "0.3", default-features = false }
 http = "1"
 http-body = "1"
-hyper = { version = "1.4", features = ["server"] }
+hyper = { version = "1", features = ["server"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
-percent-encoding = "2.3"
+percent-encoding = "2"
 serde = "1"
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "signal"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ repository = "https://github.com/zacharygolba/via"
 default = ["box-request-head", "http1"]
 
 # Allocate the request head on the heap to reduce the size of Request. This is
-# an optimization.
+# an optimization for apps that typically have 3 or more middleware functions
+# on average per-route.
 box-request-head = []
 
 http1 = ["hyper/http1"]
@@ -32,7 +33,7 @@ percent-encoding = "2.3"
 serde = "1"
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "signal"] }
-via-router = { path = "crates/via-router" }
+via-router = "3.0.0-beta.12"
 
 [dependencies.cookie]
 version = "0.18"

--- a/crates/via-router/Cargo.toml
+++ b/crates/via-router/Cargo.toml
@@ -9,5 +9,4 @@ homepage = "https://github.com/zacharygolba/via"
 repository = "https://github.com/zacharygolba/via"
 
 [dependencies]
-tinyvec = { version = "1.8", features = ["alloc"] }
-
+smallvec = "1.13.2"

--- a/crates/via-router/Cargo.toml
+++ b/crates/via-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via-router"
-version = "3.0.0-beta.11"
+version = "3.0.0-beta.12"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/crates/via-router/src/lib.rs
+++ b/crates/via-router/src/lib.rs
@@ -7,7 +7,7 @@ mod visitor;
 pub use path::Param;
 pub use visitor::{Found, VisitError};
 
-use tinyvec::TinyVec;
+use smallvec::SmallVec;
 
 use path::{Pattern, Segments};
 use routes::{Node, RouteEntry};
@@ -59,7 +59,7 @@ impl<T> Router<T> {
 
         // Split path into segment ranges and collect them into a vec.
         let segments = {
-            let mut parts = TinyVec::new();
+            let mut parts = SmallVec::new();
 
             path::split(&mut parts, path);
             Segments::new(path, parts)

--- a/crates/via-router/src/path.rs
+++ b/crates/via-router/src/path.rs
@@ -1,6 +1,6 @@
+use smallvec::SmallVec;
 use std::fmt::{self, Display, Formatter};
 use std::sync::Arc;
-use tinyvec::TinyVec;
 
 #[derive(Debug, PartialEq)]
 pub enum Pattern {
@@ -17,13 +17,13 @@ pub struct Param {
 
 pub struct Segments<'a> {
     value: &'a str,
-    parts: TinyVec<[(usize, usize); 2]>,
+    parts: SmallVec<[(usize, usize); 2]>,
 }
 
 /// Returns an iterator that yields a `Pattern` for each segment in the uri path.
 ///
 pub fn patterns(path: &'static str) -> impl Iterator<Item = Pattern> {
-    let mut segments = TinyVec::new();
+    let mut segments = SmallVec::new();
 
     split(&mut segments, path);
     segments.into_iter().map(|(start, end)| {
@@ -60,7 +60,7 @@ pub fn patterns(path: &'static str) -> impl Iterator<Item = Pattern> {
 
 /// Accumulate path segment ranges as a [Span] from path into segments.
 ///
-pub fn split(parts: &mut TinyVec<[(usize, usize); 2]>, path: &str) {
+pub fn split(parts: &mut SmallVec<[(usize, usize); 2]>, path: &str) {
     // True if parts is allocated on the heap.
     let mut spilled = false;
 
@@ -136,7 +136,7 @@ impl PartialEq<str> for Param {
 
 impl<'a> Segments<'a> {
     #[inline]
-    pub fn new(value: &'a str, parts: TinyVec<[(usize, usize); 2]>) -> Self {
+    pub fn new(value: &'a str, parts: SmallVec<[(usize, usize); 2]>) -> Self {
         Self { value, parts }
     }
 
@@ -169,7 +169,7 @@ impl<'a> Segments<'a> {
 
 #[cfg(test)]
 mod tests {
-    use tinyvec::TinyVec;
+    use smallvec::SmallVec;
 
     const PATHS: [&str; 16] = [
         "/home/about",
@@ -216,7 +216,7 @@ mod tests {
         let expected_results = get_expected_results();
 
         for (path_index, path_value) in PATHS.iter().enumerate() {
-            let mut segments = TinyVec::new();
+            let mut segments = SmallVec::new();
 
             super::split(&mut segments, path_value);
 

--- a/src/middleware/next.rs
+++ b/src/middleware/next.rs
@@ -25,3 +25,10 @@ impl<T> Next<T> {
         }
     }
 }
+
+impl<T> Next<T> {
+    #[inline]
+    pub(crate) fn push(&mut self, middleware: Arc<dyn Middleware<T>>) {
+        self.stack.push(middleware);
+    }
+}

--- a/src/request/param/path_params.rs
+++ b/src/request/param/path_params.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::type_complexity)]
-
 use std::fmt::{self, Debug, Formatter};
 use std::slice;
 use via_router::Param;
@@ -17,6 +15,11 @@ impl PathParams {
     #[inline]
     pub fn iter(&self) -> slice::Iter<(Param, Option<(usize, usize)>)> {
         self.data.iter()
+    }
+
+    #[inline]
+    pub fn push(&mut self, param: (Param, Option<(usize, usize)>)) {
+        self.data.push(param);
     }
 }
 

--- a/src/request/request.rs
+++ b/src/request/request.rs
@@ -213,36 +213,16 @@ impl<T> Request<T> {
 }
 
 impl<T> Request<T> {
-    #[cfg(not(feature = "box-request-head"))]
     #[inline]
-    pub(crate) fn new(
-        state: Arc<T>,
-        params: PathParams,
-        head: Box<Parts>,
-        body: HttpBody<RequestBody>,
-    ) -> Self {
+    pub(crate) fn new(state: Arc<T>, head: Parts, body: HttpBody<RequestBody>) -> Self {
         Self {
             state,
             cookies: None,
-            params,
+            params: PathParams::new(Vec::with_capacity(3)),
+            #[cfg(not(feature = "box-request-head"))]
             head,
-            body,
-        }
-    }
-
-    #[cfg(feature = "box-request-head")]
-    #[inline]
-    pub(crate) fn new(
-        state: Arc<T>,
-        params: PathParams,
-        head: Box<Parts>,
-        body: HttpBody<RequestBody>,
-    ) -> Self {
-        Self {
-            state,
-            cookies: None,
-            params,
-            head,
+            #[cfg(feature = "box-request-head")]
+            head: Box::new(head),
             body,
         }
     }
@@ -252,6 +232,13 @@ impl<T> Request<T> {
     #[inline]
     pub(crate) fn cookies_mut(&mut self) -> &mut CookieJar {
         self.cookies.get_or_insert_default()
+    }
+
+    /// Returns a mutable reference to the cookies associated with the request.
+    ///
+    #[inline]
+    pub(crate) fn path_and_params_mut(&mut self) -> (&str, &mut PathParams) {
+        (self.head.uri.path(), &mut self.params)
     }
 }
 

--- a/src/request/request.rs
+++ b/src/request/request.rs
@@ -16,20 +16,29 @@ pub struct Request<T = ()> {
     ///
     state: Arc<T>,
 
+    /// The component parts of the HTTP request.
+    ///
+    #[cfg(feature = "box-request-head")]
+    head: Box<Parts>,
+
+    /// The component parts of the HTTP request.
+    ///
+    #[cfg(not(feature = "box-request-head"))]
+    head: Parts,
+
+    /// A length-limited, mappable wrapper around [hyper::body::Incoming].
+    ///
+    body: HttpBody<RequestBody>,
+
     /// The cookies associated with the request. If there is not a
     /// [CookieParser](crate::middleware::CookieParser)
     /// middleware in the middleware stack for the request, this will be empty.
     ///
-    cookies: Option<CookieJar>,
+    cookies: Option<Box<CookieJar>>,
 
     /// The request's path and query parameters.
     ///
     params: PathParams,
-
-    /// A wrapper around the body of the request. This provides callers with
-    /// convienent methods for reading the request body.
-    ///
-    inner: http::Request<HttpBody<RequestBody>>,
 }
 
 impl<T> Request<T> {
@@ -38,13 +47,13 @@ impl<T> Request<T> {
     ///
     #[inline]
     pub fn map(self, map: impl FnOnce(HttpBody<RequestBody>) -> BoxBody) -> Self {
-        if cfg!(debug_assertions) && matches!(self.inner.body(), HttpBody::Mapped(_)) {
+        if cfg!(debug_assertions) && matches!(&self.body, HttpBody::Mapped(_)) {
             // TODO: Replace this with tracing and a proper logger.
             eprintln!("calling request.map() more than once can create a reference cycle.",);
         }
 
         Self {
-            inner: self.inner.map(|body| HttpBody::Mapped(map(body))),
+            body: HttpBody::Mapped(map(self.body)),
             ..self
         }
     }
@@ -53,43 +62,53 @@ impl<T> Request<T> {
     ///
     #[inline]
     pub fn into_body(self) -> HttpBody<RequestBody> {
-        self.inner.into_body()
+        self.body
     }
 
     /// Consumes the request and returns a tuple containing the component
     /// parts of the request and the request body.
     ///
+    #[cfg(feature = "box-request-head")]
     #[inline]
     pub fn into_parts(self) -> (Parts, HttpBody<RequestBody>) {
-        self.inner.into_parts()
+        (*self.head, self.body)
+    }
+
+    /// Consumes the request and returns a tuple containing the component
+    /// parts of the request and the request body.
+    ///
+    #[cfg(not(feature = "box-request-head"))]
+    #[inline]
+    pub fn into_parts(self) -> (Parts, HttpBody<RequestBody>) {
+        (self.head, self.body)
     }
 
     /// Returns a reference to the body associated with the request.
     ///
     #[inline]
     pub fn body(&self) -> &HttpBody<RequestBody> {
-        self.inner.body()
+        &self.body
     }
 
     /// Returns an optional reference to the cookie with the provided `name`.
     ///
     #[inline]
     pub fn cookie(&self, name: &str) -> Option<&Cookie<'static>> {
-        self.cookies.as_ref()?.get(name)
+        self.cookies()?.get(name)
     }
 
     /// Returns an optional reference to the cookies associated with the request.
     ///
     #[inline]
     pub fn cookies(&self) -> Option<&CookieJar> {
-        self.cookies.as_ref()
+        self.cookies.as_deref()
     }
 
     /// Returns a reference to the header value associated with the key.
     ///
     #[inline]
     pub fn header<K: AsHeaderName>(&self, key: K) -> Option<&HeaderValue> {
-        self.inner.headers().get(key)
+        self.head.headers.get(key)
     }
 
     /// Returns a reference to a map that contains the headers associated with
@@ -97,14 +116,14 @@ impl<T> Request<T> {
     ///
     #[inline]
     pub fn headers(&self) -> &HeaderMap {
-        self.inner.headers()
+        &self.head.headers
     }
 
     /// Returns a reference to the HTTP method associated with the request.
     ///
     #[inline]
     pub fn method(&self) -> &Method {
-        self.inner.method()
+        &self.head.method
     }
 
     /// Returns a convenient wrapper around an optional reference to the path
@@ -125,7 +144,7 @@ impl<T> Request<T> {
     pub fn param<'a>(&self, name: &'a str) -> PathParam<'_, 'a> {
         PathParam::new(
             name,
-            self.inner.uri().path(),
+            self.head.uri.path(),
             self.params.iter().rev().find_map(
                 |(param, at)| {
                     if param == name {
@@ -165,7 +184,7 @@ impl<T> Request<T> {
     ///
     #[inline]
     pub fn query<'a>(&self, name: &'a str) -> QueryParam<'_, 'a> {
-        QueryParam::new(name, self.inner.uri().query().unwrap_or(""))
+        QueryParam::new(name, self.head.uri.query().unwrap_or(""))
     }
 
     /// Returns a thread-safe reference-counting pointer to the application
@@ -182,29 +201,49 @@ impl<T> Request<T> {
     ///
     #[inline]
     pub fn uri(&self) -> &Uri {
-        self.inner.uri()
+        &self.head.uri
     }
 
     /// Returns the HTTP version associated with the request.
     ///
     #[inline]
     pub fn version(&self) -> Version {
-        self.inner.version()
+        self.head.version
     }
 }
 
 impl<T> Request<T> {
+    #[cfg(not(feature = "box-request-head"))]
     #[inline]
     pub(crate) fn new(
         state: Arc<T>,
         params: PathParams,
-        request: http::Request<HttpBody<RequestBody>>,
+        head: Box<Parts>,
+        body: HttpBody<RequestBody>,
     ) -> Self {
         Self {
             state,
             cookies: None,
             params,
-            inner: request,
+            head,
+            body,
+        }
+    }
+
+    #[cfg(feature = "box-request-head")]
+    #[inline]
+    pub(crate) fn new(
+        state: Arc<T>,
+        params: PathParams,
+        head: Box<Parts>,
+        body: HttpBody<RequestBody>,
+    ) -> Self {
+        Self {
+            state,
+            cookies: None,
+            params,
+            head,
+            body,
         }
     }
 
@@ -219,13 +258,13 @@ impl<T> Request<T> {
 impl<T> Debug for Request<T> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         f.debug_struct("Request")
-            .field("version", &self.inner.version())
-            .field("method", self.inner.method())
-            .field("uri", self.inner.uri())
-            .field("headers", self.inner.headers())
+            .field("version", &self.version())
+            .field("method", self.method())
+            .field("uri", self.uri())
+            .field("headers", self.headers())
             .field("params", &self.params)
             .field("cookies", &self.cookies)
-            .field("body", self.inner.body())
+            .field("body", self.body())
             .finish()
     }
 }

--- a/src/response/response.rs
+++ b/src/response/response.rs
@@ -8,7 +8,7 @@ use super::builder::Builder;
 use crate::body::{BoxBody, HttpBody, ResponseBody};
 
 pub struct Response {
-    pub(super) cookies: Option<CookieJar>,
+    pub(super) cookies: Option<Box<CookieJar>>,
     pub(super) inner: http::Response<HttpBody<ResponseBody>>,
 }
 
@@ -54,7 +54,7 @@ impl Response {
     ///
     #[inline]
     pub fn cookies(&self) -> Option<&CookieJar> {
-        self.cookies.as_ref()
+        self.cookies.as_deref()
     }
 
     /// Returns a mutable reference to the response cookies.

--- a/src/router/router.rs
+++ b/src/router/router.rs
@@ -20,8 +20,7 @@ impl<T> Router<T> {
         Route::new(self.inner.at(pattern))
     }
 
-    pub fn lookup(&self, path: &str) -> Result<(PathParams, Next<T>), VisitError> {
-        let mut params = PathParams::new(Vec::with_capacity(3));
+    pub fn lookup(&self, path: &str, params: &mut PathParams) -> Result<Next<T>, VisitError> {
         let mut next = Next::new(Vec::with_capacity(8));
 
         // Iterate over the routes that match the request's path.
@@ -60,6 +59,6 @@ impl<T> Router<T> {
             }
         }
 
-        Ok((params, next))
+        Ok(next)
     }
 }

--- a/src/router/router.rs
+++ b/src/router/router.rs
@@ -21,8 +21,8 @@ impl<T> Router<T> {
     }
 
     pub fn lookup(&self, path: &str) -> Result<(PathParams, Next<T>), VisitError> {
-        let mut params = Vec::new();
-        let mut stack = Vec::new();
+        let mut params = PathParams::new(Vec::with_capacity(3));
+        let mut next = Next::new(Vec::with_capacity(8));
 
         // Iterate over the routes that match the request's path.
         for result in self.inner.visit(path).into_iter().rev() {
@@ -56,10 +56,10 @@ impl<T> Router<T> {
                 // exact match and the visited node is not a leaf.
                 MatchWhen::Exact(_) => None,
             }) {
-                stack.push(Arc::clone(middleware));
+                next.push(Arc::clone(middleware));
             }
         }
 
-        Ok((PathParams::new(params), Next::new(stack)))
+        Ok((params, next))
     }
 }

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -1,0 +1,13 @@
+use std::error::Error;
+use std::fmt::{self, Display, Formatter};
+
+#[derive(Debug)]
+pub struct ServiceError;
+
+impl Error for ServiceError {}
+
+impl Display for ServiceError {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "internal server error")
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2,6 +2,7 @@
 //!
 
 mod acceptor;
+mod error;
 mod io_stream;
 mod serve;
 mod server;


### PR DESCRIPTION
Brings a number of stability improvements to the accept loop and service function.
  - Connections are boxed and pinned and do never move out from the pinned reference.
  - The shutdown channel is no longer passed to the service_fn.
  - Data is constructed in and stays in the request type until used in user land.

Adds a default feature flag to allocate the request head (`http::request::Parts`) on the heap.
  - This is an assumed optimization for apps with 3 or more middleware functions per route.

No breaking changes in userland.