### PR TITLE
chore(via): bump version to 2.0.0-rc.32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-rc.31"
+version = "2.0.0-rc.32"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -32,7 +32,7 @@ percent-encoding = "2"
 serde = "1"
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
-via-router = "3.0.0-beta.21"
+via-router = "3.0.0-beta.22"
 
 [dependencies.cookie]
 version = "0.18"


### PR DESCRIPTION
Via v2.0.0-rc.32

# Changelog

- #183