### PR TITLE
refactor(via): error_boundary::catch ~> error_boundary::inspect

### DIFF
--- a/examples/echo-server/src/main.rs
+++ b/examples/echo-server/src/main.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<ExitCode, Error> {
     let mut app = via::app(());
 
     // Include an error boundary to catch any errors that occur downstream.
-    app.include(error_boundary::catch(|_, error| {
+    app.include(error_boundary::inspect(|_, error| {
         eprintln!("Error: {}", error);
     }));
 

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<ExitCode, Error> {
     let mut app = via::app(());
 
     // Include an error boundary to catch any errors that occur downstream.
-    app.include(error_boundary::catch(|_, error| {
+    app.include(error_boundary::inspect(|_, error| {
         eprintln!("Error: {}", error);
     }));
 

--- a/examples/tls-rustls/src/main.rs
+++ b/examples/tls-rustls/src/main.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<ExitCode, Error> {
     let mut app = via::app(());
 
     // Include an error boundary to catch any errors that occur downstream.
-    app.include(error_boundary::catch(|_, error| {
+    app.include(error_boundary::inspect(|_, error| {
         eprintln!("Error: {}", error);
     }));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 //!     let mut app = via::app(());
 //!
 //!     // Include an error boundary to catch any errors that occur downstream.
-//!     app.include(error_boundary::catch(|_, error| {
+//!     app.include(error_boundary::inspect(|_, error| {
 //!         eprintln!("Error: {}", error);
 //!     }));
 //!

--- a/src/middleware/error_boundary.rs
+++ b/src/middleware/error_boundary.rs
@@ -10,7 +10,7 @@ use crate::response::Response;
 /// provided closure to inspect the error to another error. Think of this as a
 /// [`Result::inspect_err`] for middleware.
 ///
-pub fn catch<T, F>(inspect: F) -> impl Middleware<T>
+pub fn inspect<T, F>(inspect: F) -> impl Middleware<T>
 where
     F: Fn(Arc<T>, &Error) + Copy + Send + Sync + 'static,
     T: Send + Sync + 'static,


### PR DESCRIPTION
Renames `error_boundary::catch` back to `error_boundary::inspect` for consistency with Result and Option API.