### PR TITLE
fix(via): do not allocate on exit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-rc.10"
+version = "2.0.0-rc.11"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following to dependencies section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-via = "2.0.0-rc.10"
+via = "2.0.0-rc.11"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -130,8 +130,7 @@ where
 
                     // Construct a via::Request from the component parts of r.
                     Request::new(
-                        // Clone the arc pointer around the global application
-                        // state that was passed to the via::app function.
+                        // Get a weak ref to the app state argument.
                         Arc::downgrade(&app.state),
                         // Allocate for path params.
                         PathParams::new(Vec::new()),


### PR DESCRIPTION
Uses a non-panicking alternative to `JoinSet::join_all`. Also fixes a typo in the `service_fn`.

Changes can be tested in `rc.11`.