### PR TITLE
docs: bump version number in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following to dependencies section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-via = "2.0.0-rc.32"
+via = "2.0.0-rc.33"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 ```
 


### PR DESCRIPTION
As per tradition, we released without bumping the version number in the README. This PR updates the readme to show the latest published version of the crate.