### PR TITLE
chore(via): bump via-router to 3.0.0-rc.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ percent-encoding = "2"
 serde = "1"
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
-via-router = { path = "via-router", features = ["lru-cache"] }
+via-router = { version = "3.0.0-beta.17", features = ["lru-cache"] }
 
 [dependencies.cookie]
 version = "0.18"


### PR DESCRIPTION
Bumps via-router in the main via crate in preparation for release.