### PR TITLE
fix(via): Pin<&mut Connection> cannot be used outside select

### DIFF
--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -133,7 +133,7 @@ where
                         result = &mut connection => result.map_err(|e| e.into()),
                         _ = shutdown_rx.changed() => {
                             connection.as_mut().graceful_shutdown();
-                            connection.as_mut().await.map_err(|e| e.into())
+                            connection.await.map_err(|e| e.into())
                         }
                     }
                 }


### PR DESCRIPTION
Consumes the pin containing the mutable reference to the connection rather than re-borrowing it before shutdown. This should have no effect on the security or stability of the server. It does however, prevent the pin connection from being used after one of the select branches complete. This means that it's impossible to poll connection after it is closed and if you try to do so, it's a compile time error. The type of thing that excites us Rust developers.

The actual connection struct is dropped at the location and under the same circumstances as the last release. No changes.
