### PR TITLE
fix(via): uninit self.buffer asap in FileStream

### DIFF
--- a/src/response/file.rs
+++ b/src/response/file.rs
@@ -233,8 +233,14 @@ impl Stream for FileStream {
                 let filled = data.filled();
 
                 if let Some(remaining) = this.remaining.checked_sub(filled.len()) {
+                    let data = Bytes::copy_from_slice(filled);
                     this.remaining = remaining;
-                    Poll::Ready(Some(Ok(Bytes::copy_from_slice(filled))))
+
+                    if remaining == 0 {
+                        this.buffer.fill(MaybeUninit::uninit());
+                    }
+
+                    Poll::Ready(Some(Ok(data)))
                 } else {
                     this.remaining = 0;
                     this.buffer.fill(MaybeUninit::uninit());


### PR DESCRIPTION
Pedantically cleans up the buffer to prevent partial files from being read if they're lingering in memory in favor of poorer performance as the worst case scenario 16kb bytes instance gets moved from `data` to `Poll::Ready(Some(Ok(_)))`.

I prefer to optimize for case where PHI in a partially read informed consent PDF from an online therapy company leaking into the wrong hands is impossible as this framework is built with the finance and health care industries in mind.

Once again, if high-availability is ever the only thing that should be in mind of the product I'm building in my professional life–I would probably use a combination of S3 and CloudFront. While both of these options in the cloud are very secure and even HIPAA compliant when used correctly with per user object level permissioning it takes a lot to get right. Also, I wouldn't mind if my local doctor was able to serve my records on premise if possible.