### PR TITLE
fix(via): less arc cloning in server::serve

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-rc.9"
+version = "2.0.0-rc.10"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following to dependencies section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-via = "2.0.0-rc.9"
+via = "2.0.0-rc.10"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 

--- a/examples/blog-api/src/api/posts.rs
+++ b/examples/blog-api/src/api/posts.rs
@@ -10,13 +10,14 @@ pub async fn auth(request: Request<State>, next: Next<State>) -> via::Result {
 }
 
 pub async fn index(request: Request<State>, _: Next<State>) -> via::Result {
-    let posts = Post::public(&request.state().pool).await?;
+    let state = request.state().try_upgrade()?;
+    let posts = Post::public(&state.pool).await?;
 
     Response::build().json(&posts)
 }
 
 pub async fn create(request: Request<State>, _: Next<State>) -> via::Result {
-    let state = request.state().clone();
+    let state = request.state().try_upgrade()?;
     let payload = request.into_body().read_to_end().await?;
     let new_post = payload.parse_json::<NewPost>()?.insert(&state.pool).await?;
 
@@ -27,14 +28,15 @@ pub async fn create(request: Request<State>, _: Next<State>) -> via::Result {
 
 pub async fn show(request: Request<State>, _: Next<State>) -> via::Result {
     let id = request.param("id").parse()?;
-    let post = Post::find(&request.state().pool, id).await?;
+    let state = request.state().try_upgrade()?;
+    let post = Post::find(&state.pool, id).await?;
 
     Response::build().json(&post)
 }
 
 pub async fn update(request: Request<State>, _: Next<State>) -> via::Result {
     let id = request.param("id").parse()?;
-    let state = request.state().clone();
+    let state = request.state().try_upgrade()?;
     let payload = request.into_body().read_to_end().await?;
     let updated_post = payload
         .parse_json::<ChangeSet>()?
@@ -46,7 +48,8 @@ pub async fn update(request: Request<State>, _: Next<State>) -> via::Result {
 
 pub async fn destroy(request: Request<State>, _: Next<State>) -> via::Result {
     let id = request.param("id").parse()?;
+    let state = request.state().try_upgrade()?;
 
-    Post::delete(&request.state().pool, id).await?;
+    Post::delete(&state.pool, id).await?;
     Response::build().status(StatusCode::NO_CONTENT).finish()
 }

--- a/examples/blog-api/src/api/users.rs
+++ b/examples/blog-api/src/api/users.rs
@@ -5,13 +5,14 @@ use crate::database::models::user::*;
 use crate::State;
 
 pub async fn index(request: Request<State>, _: Next<State>) -> via::Result {
-    let users = User::all(&request.state().pool).await?;
+    let state = request.state().try_upgrade()?;
+    let users = User::all(&state.pool).await?;
 
     Response::build().json(&users)
 }
 
 pub async fn create(request: Request<State>, _: Next<State>) -> via::Result {
-    let state = request.state().clone();
+    let state = request.state().try_upgrade()?;
     let payload = request.into_body().read_to_end().await?;
     let new_user = payload.parse_json::<NewUser>()?.insert(&state.pool).await?;
 
@@ -22,14 +23,15 @@ pub async fn create(request: Request<State>, _: Next<State>) -> via::Result {
 
 pub async fn show(request: Request<State>, _: Next<State>) -> via::Result {
     let id = request.param("id").parse()?;
-    let user = User::find(&request.state().pool, id).await?;
+    let state = request.state().try_upgrade()?;
+    let user = User::find(&state.pool, id).await?;
 
     Response::build().json(&user)
 }
 
 pub async fn update(request: Request<State>, _: Next<State>) -> via::Result {
     let id = request.param("id").parse()?;
-    let state = request.state().clone();
+    let state = request.state().try_upgrade()?;
     let payload = request.into_body().read_to_end().await?;
     let updated_user = payload
         .parse_json::<ChangeSet>()?
@@ -41,7 +43,8 @@ pub async fn update(request: Request<State>, _: Next<State>) -> via::Result {
 
 pub async fn destroy(request: Request<State>, _: Next<State>) -> via::Result {
     let id = request.param("id").parse()?;
+    let state = request.state().try_upgrade()?;
 
-    User::delete(&request.state().pool, id).await?;
+    User::delete(&state.pool, id).await?;
     Response::build().status(StatusCode::NO_CONTENT).finish()
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,8 +1,10 @@
+use std::sync::Arc;
+
 use crate::middleware::Middleware;
 use crate::router::{Route, Router};
 
 pub struct App<T> {
-    pub(crate) state: T,
+    pub(crate) state: Arc<T>,
     pub(crate) router: Router<T>,
 }
 
@@ -10,7 +12,7 @@ pub struct App<T> {
 ///
 pub fn app<T>(state: T) -> App<T> {
     App {
-        state,
+        state: Arc::new(state),
         router: Router::new(),
     }
 }

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -3,6 +3,6 @@ pub mod param;
 mod request;
 
 pub use param::{PathParam, QueryParam};
-pub use request::Request;
+pub use request::{Request, State};
 
 pub(crate) use param::PathParams;

--- a/src/request/request.rs
+++ b/src/request/request.rs
@@ -3,18 +3,19 @@ use http::header::AsHeaderName;
 use http::request::Parts;
 use http::{HeaderMap, HeaderValue, Method, Uri, Version};
 use std::fmt::{self, Debug, Formatter};
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
 use super::param::{PathParam, PathParams};
 use super::QueryParam;
 use crate::body::{BoxBody, HttpBody, RequestBody};
+use crate::Error;
 
 pub struct Request<T = ()> {
     /// The shared application state passed to the
     /// [`via::app`](crate::app::app)
     /// function.
     ///
-    state: Arc<T>,
+    state: Weak<T>,
 
     /// The component parts of the HTTP request.
     ///
@@ -33,6 +34,13 @@ pub struct Request<T = ()> {
     /// The request's path and query parameters.
     ///
     params: PathParams,
+}
+
+/// A wrapper around a weak reference to the state argument passed to
+/// [`via::app`](crate::app::app).
+///
+pub struct State<T> {
+    ptr: Weak<T>,
 }
 
 impl<T> Request<T> {
@@ -177,8 +185,10 @@ impl<T> Request<T> {
     /// function.
     ///
     #[inline]
-    pub fn state(&self) -> &Arc<T> {
-        &self.state
+    pub fn state(&self) -> State<T> {
+        State {
+            ptr: Weak::clone(&self.state),
+        }
     }
 
     /// Returns a reference to the uri associated with the request.
@@ -199,7 +209,7 @@ impl<T> Request<T> {
 impl<T> Request<T> {
     #[inline]
     pub(crate) fn new(
-        state: Arc<T>,
+        state: Weak<T>,
         params: PathParams,
         head: Parts,
         body: HttpBody<RequestBody>,
@@ -239,5 +249,23 @@ impl<T> Debug for Request<T> {
             .field("cookies", &self.cookies)
             .field("body", self.body())
             .finish()
+    }
+}
+
+impl<T> State<T> {
+    /// Attempt to upgrade the weak reference to a strong reference.
+    ///
+    pub fn upgrade(self) -> Option<Arc<T>> {
+        Weak::upgrade(&self.ptr)
+    }
+
+    /// Attempt to upgrade the weak referene to a strong reference. If the
+    /// value was dropped, an error is returned.
+    ///
+    pub fn try_upgrade(self) -> Result<Arc<T>, Error> {
+        self.upgrade().ok_or_else(|| {
+            let message = "the application state is unavailable".to_string();
+            Error::internal_server_error(message.into())
+        })
     }
 }

--- a/src/server/acceptor/acceptor.rs
+++ b/src/server/acceptor/acceptor.rs
@@ -5,7 +5,7 @@ use tokio::net::TcpStream;
 
 /// A trait for types that can accept a TcpStream.
 ///
-pub trait Acceptor: Clone {
+pub trait Acceptor {
     type Accepted: Future<Output = Result<Self::Stream, Self::Error>> + Send + Sync;
     type Stream: AsyncRead + AsyncWrite + Send + Sync + Unpin;
     type Error: Error + Send + Sync;

--- a/src/server/acceptor/http.rs
+++ b/src/server/acceptor/http.rs
@@ -6,7 +6,6 @@ use super::Acceptor;
 
 /// Accepts a TCP stream and returns it as-is.
 ///
-#[derive(Clone, Copy)]
 pub struct HttpAcceptor;
 
 impl Acceptor for HttpAcceptor {

--- a/src/server/acceptor/rustls.rs
+++ b/src/server/acceptor/rustls.rs
@@ -6,7 +6,6 @@ use tokio_rustls::{Accept, TlsAcceptor};
 
 use super::Acceptor;
 
-#[derive(Clone)]
 pub struct RustlsAcceptor {
     acceptor: TlsAcceptor,
 }


### PR DESCRIPTION
- Uses weak references for global state by introducing a `State` struct.
- Wraps app in an arc to prevent an extra arc clone. This shouldn't create a cycle because Router<T> holds no references to `T`. I confirmed this is the case by checking the strong and weak counts of each arc in the cleanup branch of the i/o loop.

Changes can be tested in `rc.10`.