### PR TITLE
refactor(via): join every other turn + at an interval

### DIFF
--- a/src/server/accept.rs
+++ b/src/server/accept.rs
@@ -81,7 +81,7 @@ where
             let now = Instant::now();
 
             if let Some(diff) = now.checked_duration_since(last_sweep.get())
-                && diff < SWEEP_INTERVAL
+                && diff > SWEEP_INTERVAL
             {
                 if let Some(Err(error)) = connections.join_next().await {
                     handle_error(&error);


### PR DESCRIPTION
Experimental change to the accept loop. Adds a bit of business logic to keep the server busy accepting new connections and joining connections only when necessary.

I want to sit on this for a bit and think about whether or not it's a good strategy. It adds an unconditional atomic operation and a bit of math but I think that's a good thing.

Adding a collection that allocates for connections up front would make this one of the best choices for high assurance web application APIs in the industries where security is non-negotiable. That is assuming that nothing else slipped through the cracks. I'm not perfect and I've also been moving pretty fast. I think this has the potential to help make peoples lives easier who build software that we all rely on. Patient medical records, financial transactions, defense, etc.