### PR TITLE
refactor(via-router): prefer a has_nodes flag in Binding

### DIFF
--- a/via-router/src/binding.rs
+++ b/via-router/src/binding.rs
@@ -70,9 +70,7 @@ impl<'a, T> Binding<'a, T> {
     #[inline]
     pub(crate) fn push(&mut self, node: MatchKind<'a, T>) {
         self.nodes.push(node);
-        if !self.has_nodes {
-            self.has_nodes = true;
-        }
+        self.has_nodes = true;
     }
 }
 

--- a/via-router/src/binding.rs
+++ b/via-router/src/binding.rs
@@ -19,19 +19,15 @@ pub enum MatchKind<'a, T> {
 ///
 #[derive(Debug)]
 pub struct Binding<'a, T> {
-    range: Option<[usize; 2]>,
+    has_nodes: bool,
     nodes: SmallVec<[MatchKind<'a, T>; 1]>,
+    range: Option<[usize; 2]>,
 }
 
 impl<T> Binding<'_, T> {
     #[inline]
-    pub fn len(&self) -> usize {
-        self.nodes.len()
-    }
-
-    #[inline]
-    pub fn is_empty(&self) -> bool {
-        self.nodes.is_empty()
+    pub fn has_nodes(&self) -> bool {
+        self.has_nodes
     }
 
     #[inline]
@@ -47,13 +43,36 @@ impl<T> Binding<'_, T> {
 
 impl<'a, T> Binding<'a, T> {
     #[inline]
-    pub(crate) fn new(range: Option<[usize; 2]>, nodes: SmallVec<[MatchKind<'a, T>; 1]>) -> Self {
-        Self { range, nodes }
+    pub(crate) fn new(range: [usize; 2]) -> Self {
+        Self {
+            has_nodes: false,
+            nodes: SmallVec::new(),
+            range: Some(range),
+        }
+    }
+
+    pub(crate) fn new_with_nodes(
+        range: Option<[usize; 2]>,
+        nodes: SmallVec<[MatchKind<'a, T>; 1]>,
+    ) -> Self {
+        debug_assert!(
+            !nodes.is_empty(),
+            "Binding::new_with_nodes requires that nodes is not empty"
+        );
+
+        Self {
+            has_nodes: true,
+            nodes,
+            range,
+        }
     }
 
     #[inline]
     pub(crate) fn push(&mut self, node: MatchKind<'a, T>) {
         self.nodes.push(node);
+        if !self.has_nodes {
+            self.has_nodes = true;
+        }
     }
 }
 

--- a/via-router/src/router.rs
+++ b/via-router/src/router.rs
@@ -203,7 +203,7 @@ impl<T> Router<T> {
 
             nodes.push(wildcard);
             nodes.extend(wildcards);
-            results.push(Binding::new_with_nodes(None, nodes))
+            results.push(Binding::new_with_nodes(None, nodes));
         }
 
         results

--- a/via-router/src/router.rs
+++ b/via-router/src/router.rs
@@ -145,21 +145,22 @@ impl<T> Router<T> {
         let tree = &self.tree;
 
         if let Some(root) = tree.first() {
-            let mut binding = Binding::new(None, SmallVec::new());
+            let mut nodes = SmallVec::new();
 
             branch.extend_from_slice(&root.children);
 
-            binding.push(MatchKind::edge(!segments.has_next(), root));
-            results.push(binding);
+            nodes.push(MatchKind::edge(!segments.has_next(), root));
+            results.push(Binding::new_with_nodes(None, nodes));
         }
 
         for (is_exact, range) in &mut segments {
-            let mut binding = Binding::new(Some(range), SmallVec::new());
+            let mut binding = Binding::new(range);
             let segment = &path[range[0]..range[1]];
 
             for key in branch.drain(..) {
                 let node = tree.get(key).unwrap();
-                let kind = match &node.pattern {
+
+                binding.push(match &node.pattern {
                     Pattern::Static(value) => {
                         if value == segment {
                             next.push(&node.children);
@@ -176,34 +177,33 @@ impl<T> Router<T> {
                     Pattern::Root => {
                         continue;
                     }
-                };
-
-                binding.push(kind);
+                });
             }
 
             for children in next.drain(..) {
                 branch.extend_from_slice(children);
             }
 
-            if !binding.is_empty() {
+            if binding.has_nodes() {
                 results.push(binding);
             }
         }
 
-        let mut wildcards = branch
-            .drain(..)
-            .filter_map(|key| {
-                let node = tree.get(key).unwrap();
-                if let Pattern::Wildcard(_) = &node.pattern {
-                    Some(MatchKind::wildcard(node))
-                } else {
-                    None
-                }
-            })
-            .peekable();
+        let mut wildcards = branch.drain(..).filter_map(|key| {
+            let node = tree.get(key).unwrap();
+            if let Pattern::Wildcard(_) = &node.pattern {
+                Some(MatchKind::wildcard(node))
+            } else {
+                None
+            }
+        });
 
-        if wildcards.peek().is_some() {
-            results.push(Binding::new(None, wildcards.collect()));
+        if let Some(wildcard) = wildcards.next() {
+            let mut nodes = SmallVec::new();
+
+            nodes.push(wildcard);
+            nodes.extend(wildcards);
+            results.push(Binding::new_with_nodes(None, nodes))
         }
 
         results


### PR DESCRIPTION
Keeps a boolean flag as a cache for whether or not `!self.nodes.is_empty()` in Binding. This change is motivated by the following:

1. Binding should fit in a single cache line (also in the vec) at this size (`64` instead of `56`). This also benefits memory alignment in the results vec returned from `Router::visit`

2. The code instead the for loop in visit has less branching because we no longer have to query whether or not `self.nodes` spilled to the heap

3. We can use a specialized method that no longer has to be negated `self.has_nodes` vs. `!node.is_empty()`

