### PR TITLE
fix(via): bring back support for binary response bodies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,5 +39,8 @@ version = "0.26"
 optional = true
 default-features = false
 
+[dev-dependencies]
+http-body-util = "0.1"
+
 [workspace]
 members = ["via-router", "examples/*"]

--- a/src/body/http_body.rs
+++ b/src/body/http_body.rs
@@ -8,7 +8,6 @@ use crate::error::BoxError;
 
 /// The body of a request or response.
 ///
-#[non_exhaustive]
 #[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub enum HttpBody<T> {
@@ -19,6 +18,22 @@ pub enum HttpBody<T> {
     /// A boxed request or response body that was returned from a map function.
     ///
     Mapped(BoxBody),
+}
+
+enum HttpBodyProjection<'a, T> {
+    Original(Pin<&'a mut T>),
+    Mapped(Pin<&'a mut BoxBody>),
+}
+
+impl<T> HttpBody<T> {
+    fn project(self: Pin<&mut Self>) -> HttpBodyProjection<T> {
+        unsafe {
+            match self.get_unchecked_mut() {
+                Self::Original(body) => HttpBodyProjection::Original(Pin::new_unchecked(body)),
+                Self::Mapped(body) => HttpBodyProjection::Mapped(Pin::new(body)),
+            }
+        }
+    }
 }
 
 impl<T> HttpBody<T>
@@ -36,18 +51,18 @@ where
 
 impl<T> Body for HttpBody<T>
 where
-    T: Body<Data = Bytes, Error = BoxError> + Unpin,
+    T: Body<Data = Bytes, Error = BoxError>,
 {
     type Data = Bytes;
     type Error = BoxError;
 
     fn poll_frame(
         self: Pin<&mut Self>,
-        context: &mut Context<'_>,
+        cx: &mut Context<'_>,
     ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
-        match self.get_mut() {
-            Self::Original(ptr) => Pin::new(ptr).poll_frame(context),
-            Self::Mapped(ptr) => Pin::new(ptr).poll_frame(context),
+        match self.project() {
+            HttpBodyProjection::Original(body) => body.poll_frame(cx),
+            HttpBodyProjection::Mapped(body) => body.poll_frame(cx),
         }
     }
 

--- a/src/body/request_body.rs
+++ b/src/body/request_body.rs
@@ -10,7 +10,7 @@ use super::http_body::HttpBody;
 use super::limit_error::LimitError;
 use crate::error::{BoxError, Error};
 
-/// A length-limited request body. The default limit is `10MB`.
+/// A length-limited `impl Body`. The default limit is `10MB`.
 ///
 /// The maximum length can be configured with
 /// [`Server::max_request_size`](crate::Server::max_request_size).

--- a/src/body/response_body.rs
+++ b/src/body/response_body.rs
@@ -11,6 +11,8 @@ use crate::error::BoxError;
 ///
 const MAX_FRAME_LEN: usize = 8192; // 8KB
 
+/// A buffered `impl Body` that is read in `8KB` chunks.
+///
 #[must_use = "streams do nothing unless polled"]
 pub struct ResponseBody {
     data: Bytes,
@@ -52,7 +54,14 @@ impl Body for ResponseBody {
     }
 
     fn size_hint(&self) -> SizeHint {
-        SizeHint::with_exact(self.data.len().try_into().unwrap())
+        match self.data.len().try_into() {
+            Ok(exact) => SizeHint::with_exact(exact),
+            Err(error) => {
+                // Placeholder for tracing...
+                let _ = &error;
+                SizeHint::new()
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Adds back support for binary response bodies. This is required to respond with unboxed content-types that are not UTF-8 strings.