### PR TITLE
fix(via): do not copy owned data in ResponseBody::from

### DIFF
--- a/src/body/response_body.rs
+++ b/src/body/response_body.rs
@@ -92,7 +92,7 @@ impl From<Bytes> for ResponseBody {
 impl From<String> for ResponseBody {
     #[inline]
     fn from(data: String) -> Self {
-        Self::from(Bytes::copy_from_slice(data.as_bytes()))
+        Self::from(data.into_bytes())
     }
 }
 
@@ -106,7 +106,7 @@ impl From<&'_ str> for ResponseBody {
 impl From<Vec<u8>> for ResponseBody {
     #[inline]
     fn from(data: Vec<u8>) -> Self {
-        Self::from(Bytes::copy_from_slice(&data))
+        Self::from(Bytes::from(data))
     }
 }
 

--- a/src/response/builder.rs
+++ b/src/response/builder.rs
@@ -76,19 +76,19 @@ impl ResponseBuilder {
 
         self.header(CONTENT_TYPE, "application/json; charset=utf-8")
             .header(CONTENT_LENGTH, json.len())
-            .body(HttpBody::Original(json.into()))
+            .body(HttpBody::Original(ResponseBody::from(json)))
     }
 
     pub fn html(self, data: String) -> Result<Response, Error> {
         self.header(CONTENT_TYPE, "text/html; charset=utf-8")
             .header(CONTENT_LENGTH, data.len())
-            .body(HttpBody::Original(data.into()))
+            .body(HttpBody::Original(ResponseBody::from(data)))
     }
 
     pub fn text(self, data: String) -> Result<Response, Error> {
         self.header(CONTENT_TYPE, "text/plain; charset=utf-8")
             .header(CONTENT_LENGTH, data.len())
-            .body(HttpBody::Original(data.into()))
+            .body(HttpBody::Original(ResponseBody::from(data)))
     }
 
     /// Convert self into a [Response] with an empty payload.


### PR DESCRIPTION
Refactors the `From<_> for ResponseBody` impls to not copy data if it's owned (String or Vec<u8>). This takes a slightly less pedantic approach to security by assuming that it's safe to convert either an owned String or Vec<u8> directly to Bytes. If there is ever a case where a user prefers the previous implementation for whatever reason, you can manually clone the string or vec before it is passed to one of the ResponseBuilder methods.