### PR TITLE
chore(via): bump version to 2.0.0-rc.33

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-rc.32"
+version = "2.0.0-rc.33"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -32,7 +32,7 @@ percent-encoding = "2"
 serde = "1"
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal"] }
-via-router = { path = "./via-router" }
+via-router = { version = "3.0.0-beta.24" }
 
 [dependencies.cookie]
 version = "0.18"


### PR DESCRIPTION
Bumps via to version 2.0.0-rc.33. Breaking changes should be minimal in this release. Keep in mind that empty path parameters and query parameters that previously were resolved as empty strings are now optional. You can change any `.is_empty()` checks on parameters to use `Result::unwrap_or*`. There will likely be additional breaking changes coming to the parameter API to make it more consistent with the `Option<Result<_, _>>` and vice versa.