### PR TITLE
refactor(via): rename Server::new ~> via::start

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,7 @@ async fn main() -> Result<ExitCode, Error> {
     // Define a route that listens on /hello/:name.
     app.at("/hello/:name").respond(via::get(hello));
 
-    // Start the server.
-    Server::new(app).listen(("127.0.0.1", 8080)).await
+    via::start(app).listen(("127.0.0.1", 8080)).await
 }
 ```
 
@@ -66,7 +65,7 @@ async fn main() -> Result<ExitCode, Error> {
 
 4. **Define Routes**: The `app.at("/hello/:name").respond(via::get(hello))` line adds a route that listens for GET requests on `/hello/:name`. The colon (`:`) indicates a dynamic segment in the path, which will match any value and make it available as a parameter.
 
-5. **Start the Server**: The `Server::new(app).listen(("127.0.0.1", 8080)).await` function starts the server and listens for connections on the specified address.
+5. **Start the Server**: Calling `via::start(app).listen(("127.0.0.1", 8080)).await` starts the server and listens for connections on the specified address.
 
 ### Running the Example
 

--- a/examples/blog-api/src/main.rs
+++ b/examples/blog-api/src/main.rs
@@ -4,7 +4,7 @@ mod database;
 use std::process::ExitCode;
 use std::time::Duration;
 use via::middleware::{error_boundary, timeout};
-use via::{Next, Request, Server};
+use via::{Next, Request};
 
 use database::Pool;
 
@@ -82,6 +82,5 @@ async fn main() -> Result<ExitCode, Error> {
         });
     });
 
-    // Start the server.
-    Server::new(app).listen(("127.0.0.1", 8080)).await
+    via::start(app).listen(("127.0.0.1", 8080)).await
 }

--- a/examples/cookies/src/main.rs
+++ b/examples/cookies/src/main.rs
@@ -1,7 +1,7 @@
 use cookie::{Cookie, Key};
 use std::process::ExitCode;
 use via::middleware::{cookie_parser, error_boundary};
-use via::{Next, Request, Response, Server};
+use via::{Next, Request, Response};
 
 type Error = Box<dyn std::error::Error + Send + Sync>;
 
@@ -118,6 +118,5 @@ async fn main() -> Result<ExitCode, Error> {
     // Add a route that responds with a greeting message.
     app.at("/hello/:name").respond(via::get(hello));
 
-    // Start the server.
-    Server::new(app).listen(("127.0.0.1", 8080)).await
+    via::start(app).listen(("127.0.0.1", 8080)).await
 }

--- a/examples/echo-server/src/main.rs
+++ b/examples/echo-server/src/main.rs
@@ -1,7 +1,7 @@
 use http::header::CONTENT_TYPE;
 use std::process::ExitCode;
 use via::middleware::error_boundary;
-use via::{Next, Pipe, Request, Response, Server};
+use via::{Next, Pipe, Request, Response};
 
 type Error = Box<dyn std::error::Error + Send + Sync>;
 
@@ -35,6 +35,5 @@ async fn main() -> Result<ExitCode, Error> {
     // `via::post` function is used to specify that the `echo` middleware should
     // only accept POST requests.
 
-    // Start the server.
-    Server::new(app).listen(("127.0.0.1", 8080)).await
+    via::start(app).listen(("127.0.0.1", 8080)).await
 }

--- a/examples/file-server/src/main.rs
+++ b/examples/file-server/src/main.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 use via::middleware::error_boundary;
 use via::response::File;
-use via::{Next, Request, Server};
+use via::{Next, Request};
 
 /// The maximum amount of memory that will be allocated to serve a single file.
 ///
@@ -64,6 +64,5 @@ async fn main() -> Result<ExitCode, Error> {
     // Serve any file located in the public dir.
     app.at("/*path").respond(via::get(file_server));
 
-    // Start the server.
-    Server::new(app).listen(("127.0.0.1", 8080)).await
+    via::start(app).listen(("127.0.0.1", 8080)).await
 }

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -1,6 +1,6 @@
 use std::process::ExitCode;
 use via::middleware::error_boundary;
-use via::{Next, Request, Response, Server};
+use via::{Next, Request, Response};
 
 type Error = Box<dyn std::error::Error + Send + Sync>;
 
@@ -29,6 +29,5 @@ async fn main() -> Result<ExitCode, Error> {
     // Define a route that listens on /hello/:name.
     app.at("/hello/:name").respond(via::get(hello));
 
-    // Start the server.
-    Server::new(app).listen(("127.0.0.1", 8080)).await
+    via::start(app).listen(("127.0.0.1", 8080)).await
 }

--- a/examples/shared-state/src/main.rs
+++ b/examples/shared-state/src/main.rs
@@ -4,7 +4,7 @@ use std::process::ExitCode;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use via::middleware::error_boundary;
-use via::{Next, Request, Response, Server};
+use via::{Next, Request, Response};
 
 type Error = Box<dyn std::error::Error + Send + Sync>;
 
@@ -93,6 +93,5 @@ async fn main() -> Result<ExitCode, Error> {
     // Add the `totals` responder to the endpoint GET /totals.
     app.at("/totals").respond(via::get(totals));
 
-    // Start the server.
-    Server::new(app).listen(("127.0.0.1", 8080)).await
+    via::start(app).listen(("127.0.0.1", 8080)).await
 }

--- a/examples/tls-rustls/src/main.rs
+++ b/examples/tls-rustls/src/main.rs
@@ -2,7 +2,7 @@ mod tls;
 
 use std::process::ExitCode;
 use via::middleware::error_boundary;
-use via::{Next, Request, Response, Server};
+use via::{Next, Request, Response};
 
 type Error = Box<dyn std::error::Error + Send + Sync>;
 
@@ -31,8 +31,7 @@ async fn main() -> Result<ExitCode, Error> {
     // Add our hello responder to the endpoint /hello/:name.
     app.at("/hello/:name").respond(via::get(hello));
 
-    // Start the server.
-    Server::new(app)
+    via::start(app)
         .rustls_config(tls_config)
         .listen(("127.0.0.1", 8080))
         .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,8 +46,7 @@
 //!     // Define a route that listens on /hello/:name.
 //!     app.at("/hello/:name").respond(via::get(hello));
 //!
-//!     // Start the server.
-//!     Server::new(app).listen(("127.0.0.1", 8080)).await
+//!     via::start(app).listen(("127.0.0.1", 8080)).await
 //! }
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,4 +72,4 @@ pub use middleware::{Middleware, Next, Result};
 pub use request::Request;
 pub use response::Response;
 pub use router::Route;
-pub use server::Server;
+pub use server::{start, Server};

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -6,4 +6,4 @@ mod io_stream;
 mod serve;
 mod server;
 
-pub use server::Server;
+pub use server::{start, Server};

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -35,6 +35,19 @@ pub struct Server<T> {
     rustls_config: Option<rustls::ServerConfig>,
 }
 
+/// Creates a new server for the provided app.
+///
+pub fn start<T>(app: App<T>) -> Server<T> {
+    Server {
+        app,
+        #[cfg(feature = "rustls")]
+        rustls_config: None,
+        max_connections: None,
+        max_request_size: None,
+        shutdown_timeout: None,
+    }
+}
+
 async fn listen<T, A>(
     acceptor: A,
     address: impl ToSocketAddrs,
@@ -74,26 +87,136 @@ where
     server.await
 }
 
-impl<State> Server<State>
-where
-    State: Send + Sync + 'static,
-{
-    /// Creates a new server for the provided app.
+impl<T: Send + Sync + 'static> Server<T> {
+    /// Set the amount of time in seconds that the server will wait for inflight
+    /// connections to complete before shutting down. The default value is 30
+    /// seconds.
     ///
-    pub fn new(app: App<State>) -> Self {
+    pub fn shutdown_timeout(self, timeout: u64) -> Self {
         Self {
-            app,
-            #[cfg(feature = "rustls")]
-            rustls_config: None,
-            max_connections: None,
-            max_request_size: None,
-            shutdown_timeout: None,
+            shutdown_timeout: Some(timeout),
+            ..self
         }
     }
 
-    /// Starts the server and listens for incoming connections at the provided
-    /// address. Returns a future that resolves with an [`ExitCode`] when the
-    /// server is shutdown.
+    pub fn max_request_size(self, limit: usize) -> Self {
+        Self {
+            max_request_size: Some(limit),
+            ..self
+        }
+    }
+
+    /// Sets the maximum number of concurrent connections that the server can
+    /// accept. The default value is 256.
+    ///
+    /// We suggest not setting this value unless you know what you are doing and
+    /// have a good reason to do so. If you are unsure, it is best to leave this
+    /// value at the default and scale horizontally.
+    ///
+    /// If you do set this value, we suggest doing so by profiling the stack size
+    /// of your application when it's under load and incrementally increasing
+    /// this value until you find a balance between performance and worry-free
+    /// programming. In other words, the closer this value is to the limit based
+    /// on your application's stack consumption and the stack size of your server,
+    /// the more careful you will need to be when allocating values on the stack
+    /// (i.e dereferencing a heap pointer). Otherwise, you may encounter a stack
+    /// overflow. In addition to the stack size, you should also consider not
+    /// setting this value higher than the number of available file descriptors
+    /// (or `ulimit -n`) on POSIX systems.
+    ///
+    pub fn max_connections(self, limit: usize) -> Self {
+        Self {
+            max_connections: Some(limit),
+            ..self
+        }
+    }
+
+    /// Listens for incoming connections at the provided address.
+    ///
+    /// Returns a future that resolves with a result containing an [`ExitCode`]
+    /// when shutdown is requested.
+    ///
+    /// # Errors
+    ///
+    /// If the server fails to bind to the provided address or is unable to
+    /// finish serving all of the inflight connections within the specified
+    /// [shutdown timeout](Self::shutdown_timeout)
+    /// when a shutdown signal is received.
+    ///
+    /// # Panics
+    ///
+    /// If [`rustls_config`](Self::rustls_config)
+    /// was not provided prior to calling this method.
+    ///
+    /// # Exit Codes
+    ///
+    /// An [`ExitCode::SUCCESS`] can be viewed as a confirmation that every
+    /// request was served before exiting the accept loop.
+    ///
+    /// An [`ExitCode::FAILURE`] is an indicator that an unrecoverable error
+    /// occured which requires that the server be restarted in order to function
+    /// as intended.
+    ///
+    /// If you are running your Via application as a daemon with a process
+    /// supervisor such as upstart or systemd, you can use the exit code to
+    /// determine whether or not the process should restart.
+    ///
+    /// If you are running your Via application in a cluster behind a load
+    /// balancer you can use the exit code to properly configure node replacement
+    /// and / or decommissioning logic.
+    ///
+    /// When high availability is mission-critical, and you are scaling your Via
+    /// application both horizontally and vertically using a combination of the
+    /// aforementioned deployment strategies, we recommend configuring a temporal
+    /// threshold for the number of restarts caused by an [`ExitCode::FAILURE`].
+    /// If the threshold is exceeded the cluster should immutably replace the
+    /// node and the process supervisor should not make further attempts to
+    /// restart the process.
+    ///
+    /// This approach significantly reduces the impact of environmental entropy
+    /// on your application's availability while preventing conflicts between the
+    /// process supervisor of an individual node and the replacement and
+    /// decommissioning logic of the cluster.
+    ///
+    #[cfg(not(feature = "rustls"))]
+    pub fn listen<A: ToSocketAddrs>(
+        self,
+        address: A,
+    ) -> impl Future<Output = Result<ExitCode, DynError>> {
+        // Create a HttpAcceptor to serve connections over HTTP.
+        let acceptor = acceptor::http::HttpAcceptor;
+
+        let app = self.app;
+        let max_connections = self.max_connections;
+        let max_request_size = self.max_request_size;
+        let shutdown_timeout = self.shutdown_timeout;
+
+        listen(
+            acceptor,
+            address,
+            app,
+            max_connections,
+            max_request_size,
+            shutdown_timeout,
+        )
+    }
+}
+
+#[cfg(feature = "rustls")]
+impl<T: Send + Sync + 'static> Server<T> {
+    /// Sets the TLS configuration for the server.
+    ///
+    pub fn rustls_config(self, server_config: rustls::ServerConfig) -> Self {
+        Self {
+            rustls_config: Some(server_config),
+            ..self
+        }
+    }
+
+    /// Listens for incoming connections at the provided address.
+    ///
+    /// Returns a future that resolves with a result containing an [`ExitCode`]
+    /// when shutdown is requested.
     ///
     /// # Errors
     ///
@@ -165,121 +288,5 @@ where
             max_request_size,
             shutdown_timeout,
         )
-    }
-
-    /// Starts the server and listens for incoming connections at the provided
-    /// address. Returns a future that resolves when the server is shutdown.
-    ///
-    /// # Errors
-    ///
-    /// If the server fails to bind to the provided address or is unable to
-    /// finish serving all of the inflight connections within the specified
-    /// [shutdown timeout](Self::shutdown_timeout)
-    /// when a shutdown signal is received.
-    ///
-    /// # Exit Codes
-    ///
-    /// An [`ExitCode::SUCCESS`] can be viewed as a confirmation that every
-    /// request was served before exiting the accept loop.
-    ///
-    /// An [`ExitCode::FAILURE`] is an indicator that an unrecoverable error
-    /// occured which requires that the server be restarted in order to function
-    /// as intended.
-    ///
-    /// If you are running your Via application as a daemon with a process
-    /// supervisor such as upstart or systemd, you can use the exit code to
-    /// determine whether or not the process should restart.
-    ///
-    /// If you are running your Via application in a cluster behind a load
-    /// balancer you can use the exit code to properly configure node replacement
-    /// and / or decommissioning logic.
-    ///
-    /// When high availability is mission-critical, and you are scaling your Via
-    /// application both horizontally and vertically using a combination of the
-    /// aforementioned deployment strategies, we recommend configuring a temporal
-    /// threshold for the number of restarts caused by an [`ExitCode::FAILURE`].
-    /// If the threshold is exceeded the cluster should immutably replace the
-    /// node and the process supervisor should not make further attempts to
-    /// restart the process.
-    ///
-    /// This approach significantly reduces the impact of environmental entropy
-    /// on your application's availability while preventing conflicts between the
-    /// process supervisor of an individual node and the replacement and
-    /// decommissioning logic of the cluster.
-    ///
-    #[cfg(not(feature = "rustls"))]
-    pub fn listen<A: ToSocketAddrs>(
-        self,
-        address: A,
-    ) -> impl Future<Output = Result<ExitCode, DynError>> {
-        // Create a HttpAcceptor to serve connections over HTTP.
-        let acceptor = acceptor::http::HttpAcceptor;
-
-        let app = self.app;
-        let max_connections = self.max_connections;
-        let max_request_size = self.max_request_size;
-        let shutdown_timeout = self.shutdown_timeout;
-
-        listen(
-            acceptor,
-            address,
-            app,
-            max_connections,
-            max_request_size,
-            shutdown_timeout,
-        )
-    }
-
-    /// Set the amount of time in seconds that the server will wait for inflight
-    /// connections to complete before shutting down. The default value is 30
-    /// seconds.
-    ///
-    pub fn shutdown_timeout(self, timeout: u64) -> Self {
-        Self {
-            shutdown_timeout: Some(timeout),
-            ..self
-        }
-    }
-
-    pub fn max_request_size(self, limit: usize) -> Self {
-        Self {
-            max_request_size: Some(limit),
-            ..self
-        }
-    }
-
-    /// Sets the maximum number of concurrent connections that the server can
-    /// accept. The default value is 256.
-    ///
-    /// We suggest not setting this value unless you know what you are doing and
-    /// have a good reason to do so. If you are unsure, it is best to leave this
-    /// value at the default and scale horizontally.
-    ///
-    /// If you do set this value, we suggest doing so by profiling the stack size
-    /// of your application when it's under load and incrementally increasing
-    /// this value until you find a balance between performance and worry-free
-    /// programming. In other words, the closer this value is to the limit based
-    /// on your application's stack consumption and the stack size of your server,
-    /// the more careful you will need to be when allocating values on the stack
-    /// (i.e dereferencing a heap pointer). Otherwise, you may encounter a stack
-    /// overflow. In addition to the stack size, you should also consider not
-    /// setting this value higher than the number of available file descriptors
-    /// (or `ulimit -n`) on POSIX systems.
-    ///
-    pub fn max_connections(self, limit: usize) -> Self {
-        Self {
-            max_connections: Some(limit),
-            ..self
-        }
-    }
-
-    /// Sets the TLS configuration for the server.
-    ///
-    #[cfg(feature = "rustls")]
-    pub fn rustls_config(self, server_config: rustls::ServerConfig) -> Self {
-        Self {
-            rustls_config: Some(server_config),
-            ..self
-        }
     }
 }

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -143,11 +143,6 @@ impl<T: Send + Sync + 'static> Server<T> {
     /// [shutdown timeout](Self::shutdown_timeout)
     /// when a shutdown signal is received.
     ///
-    /// # Panics
-    ///
-    /// If [`rustls_config`](Self::rustls_config)
-    /// was not provided prior to calling this method.
-    ///
     /// # Exit Codes
     ///
     /// An [`ExitCode::SUCCESS`] can be viewed as a confirmation that every


### PR DESCRIPTION
Renames `Server::new` to `via::start`. It feels a bit strange using constructor syntax for the server where typically, in Via code–it is reserved for data. This change is inspired both by the themed `.ignite()` function in [Rocket](https://rocket.rs/) as well as the functional API seen in [warp](https://github.com/seanmonstar/warp).