### PR TITLE
fix(via): prefer indirection when moving out of BodyReader

### DIFF
--- a/src/body/body_reader.rs
+++ b/src/body/body_reader.rs
@@ -17,7 +17,7 @@ use super::RequestBody;
 
 /// The entire contents of a request body, in-memory.
 ///
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct BodyData {
     payload: Vec<Bytes>,
     trailers: Option<HeaderMap>,
@@ -26,8 +26,7 @@ pub struct BodyData {
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct BodyReader {
     body: HttpBody<RequestBody>,
-    payload: Option<Vec<Bytes>>,
-    trailers: Option<HeaderMap>,
+    data: Option<BodyData>,
 }
 
 struct JsonPayload<T> {
@@ -111,8 +110,10 @@ impl BodyReader {
     pub(crate) fn new(body: HttpBody<RequestBody>) -> Self {
         Self {
             body,
-            payload: Some(vec![]),
-            trailers: None,
+            data: Some(BodyData {
+                payload: Vec::new(),
+                trailers: None,
+            }),
         }
     }
 }
@@ -126,34 +127,30 @@ impl Future for BodyReader {
 
         loop {
             return match body.as_mut().poll_frame(context) {
+                Poll::Pending => Poll::Pending,
+
+                Poll::Ready(None) => {
+                    Poll::Ready(Ok(this.data.take().ok_or_else(body_already_read)?))
+                }
+
+                Poll::Ready(Some(Err(e))) => Poll::Ready(Err(error_from_boxed(e))),
+
                 Poll::Ready(Some(Ok(frame))) => {
-                    let payload = this.payload.as_mut().ok_or_else(body_already_read)?;
+                    let data = this.data.as_mut().ok_or_else(body_already_read)?;
                     let frame = match frame.into_data() {
                         Err(frame) => frame,
                         Ok(chunk) => {
-                            payload.push(chunk);
+                            data.payload.push(chunk);
                             continue;
                         }
                     };
 
                     if let Ok(trailers) = frame.into_trailers() {
-                        this.trailers.get_or_insert_default().extend(trailers);
+                        data.trailers.get_or_insert_default().extend(trailers);
                     }
 
                     continue;
                 }
-
-                Poll::Ready(Some(Err(e))) => {
-                    let error = error_from_boxed(e);
-                    Poll::Ready(Err(error))
-                }
-
-                Poll::Ready(None) => Poll::Ready(Ok(BodyData {
-                    payload: this.payload.take().ok_or_else(body_already_read)?,
-                    trailers: this.trailers.take(),
-                })),
-
-                Poll::Pending => Poll::Pending,
             };
         }
     }


### PR DESCRIPTION
Prefers a layer of indirection when moving the request payload out of BodyReader. #131 and this PR bring the implementation closer to the Collect and Collected API in [`http-body-util`](https://github.com/hyperium/http-body/blob/master/http-body-util/src/combinators/collect.rs).

I would prefer to use http-body-util for this business logic as the BufList optimization is awesome. However, as mentioned in #131 macros interfere to an extent with auditability. Simplicity is to us, what performance is to Actix. Yes, I'm giving you a compliment.
