### PR TITLE
refactor(via): consistency in request and response api

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,6 @@
 //!
 
 use http::StatusCode;
-use http_body_util::Either;
 use serde::ser::SerializeStruct;
 use serde::{Serialize, Serializer};
 use std::borrow::Cow;
@@ -857,7 +856,7 @@ impl From<Error> for Response {
 
         loop {
             if !respond_with_json {
-                let mut response = Self::new(Either::Left(error.to_string().into()));
+                let mut response = Self::new(error.to_string().into());
                 *response.status_mut() = error.status;
                 break response;
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,10 +27,6 @@
 //!     Response::build().text(format!("Hello, {}!", name))
 //! }
 //!
-//! // For the sake of simplifying doctests, we're specifying that we want to
-//! // use the "current_thread" runtime flavor. You'll most likely not want to
-//! // specify a runtime flavor and simpy use #[tokio::main] if your deployment
-//! // target has more than one CPU core.
 //! #[tokio::main]
 //! async fn main() -> Result<ExitCode, BoxError> {
 //!     // Create a new application.
@@ -68,7 +64,3 @@ pub use next::Next;
 pub use request::Request;
 pub use response::{Pipe, Response};
 pub use server::{Server, start};
-
-/// A type erased, dynamically dispatched [`Body`](http_body::Body).
-///
-pub type BoxBody = http_body_util::combinators::BoxBody<bytes::Bytes, error::BoxError>;

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -3,6 +3,6 @@ pub mod param;
 mod body;
 mod request;
 
-pub use body::{Body, Payload};
+pub use body::{RequestBody, RequestPayload};
 pub use param::{PathParam, QueryParam};
-pub use request::{Head, Request};
+pub use request::{Request, RequestHead};

--- a/src/response/file.rs
+++ b/src/response/file.rs
@@ -14,7 +14,7 @@ use tokio::fs::File as TokioFile;
 use tokio::io::{AsyncRead, ReadBuf};
 use tokio::{task, time};
 
-use super::buffer_body::MAX_FRAME_LEN;
+use super::body::MAX_FRAME_LEN;
 use super::{Pipe, Response, ResponseBuilder};
 use crate::error::{BoxError, Error};
 

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -1,4 +1,4 @@
-mod buffer_body;
+mod body;
 mod builder;
 mod redirect;
 mod response;
@@ -9,7 +9,7 @@ mod file;
 #[cfg(feature = "fs")]
 pub use file::File;
 
-pub use buffer_body::BufferBody;
+pub use body::{BufferBody, ResponseBody};
 pub use builder::{Pipe, ResponseBuilder};
 pub use redirect::Redirect;
-pub use response::{Response, ResponseBody};
+pub use response::Response;


### PR DESCRIPTION
Improves the consistency between the Request and Response API. Prefers module prefixed type names i.e `Body ~> RequestBody`. Type aliases have been replaced by new types so users don't have to `cargo add http-body-util` just to map a request or response.