### PR TITLE
fix(via): prefer boxing the connection

### DIFF
--- a/src/body/stream_body.rs
+++ b/src/body/stream_body.rs
@@ -23,7 +23,7 @@ impl<T> StreamBody<T> {
 
 impl<T> StreamBody<T> {
     #[inline]
-    pub fn project(self: Pin<&mut Self>) -> Pin<&mut T> {
+    fn project(self: Pin<&mut Self>) -> Pin<&mut T> {
         unsafe { self.map_unchecked_mut(|this| &mut this.stream) }
     }
 }

--- a/src/server/io_stream.rs
+++ b/src/server/io_stream.rs
@@ -4,7 +4,6 @@
 // struct in [hyper-util](https://docs.rs/hyper-util).
 //
 
-use futures_core::ready;
 use hyper::rt::{Read, ReadBufCursor, Write};
 use std::io::{Error, IoSlice};
 use std::pin::Pin;
@@ -14,21 +13,26 @@ use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 /// A hyper-compatible wrapper for a duplex stream.
 ///
 pub struct IoStream<T> {
-    stream: Pin<Box<T>>,
+    stream: T,
 }
 
 impl<T> IoStream<T> {
     #[inline]
     pub fn new(stream: T) -> Self {
-        Self {
-            stream: Box::pin(stream),
-        }
+        Self { stream }
+    }
+}
+
+impl<T> IoStream<T> {
+    #[inline]
+    fn project(self: Pin<&mut Self>) -> Pin<&mut T> {
+        unsafe { self.map_unchecked_mut(|this| &mut this.stream) }
     }
 }
 
 impl<R: AsyncRead> Read for IoStream<R> {
     fn poll_read(
-        mut self: Pin<&mut Self>,
+        self: Pin<&mut Self>,
         context: &mut Context<'_>,
         mut cursor: ReadBufCursor<'_>,
     ) -> Poll<Result<(), Error>> {
@@ -42,8 +46,10 @@ impl<R: AsyncRead> Read for IoStream<R> {
         //
         let mut buf = unsafe { ReadBuf::uninit(cursor.as_mut()) };
 
-        ready!(self.stream.as_mut().poll_read(context, &mut buf)?);
-        let len = buf.filled().len();
+        let len = match self.project().poll_read(context, &mut buf)? {
+            Poll::Pending => return Poll::Pending,
+            Poll::Ready(_) => buf.filled().len(),
+        };
 
         // Bytes were read into buf successfully. Advance the cursor by the
         // number of bytes that were read.
@@ -64,30 +70,27 @@ impl<R: AsyncRead> Read for IoStream<R> {
 
 impl<W: AsyncWrite> Write for IoStream<W> {
     fn poll_write(
-        mut self: Pin<&mut Self>,
+        self: Pin<&mut Self>,
         context: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<Result<usize, Error>> {
-        self.stream.as_mut().poll_write(context, buf)
+        self.project().poll_write(context, buf)
     }
 
-    fn poll_flush(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Result<(), Error>> {
-        self.stream.as_mut().poll_flush(context)
+    fn poll_flush(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Result<(), Error>> {
+        self.project().poll_flush(context)
     }
 
-    fn poll_shutdown(
-        mut self: Pin<&mut Self>,
-        context: &mut Context<'_>,
-    ) -> Poll<Result<(), Error>> {
-        self.stream.as_mut().poll_shutdown(context)
+    fn poll_shutdown(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Result<(), Error>> {
+        self.project().poll_shutdown(context)
     }
 
     fn poll_write_vectored(
-        mut self: Pin<&mut Self>,
+        self: Pin<&mut Self>,
         context: &mut Context<'_>,
         buf_list: &[IoSlice<'_>],
     ) -> Poll<Result<usize, Error>> {
-        self.stream.as_mut().poll_write_vectored(context, buf_list)
+        self.project().poll_write_vectored(context, buf_list)
     }
 
     fn is_write_vectored(&self) -> bool {

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -121,14 +121,14 @@ where
             let mut conn_mut = Pin::new(&mut connection);
 
             // Serve the connection.
-            if let Err(_) = tokio::select!(
+            if let Err(error) = tokio::select!(
                 result = conn_mut.as_mut() => result,
                 _ = shutdown_rx.changed() => {
                     conn_mut.as_mut().graceful_shutdown();
                     conn_mut.as_mut().await
                 }
             ) {
-                // Placeholder for tracing...
+                let _ = &error; // Placeholder for tracing...
             }
 
             drop(permit);


### PR DESCRIPTION
This change gives IoStream a predictable size and should be a reasonable alternative to boxing the connection future so it can continue to be polled on the stack. This change is mainly an improvement for apps that use the rustls feature flag.