### PR TITLE
fix(examples/blog-api): rustfmt warnings

### DIFF
--- a/examples/blog-api/src/database/schema.rs
+++ b/examples/blog-api/src/database/schema.rs
@@ -22,8 +22,4 @@ diesel::table! {
 }
 
 diesel::joinable!(posts -> users (user_id));
-
-diesel::allow_tables_to_appear_in_same_query!(
-    posts,
-    users,
-);
+diesel::allow_tables_to_appear_in_same_query!(posts, users);


### PR DESCRIPTION
Fixes the rustfmt error in examples/blog-api.