### PR TITLE
fix(via): fd contention in File impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/zacharygolba/via"
 [features]
 default = ["http1"]
 
-fs = ["dep:futures", "dep:httpdate", "dep:tokio-util", "tokio/fs", "tokio/io-util"]
+fs = ["dep:httpdate", "tokio/fs"]
 
 http1 = ["hyper/http1"]
 http2 = ["hyper/http2"]
@@ -22,7 +22,6 @@ rustls = ["dep:tokio-rustls"]
 [dependencies]
 bytes = "1"
 futures-core = { version = "0.3", default-features = false }
-futures = { version = "0.3", optional = true }
 http = "1"
 http-body = "1"
 http-body-util = "0.1"
@@ -33,7 +32,6 @@ percent-encoding = "2"
 serde = "1"
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
-tokio-util = { version = "0.7", features = ["io"], optional = true }
 via-router = { version = "3.0.0-beta.18", features = ["lru-cache"] }
 
 [dependencies.cookie]

--- a/src/response/file.rs
+++ b/src/response/file.rs
@@ -1,5 +1,5 @@
 use bytes::Bytes;
-use futures::Stream;
+use futures_core::Stream;
 use http::header::{CONTENT_LENGTH, CONTENT_TYPE, ETAG, LAST_MODIFIED};
 use httpdate::HttpDate;
 use std::fs::{File as StdFile, Metadata};

--- a/src/response/file.rs
+++ b/src/response/file.rs
@@ -1,16 +1,31 @@
-use futures::TryStreamExt;
+use bytes::Bytes;
+use futures::Stream;
 use http::header::{CONTENT_LENGTH, CONTENT_TYPE, ETAG, LAST_MODIFIED};
 use httpdate::HttpDate;
-use std::fs::Metadata;
+use std::fs::{File as StdFile, Metadata};
+use std::io::Read;
+use std::mem::MaybeUninit;
 use std::path::{Path, PathBuf};
-use tokio::fs;
-use tokio::io::AsyncReadExt;
-use tokio_util::io::ReaderStream;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+use tokio::fs::File as TokioFile;
+use tokio::io::{AsyncRead, ReadBuf};
+use tokio::{task, time};
 
-use super::Response;
+use super::{Response, ResponseBuilder};
 use crate::body::{Pipe, MAX_FRAME_LEN};
-use crate::error::Error;
+use crate::error::{DynError, Error};
 use crate::middleware;
+
+/// The base amount of time that the server will wait before
+/// attempting to open a file after an error has occurred.
+///
+const BASE_DELAY_IN_MILLIS: u64 = 100;
+
+/// The amount of times that we'll retry to open a file if in an error occurs.
+///
+const MAX_ATTEMPTS: u64 = 3;
 
 /// A function pointer used to generate an etag.
 ///
@@ -25,12 +40,75 @@ pub struct File {
     with_last_modified: bool,
 }
 
+/// The possible outcomes from attempting to open a file.
+///
+enum Open {
+    /// The file was small enough to be read in to memory.
+    ///
+    Eager(Metadata, Vec<u8>),
+
+    /// The file should be streamed over the socket with chunked
+    /// `Transfer-Encoding`.
+    ///
+    Stream(usize, Metadata, TokioFile),
+}
+
+/// A stream that wraps the `AsyncRead` impl for `TokioFile`.
+///
+#[must_use = "streams do nothing unless polled"]
+struct FileStream {
+    remaining: usize,
+    buffer: Vec<MaybeUninit<u8>>,
+    file: Option<TokioFile>,
+}
+
+/// Attempt to open the file and access the metadata at the provided path.
+///
+/// If the file size is less than `max_alloc_size`, the contents will be
+/// eagerly read into memory.
+///
+async fn open(path: &Path, max_alloc_size: usize) -> Result<Open, Error> {
+    let mut attempts = 0;
+
+    loop {
+        let path = path.to_owned();
+        let delay = BASE_DELAY_IN_MILLIS << attempts;
+        let future = task::spawn_blocking(move || {
+            let mut std = StdFile::open(path)?;
+            let metadata = std.metadata()?;
+            let required_cap = isize::try_from(metadata.len())? as usize;
+
+            if required_cap > max_alloc_size {
+                let mut file = TokioFile::from_std(std);
+
+                file.set_max_buf_size(MAX_FRAME_LEN);
+                Ok(Open::Stream(required_cap, metadata, file))
+            } else {
+                let mut data = Vec::with_capacity(required_cap);
+
+                std.read_to_end(&mut data)?;
+                Ok(Open::Eager(metadata, data))
+            }
+        });
+
+        break match future.await? {
+            Err(error) if attempts > MAX_ATTEMPTS => Err(error),
+            Ok(file_with_metadata) => Ok(file_with_metadata),
+            Err(_) => {
+                time::sleep(Duration::from_millis(delay)).await;
+                attempts += 1;
+                continue;
+            }
+        };
+    }
+}
+
 impl File {
     /// Specify the path at which the file we want to serve is located.
     ///
     pub fn open(path: impl AsRef<Path>) -> Self {
         Self {
-            path: path.as_ref().to_path_buf(),
+            path: path.as_ref().to_owned(),
             etag: None,
             content_type: None,
             with_last_modified: false,
@@ -68,24 +146,8 @@ impl File {
 
     /// Respond with a stream of the file contents in chunks.
     ///
-    pub async fn stream(mut self) -> middleware::Result {
-        let file = fs::File::open(&self.path).await.map_err(Error::from_io)?;
-        let meta = file.metadata().await.map_err(Error::from_io)?;
-
-        self.stream_file(&meta, file)
-    }
-
-    /// Respond with the entire contents of the file loaded in to memory.
-    ///
-    pub async fn send(mut self) -> middleware::Result {
-        let mut file = fs::File::open(&self.path).await.map_err(Error::from_io)?;
-        let meta = file.metadata().await.map_err(Error::from_io)?;
-        let len = isize::try_from(meta.len())? as usize;
-
-        let mut data = Vec::with_capacity(len);
-
-        file.read_to_end(&mut data).await.map_err(Error::from_io)?;
-        self.respond_from_memory(&meta, data)
+    pub async fn stream(self) -> middleware::Result {
+        self.serve(0).await
     }
 
     /// Respond with the contents of the file.
@@ -93,37 +155,34 @@ impl File {
     /// If the file is larger than the provided `max_alloc_size` in bytes, it
     /// will be streamed over the socket with chunked transfer encoding.
     ///
-    pub async fn serve(mut self, max_alloc_size: usize) -> middleware::Result {
-        let mut file = fs::File::open(&self.path).await.map_err(Error::from_io)?;
-        let meta = file.metadata().await.map_err(Error::from_io)?;
-        let len = isize::try_from(meta.len())? as usize;
-
-        if len > max_alloc_size {
-            self.stream_file(&meta, file)
-        } else {
-            let mut data = Vec::with_capacity(len);
-
-            file.read_to_end(&mut data).await.map_err(Error::from_io)?;
-            self.respond_from_memory(&meta, data)
+    pub async fn serve(self, max_alloc_size: usize) -> middleware::Result {
+        match open(&self.path, max_alloc_size).await? {
+            Open::Eager(meta, data) => {
+                let response = Response::build().header(CONTENT_LENGTH, data.len());
+                self.set_headers(&meta, response)?.body(data)
+            }
+            Open::Stream(len, meta, file) => {
+                let response = self.set_headers(&meta, Response::build())?;
+                FileStream::new(len, file).pipe(response)
+            }
         }
     }
 
-    fn gen_etag(&self, meta: &Metadata) -> Result<Option<String>, Error> {
-        match self.etag.as_ref() {
-            Some(f) => f(meta),
-            None => Ok(None),
-        }
-    }
+    fn set_headers(
+        &self,
+        meta: &Metadata,
+        builder: ResponseBuilder,
+    ) -> Result<ResponseBuilder, Error> {
+        let mut response = builder;
 
-    fn stream_file(&mut self, meta: &Metadata, mut file: fs::File) -> middleware::Result {
-        let mut response = Response::build();
-
-        if let Some(mime_type) = self.content_type.take() {
+        if let Some(mime_type) = self.content_type.as_ref() {
             response = response.header(CONTENT_TYPE, mime_type);
         }
 
-        if let Some(etag) = self.gen_etag(meta)? {
-            response = response.header(ETAG, etag);
+        if let Some(f) = self.etag.as_ref() {
+            if let Some(etag) = f(meta)? {
+                response = response.header(ETAG, etag);
+            }
         }
 
         if self.with_last_modified {
@@ -131,29 +190,52 @@ impl File {
             response = response.header(LAST_MODIFIED, last_modified.to_string());
         }
 
-        file.set_max_buf_size(MAX_FRAME_LEN * 2);
-
-        ReaderStream::new(file)
-            .map_err(|error| error.into())
-            .pipe(response)
+        Ok(response)
     }
+}
 
-    fn respond_from_memory(&mut self, meta: &Metadata, data: Vec<u8>) -> middleware::Result {
-        let mut response = Response::build().header(CONTENT_LENGTH, data.len());
+impl FileStream {
+    fn new(remaining: usize, file: TokioFile) -> Self {
+        Self {
+            remaining,
+            buffer: vec![MaybeUninit::uninit(); MAX_FRAME_LEN],
+            file: Some(file),
+        }
+    }
+}
 
-        if let Some(mime_type) = self.content_type.take() {
-            response = response.header(CONTENT_TYPE, mime_type);
+impl Stream for FileStream {
+    type Item = Result<Bytes, DynError>;
+
+    fn poll_next(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+
+        if this.remaining == 0 {
+            this.file = None;
+            this.buffer.fill(MaybeUninit::uninit());
+            return Poll::Ready(None);
         }
 
-        if let Some(etag) = self.gen_etag(meta)? {
-            response = response.header(ETAG, etag);
-        }
+        let mut data = ReadBuf::uninit(&mut this.buffer);
+        let mut file = match this.file.as_mut() {
+            None => return Poll::Ready(None),
+            Some(file) => file,
+        };
 
-        if self.with_last_modified {
-            let last_modified = HttpDate::from(meta.modified()?);
-            response = response.header(LAST_MODIFIED, last_modified.to_string());
-        }
+        match Pin::new(&mut file).poll_read(context, &mut data) {
+            Poll::Pending => Poll::Pending,
 
-        response.body(data)
+            Poll::Ready(Ok(())) => {
+                let filled = data.filled();
+                this.remaining -= filled.len();
+                Poll::Ready(Some(Ok(Bytes::copy_from_slice(filled))))
+            }
+
+            Poll::Ready(Err(error)) => {
+                this.file = None;
+                this.buffer.fill(MaybeUninit::uninit());
+                Poll::Ready(Some(Err(error.into())))
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes #152 

---

Fixes contention in the implementation of `File` by doing as much as we can in the first call to `task::spawn_blocking` to open the file. Also provides a custom wrapper around `AsyncRead` for file to ensure that `File` is dropped when it is no longer in use. I chose not to use the exponential-backoff crate as it's easier to reason about the control flow of the code this way.
