### PR TITLE
refactor(via): BoxError ~> DynError

### DIFF
--- a/src/body/http_body.rs
+++ b/src/body/http_body.rs
@@ -4,11 +4,11 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use super::RequestBody;
-use crate::error::BoxError;
+use crate::error::DynError;
 
 /// A type erased, dynamically dispatched [`Body`].
 ///
-pub type BoxBody = http_body_util::combinators::BoxBody<Bytes, BoxError>;
+pub type BoxBody = http_body_util::combinators::BoxBody<Bytes, DynError>;
 
 /// The body of a request or response.
 ///
@@ -27,7 +27,7 @@ pub enum HttpBody<T> {
 
 impl<T> HttpBody<T>
 where
-    T: Body<Data = Bytes, Error = BoxError> + Send + Sync + 'static,
+    T: Body<Data = Bytes, Error = DynError> + Send + Sync + 'static,
 {
     #[inline]
     pub fn boxed(self) -> BoxBody {
@@ -40,10 +40,10 @@ where
 
 impl<T> Body for HttpBody<T>
 where
-    T: Body<Data = Bytes, Error = BoxError> + Unpin,
+    T: Body<Data = Bytes, Error = DynError> + Unpin,
 {
     type Data = Bytes;
-    type Error = BoxError;
+    type Error = DynError;
 
     fn poll_frame(
         self: Pin<&mut Self>,

--- a/src/body/limit_error.rs
+++ b/src/body/limit_error.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Display, Formatter};
 
-use crate::error::{BoxError, Error};
+use crate::error::{DynError, Error};
 
 #[derive(Clone, Copy, Debug)]
 pub struct LimitError;
@@ -8,7 +8,7 @@ pub struct LimitError;
 /// Wrap the provided [BoxError] with [Error] and set the status based on the
 /// error type.
 ///
-pub fn error_from_boxed(error: BoxError) -> Error {
+pub fn error_from_boxed(error: DynError) -> Error {
     if let Some(&LimitError) = error.downcast_ref() {
         Error::payload_too_large(error)
     } else {

--- a/src/body/pipe.rs
+++ b/src/body/pipe.rs
@@ -7,7 +7,7 @@ use http_body::Frame;
 
 use super::stream_body::StreamBody;
 use crate::body::{BoxBody, HttpBody, RequestBody};
-use crate::error::{BoxError, Error};
+use crate::error::{DynError, Error};
 use crate::response::{Builder, Response};
 
 trait Sealed {}
@@ -40,11 +40,11 @@ impl Pipe for HttpBody<RequestBody> {
     }
 }
 
-impl<T> Sealed for T where T: Stream<Item = Result<Frame<Bytes>, BoxError>> + Send + Sync + 'static {}
+impl<T> Sealed for T where T: Stream<Item = Result<Frame<Bytes>, DynError>> + Send + Sync + 'static {}
 
 impl<T> Pipe for T
 where
-    T: Stream<Item = Result<Frame<Bytes>, BoxError>> + Send + Sync + 'static,
+    T: Stream<Item = Result<Frame<Bytes>, DynError>> + Send + Sync + 'static,
 {
     fn pipe(self, response: Builder) -> Result<Response, Error> {
         response

--- a/src/body/request_body.rs
+++ b/src/body/request_body.rs
@@ -8,7 +8,7 @@ use super::body_reader::{BodyData, BodyReader};
 use super::body_stream::BodyStream;
 use super::http_body::HttpBody;
 use super::limit_error::LimitError;
-use crate::error::{BoxError, Error};
+use crate::error::{DynError, Error};
 
 /// A length-limited `impl Body`. The default limit is `10MB`.
 ///
@@ -40,7 +40,7 @@ impl HttpBody<RequestBody> {
 
 impl Body for RequestBody {
     type Data = Bytes;
-    type Error = BoxError;
+    type Error = DynError;
 
     fn poll_frame(
         self: Pin<&mut Self>,

--- a/src/body/response_body.rs
+++ b/src/body/response_body.rs
@@ -5,7 +5,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use super::http_body::HttpBody;
-use crate::error::BoxError;
+use crate::error::DynError;
 
 /// The maximum amount of data that can be read from a buffered body per frame.
 ///
@@ -21,7 +21,7 @@ pub struct ResponseBody {
 
 impl Body for ResponseBody {
     type Data = Bytes;
-    type Error = BoxError;
+    type Error = DynError;
 
     fn poll_frame(
         mut self: Pin<&mut Self>,

--- a/src/body/stream_body.rs
+++ b/src/body/stream_body.rs
@@ -5,7 +5,7 @@ use std::fmt::{self, Debug, Formatter};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use crate::error::BoxError;
+use crate::error::DynError;
 
 /// Converts an `impl Stream` to an `impl Body`.
 ///
@@ -36,10 +36,10 @@ impl<T> StreamBody<T> {
 
 impl<T> Body for StreamBody<T>
 where
-    T: Stream<Item = Result<Frame<Bytes>, BoxError>> + Send + Sync,
+    T: Stream<Item = Result<Frame<Bytes>, DynError>> + Send + Sync,
 {
     type Data = Bytes;
-    type Error = BoxError;
+    type Error = DynError;
 
     fn poll_frame(
         self: Pin<&mut Self>,

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,7 +14,7 @@ use crate::response::Response;
 /// [`Error`](std::error::Error)
 /// that is `Send + Sync`.
 ///
-pub type BoxError = Box<dyn std::error::Error + Send + Sync>;
+pub type DynError = Box<dyn std::error::Error + Send + Sync>;
 
 /// An error type that can act as a specialized version of a response
 /// [`Builder`](crate::response::Builder).
@@ -24,7 +24,7 @@ pub struct Error {
     as_json: bool,
     status: StatusCode,
     message: Option<String>,
-    error: BoxError,
+    error: DynError,
 }
 
 /// A serialized representation of an individual error.
@@ -36,7 +36,7 @@ struct SerializeError<'a> {
 impl Error {
     /// Returns a new [`Error`] with the provided message.
     ///
-    pub fn new(source: BoxError) -> Self {
+    pub fn new(source: DynError) -> Self {
         Self::internal_server_error(source)
     }
 
@@ -179,280 +179,280 @@ impl Error {
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `400 Bad Request` status.
     ///
-    pub fn bad_request(source: BoxError) -> Self {
+    pub fn bad_request(source: DynError) -> Self {
         Self::new_with_status(StatusCode::BAD_REQUEST, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `401 Unauthorized` status.
     ///
-    pub fn unauthorized(source: BoxError) -> Self {
+    pub fn unauthorized(source: DynError) -> Self {
         Self::new_with_status(StatusCode::UNAUTHORIZED, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `402 Payment Required` status.
     ///
-    pub fn payment_required(source: BoxError) -> Self {
+    pub fn payment_required(source: DynError) -> Self {
         Self::new_with_status(StatusCode::PAYMENT_REQUIRED, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `403 Forbidden` status.
     ///
-    pub fn forbidden(source: BoxError) -> Self {
+    pub fn forbidden(source: DynError) -> Self {
         Self::new_with_status(StatusCode::FORBIDDEN, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `404 Not Found` status.
     ///
-    pub fn not_found(source: BoxError) -> Self {
+    pub fn not_found(source: DynError) -> Self {
         Self::new_with_status(StatusCode::NOT_FOUND, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `405 Method Not Allowed` status.
     ///
-    pub fn method_not_allowed(source: BoxError) -> Self {
+    pub fn method_not_allowed(source: DynError) -> Self {
         Self::new_with_status(StatusCode::METHOD_NOT_ALLOWED, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `406 Not Acceptable` status.
     ///
-    pub fn not_acceptable(source: BoxError) -> Self {
+    pub fn not_acceptable(source: DynError) -> Self {
         Self::new_with_status(StatusCode::NOT_ACCEPTABLE, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `407 Proxy Authentication Required` status.
     ///
-    pub fn proxy_authentication_required(source: BoxError) -> Self {
+    pub fn proxy_authentication_required(source: DynError) -> Self {
         Self::new_with_status(StatusCode::PROXY_AUTHENTICATION_REQUIRED, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `408 Request Timeout` status.
     ///
-    pub fn request_timeout(source: BoxError) -> Self {
+    pub fn request_timeout(source: DynError) -> Self {
         Self::new_with_status(StatusCode::REQUEST_TIMEOUT, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `409 Conflict` status.
     ///
-    pub fn conflict(source: BoxError) -> Self {
+    pub fn conflict(source: DynError) -> Self {
         Self::new_with_status(StatusCode::CONFLICT, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `410 Gone` status.
     ///
-    pub fn gone(source: BoxError) -> Self {
+    pub fn gone(source: DynError) -> Self {
         Self::new_with_status(StatusCode::GONE, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `411 Length Required` status.
     ///
-    pub fn length_required(source: BoxError) -> Self {
+    pub fn length_required(source: DynError) -> Self {
         Self::new_with_status(StatusCode::LENGTH_REQUIRED, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `412 Precondition Failed` status.
     ///
-    pub fn precondition_failed(source: BoxError) -> Self {
+    pub fn precondition_failed(source: DynError) -> Self {
         Self::new_with_status(StatusCode::PRECONDITION_FAILED, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `413 Payload Too Large` status.
     ///
-    pub fn payload_too_large(source: BoxError) -> Self {
+    pub fn payload_too_large(source: DynError) -> Self {
         Self::new_with_status(StatusCode::PAYLOAD_TOO_LARGE, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `414 URI Too Long` status.
     ///
-    pub fn uri_too_long(source: BoxError) -> Self {
+    pub fn uri_too_long(source: DynError) -> Self {
         Self::new_with_status(StatusCode::URI_TOO_LONG, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `415 Unsupported Media Type` status.
     ///
-    pub fn unsupported_media_type(source: BoxError) -> Self {
+    pub fn unsupported_media_type(source: DynError) -> Self {
         Self::new_with_status(StatusCode::UNSUPPORTED_MEDIA_TYPE, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `416 Range Not Satisfiable` status.
     ///
-    pub fn range_not_satisfiable(source: BoxError) -> Self {
+    pub fn range_not_satisfiable(source: DynError) -> Self {
         Self::new_with_status(StatusCode::RANGE_NOT_SATISFIABLE, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `417 Expectation Failed` status.
     ///
-    pub fn expectation_failed(source: BoxError) -> Self {
+    pub fn expectation_failed(source: DynError) -> Self {
         Self::new_with_status(StatusCode::EXPECTATION_FAILED, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `418 I'm a teapot` status.
     ///
-    pub fn im_a_teapot(source: BoxError) -> Self {
+    pub fn im_a_teapot(source: DynError) -> Self {
         Self::new_with_status(StatusCode::IM_A_TEAPOT, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `421 Misdirected Request` status.
     ///
-    pub fn misdirected_request(source: BoxError) -> Self {
+    pub fn misdirected_request(source: DynError) -> Self {
         Self::new_with_status(StatusCode::MISDIRECTED_REQUEST, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `422 Unprocessable Entity` status.
     ///
-    pub fn unprocessable_entity(source: BoxError) -> Self {
+    pub fn unprocessable_entity(source: DynError) -> Self {
         Self::new_with_status(StatusCode::UNPROCESSABLE_ENTITY, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `423 Locked` status.
     ///
-    pub fn locked(source: BoxError) -> Self {
+    pub fn locked(source: DynError) -> Self {
         Self::new_with_status(StatusCode::LOCKED, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `424 Failed Dependency` status.
     ///
-    pub fn failed_dependency(source: BoxError) -> Self {
+    pub fn failed_dependency(source: DynError) -> Self {
         Self::new_with_status(StatusCode::FAILED_DEPENDENCY, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `426 Upgrade Required` status.
     ///
-    pub fn upgrade_required(source: BoxError) -> Self {
+    pub fn upgrade_required(source: DynError) -> Self {
         Self::new_with_status(StatusCode::UPGRADE_REQUIRED, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `428 Precondition Required` status.
     ///
-    pub fn precondition_required(source: BoxError) -> Self {
+    pub fn precondition_required(source: DynError) -> Self {
         Self::new_with_status(StatusCode::PRECONDITION_REQUIRED, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `429 Too Many Requests` status.
     ///
-    pub fn too_many_requests(source: BoxError) -> Self {
+    pub fn too_many_requests(source: DynError) -> Self {
         Self::new_with_status(StatusCode::TOO_MANY_REQUESTS, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `431 Request Header Fields Too Large` status.
     ///
-    pub fn request_header_fields_too_large(source: BoxError) -> Self {
+    pub fn request_header_fields_too_large(source: DynError) -> Self {
         Self::new_with_status(StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `451 Unavailable For Legal Reasons` status.
     ///
-    pub fn unavailable_for_legal_reasons(source: BoxError) -> Self {
+    pub fn unavailable_for_legal_reasons(source: DynError) -> Self {
         Self::new_with_status(StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `500 Internal Server Error` status.
     ///
-    pub fn internal_server_error(source: BoxError) -> Self {
+    pub fn internal_server_error(source: DynError) -> Self {
         Self::new_with_status(StatusCode::INTERNAL_SERVER_ERROR, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `501 Not Implemented` status.
     ///
-    pub fn not_implemented(source: BoxError) -> Self {
+    pub fn not_implemented(source: DynError) -> Self {
         Self::new_with_status(StatusCode::NOT_IMPLEMENTED, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `502 Bad Gateway` status.
     ///
-    pub fn bad_gateway(source: BoxError) -> Self {
+    pub fn bad_gateway(source: DynError) -> Self {
         Self::new_with_status(StatusCode::BAD_GATEWAY, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `503 Service Unavailable` status.
     ///
-    pub fn service_unavailable(source: BoxError) -> Self {
+    pub fn service_unavailable(source: DynError) -> Self {
         Self::new_with_status(StatusCode::SERVICE_UNAVAILABLE, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `504 Gateway Timeout` status.
     ///
-    pub fn gateway_timeout(source: BoxError) -> Self {
+    pub fn gateway_timeout(source: DynError) -> Self {
         Self::new_with_status(StatusCode::GATEWAY_TIMEOUT, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `505 HTTP Version Not Supported` status.
     ///
-    pub fn http_version_not_supported(source: BoxError) -> Self {
+    pub fn http_version_not_supported(source: DynError) -> Self {
         Self::new_with_status(StatusCode::HTTP_VERSION_NOT_SUPPORTED, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `506 Variant Also Negotiates` status.
     ///
-    pub fn variant_also_negotiates(source: BoxError) -> Self {
+    pub fn variant_also_negotiates(source: DynError) -> Self {
         Self::new_with_status(StatusCode::VARIANT_ALSO_NEGOTIATES, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `507 Insufficient Storage` status.
     ///
-    pub fn insufficient_storage(source: BoxError) -> Self {
+    pub fn insufficient_storage(source: DynError) -> Self {
         Self::new_with_status(StatusCode::INSUFFICIENT_STORAGE, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `508 Loop Detected` status.
     ///
-    pub fn loop_detected(source: BoxError) -> Self {
+    pub fn loop_detected(source: DynError) -> Self {
         Self::new_with_status(StatusCode::LOOP_DETECTED, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `510 Not Extended` status.
     ///
-    pub fn not_extended(source: BoxError) -> Self {
+    pub fn not_extended(source: DynError) -> Self {
         Self::new_with_status(StatusCode::NOT_EXTENDED, source)
     }
 
     /// Returns a new [`Error`] from the provided source that will generate a
     /// [`Response`] with a `511 Network Authentication Required` status.
     ///
-    pub fn network_authentication_required(source: BoxError) -> Self {
+    pub fn network_authentication_required(source: DynError) -> Self {
         Self::new_with_status(StatusCode::NETWORK_AUTHENTICATION_REQUIRED, source)
     }
 }
 
 impl Error {
     #[inline]
-    fn new_with_status(status: StatusCode, source: BoxError) -> Self {
+    fn new_with_status(status: StatusCode, source: DynError) -> Self {
         Self {
             as_json: false,
             message: None,

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -15,7 +15,7 @@ use hyper_util::rt::TokioExecutor;
 
 use super::acceptor::Acceptor;
 use crate::body::RequestBody;
-use crate::error::BoxError;
+use crate::error::DynError;
 use crate::request::Request;
 use crate::router::{Router, RouterError};
 use crate::server::io_stream::IoStream;
@@ -28,7 +28,7 @@ pub async fn serve<T, A>(
     max_connections: usize,
     max_request_size: usize,
     shutdown_timeout: Duration,
-) -> Result<ExitCode, BoxError>
+) -> Result<ExitCode, DynError>
 where
     T: Send + Sync + 'static,
     A: Acceptor + Send + Sync + 'static,
@@ -208,7 +208,7 @@ where
         // Otherwise, return an error.
         _ = time::sleep(shutdown_timeout) => {
             let message = "server exited before all connections were closed".to_owned();
-            Err(BoxError::from(message))
+            Err(DynError::from(message))
         }
     }
 }

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -9,7 +9,7 @@ use tokio_rustls::rustls;
 use super::acceptor::{self, Acceptor};
 use super::serve::serve;
 use crate::app::App;
-use crate::error::BoxError;
+use crate::error::DynError;
 
 /// The default value of the maximum number of concurrent connections.
 ///
@@ -42,7 +42,7 @@ async fn listen<T, A>(
     max_connections: Option<usize>,
     max_request_size: Option<usize>,
     shutdown_timeout: Option<u64>,
-) -> Result<ExitCode, BoxError>
+) -> Result<ExitCode, DynError>
 where
     T: Send + Sync + 'static,
     A: Acceptor + Send + Sync + 'static,
@@ -141,7 +141,7 @@ where
     pub fn listen<A: ToSocketAddrs>(
         self,
         address: A,
-    ) -> impl Future<Output = Result<ExitCode, BoxError>> {
+    ) -> impl Future<Output = Result<ExitCode, DynError>> {
         // Confirm that rustls_config exists before proceeding.
 
         let tls_config = match self.rustls_config {
@@ -211,7 +211,7 @@ where
     pub fn listen<A: ToSocketAddrs>(
         self,
         address: A,
-    ) -> impl Future<Output = Result<ExitCode, BoxError>> {
+    ) -> impl Future<Output = Result<ExitCode, DynError>> {
         // Create a HttpAcceptor to serve connections over HTTP.
         let acceptor = acceptor::http::HttpAcceptor;
 


### PR DESCRIPTION
Renames `BoxError` to `DynError` so I feel less shame when allocating on the heap and remember to eat dinner.