### PR TITLE
chore(via): bump version to 2.0.0-rc.22

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-rc.21"
+version = "2.0.0-rc.22"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following to dependencies section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-via = "2.0.0-rc.20"
+via = "2.0.0-rc.22"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 ```
 


### PR DESCRIPTION
Bumps Via to version `2.0.0-rc.22` in preparation for release.

## Changelog

- #147
- #140
- #145
- #144
- #143
- #142
- #141