### PR TITLE
refactor(via): response::Builder ~> ResponseBuilder

### DIFF
--- a/src/response/builder.rs
+++ b/src/response/builder.rs
@@ -8,7 +8,7 @@ use crate::body::{HttpBody, ResponseBody};
 use crate::error::Error;
 
 #[derive(Debug, Default)]
-pub struct Builder {
+pub struct ResponseBuilder {
     inner: http::response::Builder,
 }
 
@@ -16,7 +16,7 @@ struct JsonPayload<'a, T> {
     data: &'a T,
 }
 
-impl Builder {
+impl ResponseBuilder {
     #[inline]
     pub fn header<K, V>(self, key: K, value: V) -> Self
     where

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -2,6 +2,6 @@ mod builder;
 mod redirect;
 mod response;
 
-pub use builder::Builder;
+pub use builder::ResponseBuilder;
 pub use redirect::Redirect;
 pub use response::Response;

--- a/src/response/response.rs
+++ b/src/response/response.rs
@@ -3,7 +3,7 @@ use http::response::Parts;
 use http::{HeaderMap, StatusCode, Version};
 use std::fmt::{self, Debug, Formatter};
 
-use super::builder::Builder;
+use super::builder::ResponseBuilder;
 use crate::body::{BoxBody, HttpBody, ResponseBody};
 
 pub struct Response {
@@ -13,7 +13,7 @@ pub struct Response {
 
 impl Response {
     #[inline]
-    pub fn build() -> Builder {
+    pub fn build() -> ResponseBuilder {
         Default::default()
     }
 


### PR DESCRIPTION
Renames `response::Builder` to `ResponseBuilder` so the structs in the response module doc stack like this:

<img width="816" alt="Screenshot 2025-03-03 alle 5 58 31 PM" src="https://github.com/user-attachments/assets/c0501313-ff6b-4144-ae59-a387e295a33b" />
