### PR TITLE
chore(via): bump version to 2.0.0-rc.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-rc.14"
+version = "2.0.0-rc.15"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -28,7 +28,7 @@ percent-encoding = "2"
 serde = "1"
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "signal"] }
-via-router = { path = "crates/via-router", features = ["lru-cache"] }
+via-router = { version = "3.0.0-beta.16", features = ["lru-cache"] }
 
 [dependencies.cookie]
 version = "0.18"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following to dependencies section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-via = "2.0.0-rc.14"
+via = "2.0.0-rc.15"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 


### PR DESCRIPTION
Actually bumps the version to `2.0.0-rc.15`.