### PR TITLE
fix(via): do not set cookie headers in the service_fn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-rc.8"
+version = "2.0.0-rc.9"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following to dependencies section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-via = "2.0.0-rc.8"
+via = "2.0.0-rc.9"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,10 +1,8 @@
-use std::sync::Arc;
-
 use crate::middleware::Middleware;
 use crate::router::{Route, Router};
 
 pub struct App<T> {
-    pub(crate) state: Arc<T>,
+    pub(crate) state: T,
     pub(crate) router: Router<T>,
 }
 
@@ -12,7 +10,7 @@ pub struct App<T> {
 ///
 pub fn app<T>(state: T) -> App<T> {
     App {
-        state: Arc::new(state),
+        state,
         router: Router::new(),
     }
 }

--- a/src/middleware/cookie_parser.rs
+++ b/src/middleware/cookie_parser.rs
@@ -91,10 +91,11 @@ fn cookie_parser<P: ParseCookies, T>() -> impl Middleware<T> {
             }
         }
 
+        // Call the next middleware to get a response.
         let future = next.call(request);
 
         async {
-            // Call the next middleware to get a response.
+            // Await the response future.
             let mut response = future.await?;
 
             if let Some(cookies) = existing {
@@ -103,6 +104,10 @@ fn cookie_parser<P: ParseCookies, T>() -> impl Middleware<T> {
                     jar.add_original(cookie);
                 }
             }
+
+            // If any cookies changed during the request, serialize them to
+            // Set-Cookie headers and include them in the response headers.
+            response.set_cookie_headers();
 
             // Return the response.
             Ok(response)

--- a/src/server/io_stream.rs
+++ b/src/server/io_stream.rs
@@ -24,18 +24,15 @@ impl<T> IoStream<T> {
 
 impl<T> IoStream<T> {
     fn project(self: Pin<&mut Self>) -> Pin<&mut T> {
-        // Get a pinned mutable reference to `self.stream` from a pinned mutable
-        // reference to `self`.
+        // Get a pinned mutable reference to `self.stream` from a pinned
+        // mutable reference to `self`.
         //
         // Safety:
         //
         // This is safe because data is never moved out of self or
         // `self.stream`.
         //
-        unsafe {
-            let this = self.get_unchecked_mut();
-            Pin::new_unchecked(&mut this.stream)
-        }
+        unsafe { Pin::map_unchecked_mut(self, |this| &mut this.stream) }
     }
 }
 

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -1,6 +1,5 @@
 use std::future::Future;
 use std::process::ExitCode;
-use std::sync::Arc;
 use std::time::Duration;
 use tokio::net::{TcpListener, ToSocketAddrs};
 
@@ -28,8 +27,8 @@ const DEFAULT_SHUTDOWN_TIMEOUT: u64 = 30;
 /// Serve an app over HTTP.
 ///
 pub struct Server<T> {
-    state: Arc<T>,
-    router: Arc<Router<T>>,
+    state: T,
+    router: Router<T>,
     max_connections: Option<usize>,
     max_request_size: Option<usize>,
     shutdown_timeout: Option<u64>,
@@ -41,8 +40,8 @@ pub struct Server<T> {
 async fn listen<T, A>(
     acceptor: A,
     address: impl ToSocketAddrs,
-    state: Arc<T>,
-    router: Arc<Router<T>>,
+    state: T,
+    router: Router<T>,
     max_connections: Option<usize>,
     max_request_size: Option<usize>,
     shutdown_timeout: Option<u64>,
@@ -87,7 +86,7 @@ where
     pub fn new(app: App<State>) -> Self {
         Self {
             state: app.state,
-            router: Arc::new(app.router),
+            router: app.router,
             #[cfg(feature = "rustls")]
             rustls_config: None,
             max_connections: None,
@@ -150,7 +149,7 @@ where
         // Confirm that rustls_config exists before proceeding.
 
         let tls_config = match self.rustls_config {
-            Some(config) => Arc::new(config),
+            Some(config) => config.into(),
             None => panic!("rustls_config is required to use the 'rustls' feature"),
         };
 


### PR DESCRIPTION
Moves the call to `set_cookie_headers` outside of the main service function. This prevents cookies from being set if there isn't a [`cookie_parser`](https://github.com/zacharygolba/via/blob/main/src/middleware/cookie_parser.rs) middleware in your route tree. Be mindful that this is somewhat of a breaking change. The cookie parser middleware must be added before any other middleware functions that use cookies in order for changed cookies to become set cookie headers.