### PR TITLE
fix(via): remove ResponseBuilder::headers

### DIFF
--- a/examples/echo-server/src/main.rs
+++ b/examples/echo-server/src/main.rs
@@ -6,11 +6,12 @@ use via::{Next, Pipe, Request, Response, Server};
 type Error = Box<dyn std::error::Error + Send + Sync>;
 
 async fn echo(request: Request, _: Next) -> via::Result {
-    // Get an optional copy of the Content-Type header from the request.
-    let content_type = request.header(CONTENT_TYPE).cloned();
+    let mut response = Response::build();
 
-    // Create a response builder with the Content-Type header from the request.
-    let response = Response::build().headers([(CONTENT_TYPE, content_type)]);
+    // If a Content-Type header is present, include it in the response.
+    if let Some(content_type) = request.header(CONTENT_TYPE).cloned() {
+        response = response.header(CONTENT_TYPE, content_type);
+    }
 
     // Stream the request payload back to the client with the options configured
     // in the response builder above.

--- a/src/body/pipe.rs
+++ b/src/body/pipe.rs
@@ -19,8 +19,11 @@ trait Sealed {}
 /// use via::{Next, Request, Response, Pipe};
 ///
 /// async fn echo(request: Request, _: Next) -> via::Result {
-///     let content_type = request.header(CONTENT_TYPE).cloned();
-///     let response = Response::build().headers([(CONTENT_TYPE, content_type)]);
+///     let mut response = Response::build();
+///
+///     if let Some(content_type) = request.header(CONTENT_TYPE).cloned() {
+///         response = response.header(CONTENT_TYPE, content_type);
+///     }
 ///
 ///     request.into_body().pipe(response)
 /// }

--- a/src/response/builder.rs
+++ b/src/response/builder.rs
@@ -30,21 +30,6 @@ impl ResponseBuilder {
         }
     }
 
-    pub fn headers<I, K, V>(self, iter: I) -> Self
-    where
-        I: IntoIterator<Item = (K, Option<V>)>,
-        HeaderName: TryFrom<K>,
-        <HeaderName as TryFrom<K>>::Error: Into<http::Error>,
-        HeaderValue: TryFrom<V>,
-        <HeaderValue as TryFrom<V>>::Error: Into<http::Error>,
-    {
-        iter.into_iter()
-            .fold(self, |builder, (key, option)| match option {
-                Some(value) => builder.header(key, value),
-                None => builder,
-            })
-    }
-
     #[inline]
     pub fn status<T>(self, status: T) -> Self
     where


### PR DESCRIPTION
Removes the `ResponseBuilder::headers` method. While this is a nice idea with convenience in mind, it often times requires a temporary allocation just store the argument. In practice, we're almost always going to want to use the individual `ResponseBuilder::header` method with branching as seen in #140. While I'm not one to want to remove features of a public API, the business logic is simple enough to write by hand if it makes sense for a particular edge case. This way, we don't encourage a (most likely) wasteful practice.