### PR TITLE
refactor(via): introduce stateless error boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Below is a basic example to demonstrate how to use Via to create a simple web se
 ```rust
 use std::process::ExitCode;
 use via::middleware::error_boundary;
-use via::{Next, Request, Response, Server};
+use via::{Next, Request, Response};
 
 type Error = Box<dyn std::error::Error + Send + Sync>;
 
@@ -44,8 +44,9 @@ async fn main() -> Result<ExitCode, Error> {
     let mut app = via::app(());
 
     // Include an error boundary to catch any errors that occur downstream.
-    app.include(error_boundary::inspect(|_, error| {
-        eprintln!("Error: {}", error);
+    app.include(error_boundary::map(|error| {
+        eprintln!("error: {}", error);
+        error.use_canonical_reason()
     }));
 
     // Define a route that listens on /hello/:name.

--- a/examples/blog-api/src/api/util.rs
+++ b/examples/blog-api/src/api/util.rs
@@ -7,6 +7,8 @@ use via::Error;
 /// JSON and do not leak sensitive information to the client.
 ///
 pub fn map_error(error: Error) -> Error {
+    eprintln!("error: {}", error);
+
     match error.source().downcast_ref() {
         // The error occurred because a database record was not found.
         Some(DieselError::NotFound) => error

--- a/examples/blog-api/src/main.rs
+++ b/examples/blog-api/src/main.rs
@@ -44,10 +44,7 @@ async fn main() -> Result<ExitCode, Error> {
 
         // Catch any errors that occur in the API namespace and generate a
         // JSON response from a redacted version of the original error.
-        api.include(error_boundary::map(|_, error| {
-            eprintln!("Error: {}", error); // Placeholder for tracing...
-            util::map_error(error)
-        }));
+        api.include(error_boundary::map(util::map_error));
 
         // Add a timeout middleware to the /api routes. This will prevent the
         // server from waiting indefinitely if we lose connection to the

--- a/examples/cookies/src/main.rs
+++ b/examples/cookies/src/main.rs
@@ -101,8 +101,8 @@ async fn main() -> Result<ExitCode, Error> {
     });
 
     // Include an error boundary to catch any errors that occur downstream.
-    app.include(error_boundary::map(|_, error| {
-        eprintln!("Error: {}", error);
+    app.include(error_boundary::map(|error| {
+        eprintln!("error: {}", error);
         error.use_canonical_reason()
     }));
 

--- a/examples/echo-server/src/main.rs
+++ b/examples/echo-server/src/main.rs
@@ -23,8 +23,9 @@ async fn main() -> Result<ExitCode, Error> {
     let mut app = via::app(());
 
     // Include an error boundary to catch any errors that occur downstream.
-    app.include(error_boundary::inspect(|_, error| {
-        eprintln!("Error: {}", error);
+    app.include(error_boundary::map(|error| {
+        eprintln!("error: {}", error);
+        error.use_canonical_reason()
     }));
 
     // Add our echo responder to the endpoint /echo.

--- a/examples/file-server/src/main.rs
+++ b/examples/file-server/src/main.rs
@@ -57,8 +57,9 @@ async fn main() -> Result<ExitCode, Error> {
     let mut app = via::app(());
 
     // Include an error boundary to catch any errors that occur downstream.
-    app.include(error_boundary::inspect(|_, error| {
-        eprintln!("Error: {}", error);
+    app.include(error_boundary::map(|error| {
+        eprintln!("error: {}", error);
+        error.use_canonical_reason()
     }));
 
     // Serve any file located in the public dir.

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -18,8 +18,9 @@ async fn main() -> Result<ExitCode, Error> {
     let mut app = via::app(());
 
     // Include an error boundary to catch any errors that occur downstream.
-    app.include(error_boundary::inspect(|_, error| {
-        eprintln!("Error: {}", error);
+    app.include(error_boundary::map(|error| {
+        eprintln!("error: {}", error);
+        error.use_canonical_reason()
     }));
 
     // Define a route that listens on /hello/:name.

--- a/examples/shared-state/src/main.rs
+++ b/examples/shared-state/src/main.rs
@@ -80,8 +80,8 @@ async fn main() -> Result<ExitCode, Error> {
     });
 
     // Include an error boundary to catch any errors that occur downstream.
-    app.include(error_boundary::map(|_, error| {
-        eprintln!("Error: {}", error);
+    app.include(error_boundary::map(|error| {
+        eprintln!("error: {}", error);
         error.use_canonical_reason()
     }));
 

--- a/examples/tls-rustls/src/main.rs
+++ b/examples/tls-rustls/src/main.rs
@@ -24,8 +24,9 @@ async fn main() -> Result<ExitCode, Error> {
     let mut app = via::app(());
 
     // Include an error boundary to catch any errors that occur downstream.
-    app.include(error_boundary::inspect(|_, error| {
-        eprintln!("Error: {}", error);
+    app.include(error_boundary::map(|error| {
+        eprintln!("error: {}", error);
+        error.use_canonical_reason()
     }));
 
     // Add our hello responder to the endpoint /hello/:name.

--- a/src/error.rs
+++ b/src/error.rs
@@ -157,7 +157,7 @@ impl Error {
     ///     // Add an `ErrorBoundary` middleware to the route tree that maps
     ///     // errors that occur in subsequent middleware by calling the `redact`
     ///     // function.
-    ///     app.include(error_boundary::map(|_, error| {
+    ///     app.include(error_boundary::map(|error| {
     ///         error.redact(|message| {
     ///             if message.contains("password") {
     ///                 // If password is even mentioned in the error, return an
@@ -229,7 +229,7 @@ impl Error {
     ///     // Add an `ErrorBoundary` middleware to the route tree that maps
     ///     // errors that occur in subsequent middleware by calling the
     ///     // `use_canonical_reason` function.
-    ///     app.include(error_boundary::map(|_, error| {
+    ///     app.include(error_boundary::map(|error| {
     ///         // Prevent error messages that occur in downstream middleware from
     ///         // leaking into the response body by using the reason phrase of
     ///         // the status code associated with the error.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,8 +39,9 @@
 //!     let mut app = via::app(());
 //!
 //!     // Include an error boundary to catch any errors that occur downstream.
-//!     app.include(error_boundary::inspect(|_, error| {
-//!         eprintln!("Error: {}", error);
+//!     app.include(error_boundary::map(|error| {
+//!         eprintln!("error: {}", error);
+//!         error.use_canonical_reason()
 //!     }));
 //!
 //!     // Define a route that listens on /hello/:name.

--- a/src/middleware/error_boundary.rs
+++ b/src/middleware/error_boundary.rs
@@ -4,13 +4,33 @@ use super::middleware::Middleware;
 use super::next::Next;
 use crate::error::Error;
 use crate::request::Request;
-use crate::response::Response;
 
 /// A middleware that catches errors that occur downstream and then calls the
 /// provided closure to inspect the error to another error. Think of this as a
 /// [`Result::inspect_err`] for middleware.
 ///
 pub fn inspect<T, F>(inspect: F) -> impl Middleware<T>
+where
+    F: Fn(&Error) + Copy + Send + Sync + 'static,
+    T: Send + Sync + 'static,
+{
+    move |request: Request<T>, next: Next<T>| {
+        let future = next.call(request);
+
+        async move {
+            future.await.or_else(|error| {
+                inspect(&error);
+                Ok(error.into())
+            })
+        }
+    }
+}
+
+/// Similar to [`inspect`], but includes an owned arc to the state argument
+/// that was passed to [`via::app`](crate::app::app) as the first argument
+/// to the provided closure.
+///
+pub fn inspect_with_state<T, F>(inspect: F) -> impl Middleware<T>
 where
     F: Fn(Arc<T>, &Error) + Copy + Send + Sync + 'static,
     T: Send + Sync + 'static,
@@ -40,11 +60,29 @@ where
 /// provided closure to map the error to another error. Think of this as a
 /// `Result::map` for middleware.
 ///
-/// Middleware that is upstream from a `MapErrorBoundary` will continue to
-/// execute as usual since the error returned from the provided `map` function
-/// is eagerly converted into a response.
-///
 pub fn map<T, F>(map: F) -> impl Middleware<T>
+where
+    F: Fn(Error) -> Error + Copy + Send + Sync + 'static,
+    T: Send + Sync + 'static,
+{
+    move |request: Request<T>, next: Next<T>| {
+        let future = next.call(request);
+
+        async move {
+            // Await the future. If it resolves to a `Result::Err`, call the
+            // provided map function with the error and a reference to the global
+            // application state. Then generate a response from the returned
+            // error.
+            future.await.or_else(|error| Ok(map(error).into()))
+        }
+    }
+}
+
+/// Similar to [`map`], but includes an owned arc to the state argument that
+/// was passed to [`via::app`](crate::app::app) as the first argument to the
+/// provided closure.
+///
+pub fn map_with_state<T, F>(map: F) -> impl Middleware<T>
 where
     F: Fn(Arc<T>, Error) -> Error + Copy + Send + Sync + 'static,
     T: Send + Sync + 'static,
@@ -64,37 +102,6 @@ where
             // application state. Then generate a response from the returned
             // error.
             future.await.or_else(|error| Ok(map(state, error).into()))
-        }
-    }
-}
-
-/// A middleware that catches errors that occur downstream and then calls the
-/// provided closure to map the error to another result. Think of this as a
-/// `Result::or_else` for middleware.
-///
-/// Middleware that is upstream from a `OrElseErrorBoundary` will continue to
-/// execute as usual since the result returned from the provided `or_else`
-/// function is eagerly converted into a response.
-///
-pub fn or_else<T, F>(or_else: F) -> impl Middleware<T>
-where
-    F: Fn(Arc<T>, Error) -> Result<Response, Error> + Copy + Send + Sync + 'static,
-    T: Send + Sync + 'static,
-{
-    move |request: Request<T>, next: Next<T>| {
-        // Clone `request.state` so it can be used after ownership of `request`
-        // is transfered to `next.call()`.
-        let state = request.state().clone();
-
-        // Call the next middleware to get a future that will resolve to a
-        // response.
-        let future = next.call(request);
-
-        async move {
-            // Await the future. If it resolves to a `Result::Err`, call the p
-            // provided or_else function with the error and a reference to the
-            // global application state.
-            future.await.or_else(|error| or_else(state, error))
         }
     }
 }


### PR DESCRIPTION
Introduces stateless error boundaries to give users the option to opt out of an extra arc clone if state isn't required to map or inspect an error.