### PR TITLE
fix(via): StreamBody should require T: Unpin

### DIFF
--- a/src/body/pipe.rs
+++ b/src/body/pipe.rs
@@ -46,7 +46,7 @@ impl<T> Sealed for T where T: Stream<Item = Result<Bytes, DynError>> + Send + Sy
 
 impl<T> Pipe for T
 where
-    T: Stream<Item = Result<Bytes, DynError>> + Send + Sync + 'static,
+    T: Stream<Item = Result<Bytes, DynError>> + Send + Sync + Unpin + 'static,
 {
     fn pipe(self, response: ResponseBuilder) -> Result<Response, Error> {
         response


### PR DESCRIPTION
As mentioned in #140. For API safety, StreamBody should require that `T: Unpin`. If someone needs an `!Unpin` stream, they can pass `BoxBody` directly to `Response::new`.