### PR TITLE
fix(via-router): cleanup code in the cache module

### DIFF
--- a/via-router/Cargo.toml
+++ b/via-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via-router"
-version = "3.0.0-beta.17"
+version = "3.0.0-beta.18"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/via-router/src/router.rs
+++ b/via-router/src/router.rs
@@ -3,8 +3,6 @@ use crate::path::{self, Param, Pattern, Split};
 #[cfg(feature = "lru-cache")]
 use crate::cache::Cache;
 
-pub type Matched = Vec<Option<Match>>;
-
 /// A matched node in the route tree.
 ///
 /// Contains a reference to the route associated with the node and additional


### PR DESCRIPTION
Cleans up the code in the cache module of via-router for correctness and readability.