### PR TITLE
chore(via): bump via-router to 3.0.0-beta.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ percent-encoding = "2"
 serde = "1"
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
-via-router = "3.0.0-beta.22"
+via-router = "3.0.0-beta.23"
 
 [dependencies.cookie]
 version = "0.18"


### PR DESCRIPTION
Bumps via-router to the latest version prior to releasing v2.0.0-rc.32.