### PR TITLE
refactor(via): buffer ResponseBody in 16kb chunks

### DIFF
--- a/src/body/response_body.rs
+++ b/src/body/response_body.rs
@@ -9,9 +9,9 @@ use crate::error::DynError;
 
 /// The maximum amount of data that can be read from a buffered body per frame.
 ///
-pub const MAX_FRAME_LEN: usize = 8192; // 8KB
+pub const MAX_FRAME_LEN: usize = 16384; // 16KB
 
-/// A buffered `impl Body` that is read in `8KB` chunks.
+/// A buffered `impl Body` that is read in `16KB` chunks.
 ///
 #[must_use = "streams do nothing unless polled"]
 pub struct ResponseBody {


### PR DESCRIPTION
Increases the buffer size for `ResponseBody` to `16kb`. I'm guessing with a high degree of certainty that this will be more efficient than the previous implementation as the larger buffer size should provide the benefit that using `Full` provides for a `10KB` in-memory json response body since `Body::poll_frame`. This also should provide a performance improvement for files streamed with the `File` API as less system calls are required to read the entire contents of a file. I prefer to not have this number be configurable but imagine it could change in the future to perhaps `24kb` or `32kb` as we benchmark performance prior to releasing the official version 2.0.