### PR TITLE
fix(via): prefer timeout in accept w/ try_join_next

### DIFF
--- a/src/server/accept.rs
+++ b/src/server/accept.rs
@@ -17,11 +17,12 @@ use super::io::IoWithPermit;
 use crate::app::{App, AppService};
 use crate::error::ServerError;
 
+const SECONDS_IN_A_DAY: u64 = 60 * 60 * 24;
+
 macro_rules! accept_with_timeout {
     ($future:expr, $immediate:expr) => {
         time::timeout(
-            // Timeout after 1 second or 1 day.
-            Duration::from_secs(if $immediate { 1 } else { 60 * 60 * 24 }),
+            Duration::from_secs(if $immediate { 1 } else { SECONDS_IN_A_DAY }),
             $future,
         )
     };
@@ -30,9 +31,9 @@ macro_rules! accept_with_timeout {
 macro_rules! joined {
     ($result:expr) => {
         match $result {
+            Ok(Ok(_)) => {}
             Ok(Err(error)) => handle_error(&error),
             Err(error) => handle_error(&ServerError::Join(error)),
-            _ => {}
         }
     };
 }

--- a/src/server/accept.rs
+++ b/src/server/accept.rs
@@ -116,6 +116,7 @@ where
                     // Error, burn the permit and try again.
                     Ok(Err(error)) => {
                         log!("error(accept): {}", error);
+                        should_join_next = true;
                     }
                     // Idle, set `should_join_next` and try again.
                     Err(_) => {

--- a/src/server/accept.rs
+++ b/src/server/accept.rs
@@ -17,6 +17,16 @@ use super::io::IoWithPermit;
 use crate::app::{App, AppService};
 use crate::error::ServerError;
 
+macro_rules! accept_with_timeout {
+    ($future:expr, $immediate:expr) => {
+        time::timeout(
+            // Timeout after 1 second or 1 day.
+            Duration::from_secs(if $immediate { 1 } else { 60 * 60 * 24 }),
+            $future,
+        )
+    };
+}
+
 macro_rules! joined {
     ($result:expr) => {
         match $result {
@@ -65,6 +75,11 @@ where
         rx
     };
 
+    // We alternate between accepting new connections and joining finished
+    // ones. This avoids starving connection tasks while keeping accept latency
+    // low. In practice, this means we only call `join_next()` every other turn.
+    let mut should_join_next = false;
+
     // Wrap app in an arc so it can be cloned into the connection task.
     let app = Arc::new(app);
 
@@ -81,27 +96,37 @@ where
             biased;
 
             // Accept a connection from the TCP listener.
-            result = listener.accept() => match result {
-                // Connection accepted.
-                Ok((tcp_stream, _)) => {
-                    // Spawn a task to serve the connection.
-                    connections.spawn(handle_connection(
-                        permit,
-                        tcp_stream,
-                        acceptor.clone(),
-                        shutdown_rx.clone(),
-                        Arc::clone(&app),
-                        max_body_size,
-                    ));
+            result = accept_with_timeout!(listener.accept(), !connections.is_empty()) => {
+                match result {
+                    // Connection accepted.
+                    Ok(Ok((tcp_stream, _))) => {
+                        // Spawn a task to serve the connection.
+                        connections.spawn(handle_connection(
+                            permit,
+                            tcp_stream,
+                            acceptor.clone(),
+                            shutdown_rx.clone(),
+                            Arc::clone(&app),
+                            max_body_size,
+                        ));
+
+                        // Flip the `should_join_next` bit.
+                        should_join_next = !should_join_next;
+                    }
+                    // Error, burn the permit and try again.
+                    Ok(Err(error)) => {
+                        log!("error(accept): {}", error);
+                    }
+                    // Idle, set `should_join_next` and try again.
+                    Err(_) => {
+                        should_join_next = true;
+                    }
                 }
-                // Error, burn the permit and try again.
-                Err(error) => {
-                    log!("error(accept): {}", error);
-                }
-            },
+            }
 
             // Maybe try to join a connection while we wait.
-            Some(result) = connections.join_next(), if !connections.is_empty() => {
+            Some(result) = connections.join_next(), if should_join_next => {
+                should_join_next = false;
                 joined!(result);
             }
 
@@ -111,11 +136,9 @@ where
             }
         }
 
-        for _ in 0..32 {
-            match connections.try_join_next() {
-                Some(result) => joined!(result),
-                None => break,
-            }
+        // Try to join a connection task opportunistically.
+        if let Some(result) = connections.try_join_next() {
+            joined!(result);
         }
     };
 


### PR DESCRIPTION
Reverts the unconditionally opportunistic joins in the previous release, uses try_join_next instead of the noop waker, and reduces the timeout for when we have connections in the JoinQueue from 2 seconds to 1 second.

This is an all around improvement that builds on top of the code released in `rc.40`.
