### PR TITLE
fix: enable tokio/rt-multi-thread until #52

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ hyper-util = { version = "0.1", features = ["tokio"] }
 percent-encoding = "2"
 serde = "1"
 serde_json = "1"
-tokio = { version = "1", features = ["macros", "signal"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 via-router = { path = "via-router", features = ["lru-cache"] }
 
 [dependencies.cookie]

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -12,6 +12,10 @@ async fn hello(request: Request, _: Next) -> via::Result {
     Response::build().text(format!("Hello, {}!", name))
 }
 
+// For the sake of simplifying doctests, we're specifying that we want to
+// use the "current_thread" runtime flavor. You'll most likely not want to
+// specify a runtime flavor and simpy use #[tokio::main] if your deployment
+// target has more than one CPU core.
 #[tokio::main]
 async fn main() -> Result<ExitCode, Error> {
     // Create a new application.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //! // use the "current_thread" runtime flavor. You'll most likely not want to
 //! // specify a runtime flavor and simpy use #[tokio::main] if your deployment
 //! // target has more than one CPU core.
-//! #[tokio::main(flavor = "current_thread")]
+//! #[tokio::main]
 //! async fn main() -> Result<ExitCode, Error> {
 //!     // Create a new application.
 //!     let mut app = via::app(());


### PR DESCRIPTION
Prevents via from being used with a single thread runtime until #52 lands.