### PR TITLE
fix(via): if File is not present do not retry

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -68,14 +68,16 @@ impl Error {
                 Self::bad_request(Box::new(source))
             }
 
+            io::ErrorKind::IsADirectory
+            | io::ErrorKind::NotADirectory
+            | io::ErrorKind::PermissionDenied => {
+                // Implies restricted access.
+                Self::forbidden(Box::new(source))
+            }
+
             io::ErrorKind::NotFound => {
                 // Indicates a missing resource.
                 Self::not_found(Box::new(source))
-            }
-
-            io::ErrorKind::PermissionDenied => {
-                // Implies restricted access.
-                Self::forbidden(Box::new(source))
             }
 
             io::ErrorKind::TimedOut => {


### PR DESCRIPTION
Fixes a bug where the File API does not properly set status codes for missing or forbidden files.