### PR TITLE
dx: configure ci with github actions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,5 +7,5 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = false
 
-[*.sql]
+[*.{sql,yaml}]
 indent_size = 2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build_and_test:
-    name: Build and test
+    name: build and test
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -49,8 +49,8 @@ jobs:
           command: test
           args: --package via-router --features lru-cache
 
-  check_fmt_and_docs:
-    name: Checking fmt, clippy, and docs
+  fmt_clippy_and_docs:
+    name: fmt, clippy, and docs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,70 @@
+#
+# Copied verbatim from Tide and then slightly modified. Great work everyone!
+#
+# https://github.com/http-rs/tide/blob/main/.github/workflows/ci.yaml
+#
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+env:
+  RUSTFLAGS: -Dwarnings
+
+jobs:
+  build_and_test:
+    name: Build and test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        rust: [stable, nightly]
+
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Install ${{ matrix.rust }}
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      - name: check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --all --bins --examples
+
+      - name: test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+      - name: test router
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --package via-router --features lru-cache
+
+  check_fmt_and_docs:
+    name: Checking fmt, clippy, and docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - name: setup
+        run: |
+          rustup component add clippy rustfmt
+          rustc --version
+
+      - name: clippy
+        run: cargo clippy --tests --examples -- -D warnings
+
+      - name: fmt
+        run: cargo fmt --all -- --check
+
+      - name: docs
+        run: cargo doc --no-deps


### PR DESCRIPTION
Closes #124

---

Uses the same matrix as [Tide](https://github.com/http-rs/tide/blob/main/.github/workflows/ci.yaml). This should cover most development environments to prevent regressions and maintain stability in preparation for an official 2.0 release.