### PR TITLE
fix(via): prefer mapping request

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ percent-encoding = "2"
 serde = "1"
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "signal"] }
-via-router = { version = "3.0.0-beta.16", features = ["lru-cache"] }
+via-router = { path = "via-router", features = ["lru-cache"] }
 
 [dependencies.cookie]
 version = "0.18"

--- a/examples/blog-api/src/api/users.rs
+++ b/examples/blog-api/src/api/users.rs
@@ -5,14 +5,13 @@ use crate::database::models::user::*;
 use crate::State;
 
 pub async fn index(request: Request<State>, _: Next<State>) -> via::Result {
-    let state = request.state().try_upgrade()?;
-    let users = User::all(&state.pool).await?;
+    let users = User::all(&request.state().pool).await?;
 
     Response::build().json(&users)
 }
 
 pub async fn create(request: Request<State>, _: Next<State>) -> via::Result {
-    let state = request.state().try_upgrade()?;
+    let state = request.state().clone();
     let payload = request.into_body().read_to_end().await?;
     let new_user = payload.parse_json::<NewUser>()?.insert(&state.pool).await?;
 
@@ -23,15 +22,14 @@ pub async fn create(request: Request<State>, _: Next<State>) -> via::Result {
 
 pub async fn show(request: Request<State>, _: Next<State>) -> via::Result {
     let id = request.param("id").parse()?;
-    let state = request.state().try_upgrade()?;
-    let user = User::find(&state.pool, id).await?;
+    let user = User::find(&request.state().clone().pool, id).await?;
 
     Response::build().json(&user)
 }
 
 pub async fn update(request: Request<State>, _: Next<State>) -> via::Result {
     let id = request.param("id").parse()?;
-    let state = request.state().try_upgrade()?;
+    let state = request.state().clone();
     let payload = request.into_body().read_to_end().await?;
     let updated_user = payload
         .parse_json::<ChangeSet>()?
@@ -43,8 +41,7 @@ pub async fn update(request: Request<State>, _: Next<State>) -> via::Result {
 
 pub async fn destroy(request: Request<State>, _: Next<State>) -> via::Result {
     let id = request.param("id").parse()?;
-    let state = request.state().try_upgrade()?;
 
-    User::delete(&state.pool, id).await?;
+    User::delete(&request.state().pool, id).await?;
     Response::build().status(StatusCode::NO_CONTENT).finish()
 }

--- a/examples/cookies/src/main.rs
+++ b/examples/cookies/src/main.rs
@@ -32,7 +32,7 @@ async fn count_visits(request: Request<State>, next: Next<State>) -> via::Result
     // Clone the state from the request so we can access the secret key after
     // passing ownership of the request to the next middleware.
     //
-    let state = request.state().try_upgrade()?;
+    let state = request.state().clone();
 
     // Get a reference to the secret key from state.
     let secret = &state.secret;

--- a/examples/shared-state/src/main.rs
+++ b/examples/shared-state/src/main.rs
@@ -30,7 +30,7 @@ async fn counter(request: Request<State>, next: Next<State>) -> via::Result {
     // Clone the `Counter` state by incrementing the reference count of the
     // outer `Arc`. This will allow us to modify the `state` after we pass
     // ownership of `request` to the `next` middleware.
-    let state = request.state().try_upgrade()?;
+    let state = request.state().clone();
 
     // Call the next middleware in the app and await the response.
     let response = next.call(request).await?;
@@ -52,7 +52,7 @@ async fn totals(request: Request<State>, _: Next<State>) -> via::Result {
     // Get a reference to the `Counter` state from the request. We don't need
     // to clone the state since we are consuming the request rather than
     // passing it as an argument to `next.call`.
-    let state = request.state().try_upgrade()?;
+    let state = request.state();
 
     // Load the current value of `errors` from the atomic integer.
     let errors = state.errors.load(Ordering::Relaxed);

--- a/src/body/http_body.rs
+++ b/src/body/http_body.rs
@@ -3,7 +3,7 @@ use http_body::{Body, Frame, SizeHint};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use super::BoxBody;
+use super::{BoxBody, RequestBody};
 use crate::error::BoxError;
 
 /// The body of a request or response.
@@ -69,5 +69,12 @@ where
 impl<T> From<BoxBody> for HttpBody<T> {
     fn from(body: BoxBody) -> Self {
         Self::Mapped(body)
+    }
+}
+
+impl From<RequestBody> for HttpBody<RequestBody> {
+    #[inline]
+    fn from(body: RequestBody) -> Self {
+        Self::Original(body)
     }
 }

--- a/src/middleware/next.rs
+++ b/src/middleware/next.rs
@@ -1,45 +1,25 @@
-use std::sync::Weak;
+use std::sync::Arc;
 
 use super::middleware::{FutureResponse, Middleware};
 use crate::error::Error;
 use crate::request::Request;
 
 pub struct Next<T = ()> {
-    stack: Vec<Weak<dyn Middleware<T>>>,
+    stack: Vec<Arc<dyn Middleware<T>>>,
 }
 
 impl<T> Next<T> {
-    #[inline]
+    pub(crate) fn new(stack: Vec<Arc<dyn Middleware<T>>>) -> Self {
+        Self { stack }
+    }
+
     pub fn call(mut self, request: Request<T>) -> FutureResponse {
-        let next = {
-            let stack = &mut self.stack;
-
-            #[allow(clippy::never_loop)]
-            loop {
-                if let Some(weak) = stack.pop() {
-                    break weak;
-                }
-
-                return Box::pin(async {
-                    let message = "not found".to_owned();
-                    Err(Error::not_found(message.into()))
-                });
-            }
-        };
-
-        match Weak::upgrade(&next) {
-            Some(middleware) => middleware.call(request, Self { ..self }),
+        match self.stack.pop() {
+            Some(middleware) => middleware.call(request, self),
             None => Box::pin(async {
-                let message = "internal server error".to_owned();
-                Err(Error::internal_server_error(message.into()))
+                let message = "not found".to_owned();
+                Err(Error::not_found(message.into()))
             }),
         }
-    }
-}
-
-impl<T> Next<T> {
-    #[inline]
-    pub(crate) fn new(stack: Vec<Weak<dyn Middleware<T>>>) -> Self {
-        Self { stack }
     }
 }

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -3,6 +3,6 @@ pub mod param;
 mod request;
 
 pub use param::{PathParam, QueryParam};
-pub use request::{Request, State};
+pub use request::Request;
 
 pub(crate) use param::PathParams;

--- a/src/request/param/path_params.rs
+++ b/src/request/param/path_params.rs
@@ -8,13 +8,18 @@ pub struct PathParams {
 
 impl PathParams {
     #[inline]
-    pub const fn new(data: Vec<(Param, Option<[usize; 2]>)>) -> Self {
+    pub fn new(data: Vec<(Param, Option<[usize; 2]>)>) -> Self {
         Self { data }
     }
 
     #[inline]
     pub fn iter(&self) -> slice::Iter<(Param, Option<[usize; 2]>)> {
         self.data.iter()
+    }
+
+    #[inline]
+    pub fn push(&mut self, name: &Param, range: Option<[usize; 2]>) {
+        self.data.push((name.clone(), range));
     }
 }
 

--- a/src/response/response.rs
+++ b/src/response/response.rs
@@ -9,7 +9,7 @@ use crate::body::{BoxBody, HttpBody, ResponseBody};
 
 pub struct Response {
     pub(super) cookies: Option<Box<CookieJar>>,
-    pub(super) inner: http::Response<HttpBody<ResponseBody>>,
+    pub(crate) inner: http::Response<HttpBody<ResponseBody>>,
 }
 
 impl Response {
@@ -92,7 +92,7 @@ impl Response {
 
 impl Response {
     #[inline]
-    pub(crate) fn into_inner(self) -> http::Response<HttpBody<ResponseBody>> {
+    pub(crate) fn into_http_response(self) -> http::Response<HttpBody<ResponseBody>> {
         self.inner
     }
 

--- a/src/response/response.rs
+++ b/src/response/response.rs
@@ -1,5 +1,4 @@
 use cookie::CookieJar;
-use http::header::SET_COOKIE;
 use http::response::Parts;
 use http::{HeaderMap, StatusCode, Version};
 use std::fmt::{self, Debug, Formatter};
@@ -8,7 +7,7 @@ use super::builder::Builder;
 use crate::body::{BoxBody, HttpBody, ResponseBody};
 
 pub struct Response {
-    pub(super) cookies: Option<Box<CookieJar>>,
+    pub(crate) cookies: Option<Box<CookieJar>>,
     pub(crate) inner: http::Response<HttpBody<ResponseBody>>,
 }
 
@@ -90,36 +89,8 @@ impl Response {
     }
 }
 
-impl Response {
-    #[inline]
-    pub(crate) fn into_http_response(self) -> http::Response<HttpBody<ResponseBody>> {
-        self.inner
-    }
-
-    pub(crate) fn set_cookie_headers(&mut self) {
-        let headers = self.inner.headers_mut();
-        let delta = match &self.cookies {
-            Some(jar) => jar.delta(),
-            None => return,
-        };
-
-        for cookie in delta {
-            let set_cookie = match cookie.encoded().to_string().parse() {
-                Ok(header_value) => header_value,
-                Err(error) => {
-                    let _ = &error; // Placeholder for tracing
-                    continue;
-                }
-            };
-
-            if let Err(error) = headers.try_append(SET_COOKIE, set_cookie) {
-                let _ = &error; // Placeholder for tracing
-            }
-        }
-    }
-}
-
 impl Default for Response {
+    #[inline]
     fn default() -> Self {
         Self::new(HttpBody::new())
     }

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -64,7 +64,8 @@ where
     let server = serve(
         listener,
         acceptor,
-        app,
+        app.state,
+        app.router,
         max_connections,
         max_content_length,
         shutdown_timeout,

--- a/via-router/benches/bench.rs
+++ b/via-router/benches/bench.rs
@@ -117,7 +117,7 @@ fn find_matches_1(b: &mut Bencher) {
 
     b.iter(|| {
         for matching in router.visit("/dashboard") {
-            let _ = router.resolve(matching);
+            let _ = router.resolve(&matching.unwrap());
         }
     });
 }
@@ -132,7 +132,7 @@ fn find_matches_2(b: &mut Bencher) {
 
     b.iter(|| {
         for matching in router.visit("/dashboard/overview") {
-            let _ = router.resolve(matching);
+            let _ = router.resolve(&matching.unwrap());
         }
     });
 }
@@ -147,7 +147,7 @@ fn find_matches_3(b: &mut Bencher) {
 
     b.iter(|| {
         for matching in router.visit("/help/article/12345678987654321") {
-            let _ = router.resolve(matching);
+            let _ = router.resolve(&matching.unwrap());
         }
     });
 }
@@ -162,7 +162,7 @@ fn find_matches_4(b: &mut Bencher) {
 
     b.iter(|| {
         for matching in router.visit("/api/v1/products/12345678987654321") {
-            let _ = router.resolve(matching);
+            let _ = router.resolve(&matching.unwrap());
         }
     });
 }
@@ -179,7 +179,7 @@ fn find_matches_5(b: &mut Bencher) {
         for matching in
             router.visit("/api/v1/products/12345678987654321/comments/12345678987654321")
         {
-            let _ = router.resolve(matching);
+            let _ = router.resolve(&matching.unwrap());
         }
     });
 }
@@ -196,7 +196,7 @@ fn find_matches_6(b: &mut Bencher) {
         for matching in
             router.visit("/api/v1/products/12345678987654321/comments/12345678987654321")
         {
-            let _ = router.resolve(matching);
+            let _ = router.resolve(&matching.unwrap());
         }
     });
 }
@@ -213,7 +213,7 @@ fn find_matches_7(b: &mut Bencher) {
         for matching in
             router.visit("/api/v1/products/12345678987654321/comments/12345678987654321/edit")
         {
-            let _ = router.resolve(matching);
+            let _ = router.resolve(&matching.unwrap());
         }
     });
 }

--- a/via-router/src/lib.rs
+++ b/via-router/src/lib.rs
@@ -7,4 +7,4 @@ mod path;
 mod router;
 
 pub use path::Param;
-pub use router::{Found, Match, Route, Router};
+pub use router::{Match, Route, Router};


### PR DESCRIPTION
Prefers mapping request rather than working with the component parts individually.
I would like version 2 to not preclude someone from creating a proxy server if they chose to do so.

Keeping the request intact and introducing a `Request::into_inner` function is all that's needed other than writing docs, calling it version 2, and switching a more professional--predictable release cycle. 

:v:
