### PR TITLE
chore(via): bump version to 2.0.0-rc.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-rc.18"
+version = "2.0.0-rc.19"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -28,7 +28,7 @@ percent-encoding = "2"
 serde = "1"
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
-via-router = { version = "3.0.0-beta.17", features = ["lru-cache"] }
+via-router = { version = "3.0.0-beta.18", features = ["lru-cache"] }
 
 [dependencies.cookie]
 version = "0.18"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following to dependencies section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-via = "2.0.0-rc.18"
+via = "2.0.0-rc.19"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 ```
 


### PR DESCRIPTION
Upgrades via-router to the latest version and bumps via to version `2.0.0-rc.19` in preparation for release.

### Changelog

• fix(via-router): use Box<dyn Error> for Cache::read (fb9b67d)
• fix(via-router): cleanup code in the cache module (22364cc)
• fix(via): IoStream should be Unpin (#122)