### PR TITLE
chore(via): bump version to 2.0.0-rc.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-rc.22"
+version = "2.0.0-rc.23"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following to dependencies section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-via = "2.0.0-rc.22"
+via = "2.0.0-rc.23"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 ```
 


### PR DESCRIPTION
How embarrassing! I should have looked at the releases before specifying `rc.22` is the next version. Go easy on me though. I haven't had my orange juice yet this morning!

Fortunately, we're still just a little ways away from an official 2.0 release. When that happens, the development pace will slow down and become more organized. If I'm working by myself, I have the tendency to go as fast as possible. However, it is important to me that the SDLC of this project match the emphasis on security in the code. Copying the changelog from #148 as there are no changes.