### PR TITLE
chore(via-router): bump version to 3.0.0-beta.25

### DIFF
--- a/via-router/Cargo.toml
+++ b/via-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via-router"
-version = "3.0.0-beta.24"
+version = "3.0.0-beta.25"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Bumps via-router to `v3.0.0-beta.25`.

---

### Changelog

- #201
- #202