### PR TITLE
refactor(via): filter_method ~> accept_method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ mod server;
 pub use app::{app, App};
 pub use body::Pipe;
 pub use error::Error;
-pub use middleware::filter_method::{connect, delete, get, head, options, patch, post, put, trace};
+pub use middleware::accept_method::{connect, delete, get, head, options, patch, post, put, trace};
 pub use middleware::{Middleware, Next, Result};
 pub use request::Request;
 pub use response::Response;

--- a/src/middleware/accept_method.rs
+++ b/src/middleware/accept_method.rs
@@ -4,42 +4,42 @@ use super::Middleware;
 use crate::request::Request;
 
 pub fn connect<T>(middleware: impl Middleware<T>) -> impl Middleware<T> {
-    filter(Method::CONNECT, middleware)
+    accept_method(Method::CONNECT, middleware)
 }
 
 pub fn delete<T>(middleware: impl Middleware<T>) -> impl Middleware<T> {
-    filter(Method::DELETE, middleware)
+    accept_method(Method::DELETE, middleware)
 }
 
 pub fn get<T>(middleware: impl Middleware<T>) -> impl Middleware<T> {
-    filter(Method::GET, middleware)
+    accept_method(Method::GET, middleware)
 }
 
 pub fn head<T>(middleware: impl Middleware<T>) -> impl Middleware<T> {
-    filter(Method::HEAD, middleware)
+    accept_method(Method::HEAD, middleware)
 }
 
 pub fn options<T>(middleware: impl Middleware<T>) -> impl Middleware<T> {
-    filter(Method::OPTIONS, middleware)
+    accept_method(Method::OPTIONS, middleware)
 }
 
 pub fn patch<T>(middleware: impl Middleware<T>) -> impl Middleware<T> {
-    filter(Method::PATCH, middleware)
+    accept_method(Method::PATCH, middleware)
 }
 
 pub fn post<T>(middleware: impl Middleware<T>) -> impl Middleware<T> {
-    filter(Method::POST, middleware)
+    accept_method(Method::POST, middleware)
 }
 
 pub fn put<T>(middleware: impl Middleware<T>) -> impl Middleware<T> {
-    filter(Method::PUT, middleware)
+    accept_method(Method::PUT, middleware)
 }
 
 pub fn trace<T>(middleware: impl Middleware<T>) -> impl Middleware<T> {
-    filter(Method::TRACE, middleware)
+    accept_method(Method::TRACE, middleware)
 }
 
-fn filter<T>(method: Method, middleware: impl Middleware<T>) -> impl Middleware<T> {
+fn accept_method<T>(method: Method, middleware: impl Middleware<T>) -> impl Middleware<T> {
     move |request: Request<T>, next| {
         if request.method() == method {
             middleware.call(request, next)

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -1,7 +1,7 @@
 pub mod cookie_parser;
 pub mod error_boundary;
 
-pub(crate) mod filter_method;
+pub(crate) mod accept_method;
 
 mod middleware;
 mod next;


### PR DESCRIPTION
Renames `filter_method` to `accept_method` for the sake of specificity in the private API. This is a non-breaking change that is future thinking in the sense that it would be great to have an interop layer to support using [`warp`](https://github.com/seanmonstar/warp) filters as Via middleware. We like to be specific in the Rust community so having lots of choices is a good thing.
