### PR TITLE
fix(clippy): disambiguate elided lifetimes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ hyper-util = { version = "0.1", features = ["tokio"] }
 percent-encoding = "2"
 serde = "1"
 serde_json = "1"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
+tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal"] }
 via-router = { path = "./via-router" }
 
 [dependencies.cookie]

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -18,7 +18,7 @@ pub fn app<T>(state: T) -> App<T> {
 }
 
 impl<T> App<T> {
-    pub fn at(&mut self, path: &'static str) -> Route<T> {
+    pub fn at(&mut self, path: &'static str) -> Route<'_, T> {
         Route {
             inner: self.router.at(path),
         }

--- a/src/app/router.rs
+++ b/src/app/router.rs
@@ -9,7 +9,7 @@ pub struct Route<'a, T> {
 }
 
 impl<T> Route<'_, T> {
-    pub fn at(&mut self, path: &'static str) -> Route<T> {
+    pub fn at(&mut self, path: &'static str) -> Route<'_, T> {
         Route {
             inner: self.inner.at(path),
         }

--- a/src/request/param/decode.rs
+++ b/src/request/param/decode.rs
@@ -6,7 +6,7 @@ use crate::error::Error;
 /// A trait that defines how to decode the value of a parameter.
 ///
 pub trait DecodeParam {
-    fn decode(encoded: &str) -> Result<Cow<str>, Error>;
+    fn decode(encoded: &str) -> Result<Cow<'_, str>, Error>;
 }
 
 /// The default decoder used for unencoded path and query params.
@@ -19,14 +19,14 @@ pub struct PercentDecode;
 
 impl DecodeParam for NoopDecode {
     #[inline]
-    fn decode(encoded: &str) -> Result<Cow<str>, Error> {
+    fn decode(encoded: &str) -> Result<Cow<'_, str>, Error> {
         Ok(Cow::Borrowed(encoded))
     }
 }
 
 impl DecodeParam for PercentDecode {
     #[inline]
-    fn decode(encoded: &str) -> Result<Cow<str>, Error> {
+    fn decode(encoded: &str) -> Result<Cow<'_, str>, Error> {
         Ok(percent_decode_str(encoded).decode_utf8()?)
     }
 }

--- a/src/request/param/path_params.rs
+++ b/src/request/param/path_params.rs
@@ -14,7 +14,7 @@ impl PathParams {
     }
 
     #[inline]
-    pub fn iter(&self) -> slice::Iter<(Param, [usize; 2])> {
+    pub fn iter(&self) -> slice::Iter<'_, (Param, [usize; 2])> {
         self.data.iter()
     }
 }

--- a/src/request/param/query_parser.rs
+++ b/src/request/param/query_parser.rs
@@ -8,11 +8,11 @@ pub struct QueryParser<'a> {
     from: usize,
 }
 
-fn decode(input: &str) -> Cow<str> {
+fn decode(input: &str) -> Cow<'_, str> {
     percent_decode_str(input).decode_utf8_lossy()
 }
 
-fn take_name(input: &str, from: usize) -> (usize, Option<Cow<str>>) {
+fn take_name(input: &str, from: usize) -> (usize, Option<Cow<'_, str>>) {
     // Get the length of the input. We'll use this value as the end index if we
     // reach the end of the input.
     let len = input.len();

--- a/via-router/src/binding.rs
+++ b/via-router/src/binding.rs
@@ -24,14 +24,14 @@ pub struct Binding<'a, T> {
     range: Option<[usize; 2]>,
 }
 
-impl<T> Binding<'_, T> {
+impl<'a, T> Binding<'a, T> {
     #[inline]
     pub fn has_nodes(&self) -> bool {
         self.has_nodes
     }
 
     #[inline]
-    pub fn nodes(&self) -> slice::Iter<MatchKind<T>> {
+    pub fn nodes(&self) -> slice::Iter<'_, MatchKind<'a, T>> {
         self.nodes.iter()
     }
 

--- a/via-router/src/router.rs
+++ b/via-router/src/router.rs
@@ -56,7 +56,7 @@ impl<T> Node<T> {
     }
 
     #[inline]
-    pub fn route(&self) -> slice::Iter<MatchCond<T>> {
+    pub fn route(&self) -> slice::Iter<'_, MatchCond<T>> {
         self.route.iter()
     }
 
@@ -85,7 +85,7 @@ impl<T> Node<T> {
 }
 
 impl<T> Route<'_, T> {
-    pub fn at(&mut self, path: &'static str) -> Route<T> {
+    pub fn at(&mut self, path: &'static str) -> Route<'_, T> {
         let mut segments = path::patterns(path);
         let key = insert(self.tree, &mut segments, self.key);
 
@@ -115,7 +115,7 @@ impl<T> Router<T> {
         Default::default()
     }
 
-    pub fn at(&mut self, path: &'static str) -> Route<T> {
+    pub fn at(&mut self, path: &'static str) -> Route<'_, T> {
         let mut segments = path::patterns(path);
         let key = insert(&mut self.tree, &mut segments, 0);
 


### PR DESCRIPTION
Fixes clippy warnings by disambiguating some of the elided lifetimes.