### PR TITLE
chore(via-router): bump version to 3.0.0-beta.17

### DIFF
--- a/via-router/Cargo.toml
+++ b/via-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via-router"
-version = "3.0.0-beta.16"
+version = "3.0.0-beta.17"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/via-router/src/cache.rs
+++ b/via-router/src/cache.rs
@@ -5,6 +5,7 @@ use crate::router::Match;
 
 pub struct Cache {
     capacity: usize,
+
     #[allow(clippy::type_complexity)]
     entries: RwLock<VecDeque<(Box<str>, Vec<Option<Match>>)>>,
 }


### PR DESCRIPTION
Bumps via-router to version `3.0.0-beta.17`.