### PR TITLE
chore(via): bump version to 2.0.0-rc.40

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-rc.39"
+version = "2.0.0-rc.40"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -71,7 +71,7 @@ features = ["aws_lc_rs", "server"]
 optional = true
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["fs", "ws"]
 
 [workspace]
 members = ["via-router", "examples/*"]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following to dependencies section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-via = "2.0.0-rc.39"
+via = "2.0.0-rc.40"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 ```
 


### PR DESCRIPTION
Bumps via to `2.0.0-rc.40` with no changes other than a directive to docs.rs to fix the docs build.