### PR TITLE
chore(via-router): bump version to 3.0.0-beta.22

### DIFF
--- a/via-router/Cargo.toml
+++ b/via-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via-router"
-version = "3.0.0-beta.21"
+version = "3.0.0-beta.22"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Via Router v3.0.0-beta.22

## Changelog

- #182
- #181
- #180