### PR TITLE
chore(via): bump version to 2.0.0-rc.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-rc.16"
+version = "2.0.0-rc.17"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Add the following to dependencies section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-via = "2.0.0-rc.15"
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+via = "2.0.0-rc.17"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 ```
 
 ## Hello World Example


### PR DESCRIPTION
Identical to `2.0.0-rc.17` but the README is up to date.