### PR TITLE
chore(via): bump version to 2.0.0-rc.25

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-rc.24"
+version = "2.0.0-rc.25"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following to dependencies section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-via = "2.0.0-rc.24"
+via = "2.0.0-rc.25"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 ```
 


### PR DESCRIPTION
Hotfix release for a bug in the new, feature flagged File API. Bumps Via to version `2.0.0-rc.25`.

## Changelog

- #157
