### PR TITLE
fix(via): reduce latency in accept

### DIFF
--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -29,6 +29,16 @@ impl<T> AppService<T> {
     }
 }
 
+impl<State> Clone for AppService<State> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self {
+            app: Arc::clone(&self.app),
+            max_body_size: self.max_body_size,
+        }
+    }
+}
+
 impl<T: Send + Sync> Service<http::Request<Incoming>> for AppService<T> {
     type Error = Infallible;
     type Future = ServeRequest;

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,10 +34,10 @@ pub struct ErrorMessage<'a> {
 }
 
 #[derive(Debug)]
-pub(crate) enum ServerError {
-    Io(io::Error),
-    Join(JoinError),
-    Hyper(hyper::Error),
+pub(crate) enum ServerError<'a> {
+    Io(&'a io::Error),
+    Join(&'a JoinError),
+    Hyper(&'a hyper::Error),
 }
 
 #[macro_export]
@@ -926,7 +926,7 @@ impl Display for ErrorMessage<'_> {
     }
 }
 
-impl StdError for ServerError {
+impl StdError for ServerError<'_> {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
             Self::Io(error) => error.source(),
@@ -936,24 +936,12 @@ impl StdError for ServerError {
     }
 }
 
-impl Display for ServerError {
+impl Display for ServerError<'_> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
             Self::Io(error) => Display::fmt(error, f),
             Self::Join(error) => Display::fmt(error, f),
             Self::Hyper(error) => Display::fmt(error, f),
         }
-    }
-}
-
-impl From<io::Error> for ServerError {
-    fn from(error: io::Error) -> Self {
-        Self::Io(error)
-    }
-}
-
-impl From<hyper::Error> for ServerError {
-    fn from(error: hyper::Error) -> Self {
-        Self::Hyper(error)
     }
 }

--- a/src/server/accept.rs
+++ b/src/server/accept.rs
@@ -26,6 +26,7 @@ macro_rules! log {
     };
 }
 
+#[inline(never)]
 pub async fn accept<A, T>(
     listener: TcpListener,
     acceptor: A,

--- a/src/server/accept.rs
+++ b/src/server/accept.rs
@@ -4,8 +4,8 @@ use std::error::Error;
 use std::process::ExitCode;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::{OwnedSemaphorePermit, Semaphore, watch};
+use tokio::net::TcpListener;
+use tokio::sync::{Semaphore, watch};
 use tokio::task::JoinSet;
 use tokio::{signal, time};
 
@@ -14,29 +14,9 @@ use hyper_util::rt::TokioExecutor;
 
 use super::acceptor::Acceptor;
 use super::io::IoWithPermit;
-use crate::app::{App, AppService};
+use super::server::ServerConfig;
+use crate::app::AppService;
 use crate::error::ServerError;
-
-const SECONDS_IN_A_DAY: u64 = 60 * 60 * 24;
-
-macro_rules! accept_with_timeout {
-    ($future:expr, $immediate:expr) => {
-        time::timeout(
-            Duration::from_secs(if $immediate { 1 } else { SECONDS_IN_A_DAY }),
-            $future,
-        )
-    };
-}
-
-macro_rules! joined {
-    ($result:expr) => {
-        match $result {
-            Ok(Ok(_)) => {}
-            Ok(Err(error)) => handle_error(&error),
-            Err(error) => handle_error(&ServerError::Join(error)),
-        }
-    };
-}
 
 macro_rules! log {
     ($($arg:tt)*) => {
@@ -49,10 +29,8 @@ macro_rules! log {
 pub async fn accept<A, T>(
     listener: TcpListener,
     acceptor: A,
-    app: App<T>,
-    max_body_size: usize,
-    max_connections: usize,
-    shutdown_timeout: u64,
+    app_service: AppService<T>,
+    server_config: ServerConfig,
 ) -> ExitCode
 where
     A: Acceptor + Send + Sync + 'static,
@@ -62,11 +40,7 @@ where
     // of connections that the server can handle concurrently. If the maximum
     // number of connections is reached, we'll wait until a permit is available
     // before accepting a new connection.
-    let semaphore = Arc::new(Semaphore::new(max_connections));
-
-    // Create a JoinSet to track inflight connections. We'll use this to wait for
-    // all connections to close before the server exits.
-    let mut connections = JoinSet::<Result<(), ServerError>>::new();
+    let semaphore = Arc::new(Semaphore::new(server_config.max_connections));
 
     // Create a watch channel to notify the connections to initiate a
     // graceful shutdown process when the `ctrl_c` future resolves.
@@ -76,13 +50,9 @@ where
         rx
     };
 
-    // We alternate between accepting new connections and joining finished
-    // ones. This avoids starving connection tasks while keeping accept latency
-    // low. In practice, this means we only call `join_next()` every other turn.
-    let mut should_join_next = false;
-
-    // Wrap app in an arc so it can be cloned into the connection task.
-    let app = Arc::new(app);
+    // A JoinSet to track inflight connections. We use this to drain connection
+    // tasks before returning the exit code.
+    let mut connections = JoinSet::new();
 
     // Start accepting incoming connections.
     let exit_code = loop {
@@ -92,60 +62,81 @@ where
             Err(_) => break ExitCode::FAILURE,
         };
 
-        tokio::select! {
-            // Poll the listener before anything else.
-            biased;
-
-            // Accept a connection from the TCP listener.
-            result = accept_with_timeout!(listener.accept(), !connections.is_empty()) => {
-                match result {
-                    // Connection accepted.
-                    Ok(Ok((tcp_stream, _))) => {
-                        // Spawn a task to serve the connection.
-                        connections.spawn(handle_connection(
-                            permit,
-                            tcp_stream,
-                            acceptor.clone(),
-                            shutdown_rx.clone(),
-                            Arc::clone(&app),
-                            max_body_size,
-                        ));
-
-                        // Flip the `should_join_next` bit.
-                        should_join_next = !should_join_next;
-                    }
-                    // Error, burn the permit and try again.
-                    Ok(Err(error)) => {
-                        log!("error(accept): {}", error);
-                        should_join_next = true;
-                    }
-                    // Idle, set `should_join_next` and try again.
-                    Err(_) => {
-                        should_join_next = true;
-                    }
+        let (tcp_stream, _) = tokio::select! {
+            // A new TCP stream was accepted from the listener.
+            result = listener.accept() => match result {
+                Ok(accepted) => accepted,
+                Err(error) => {
+                    log!("error(accept): {}", error);
+                    continue;
                 }
-            }
-
-            // Maybe try to join a connection while we wait.
-            Some(result) = connections.join_next(), if should_join_next => {
-                should_join_next = false;
-                joined!(result);
-            }
-
-            // Break if we receive a graceful shutdown signal.
-            _shutdown_signal = shutdown_rx.changed() => {
+            },
+            // The process received a graceful shutdown signal.
+            _ = shutdown_rx.changed() => {
                 break shutdown_rx.borrow_and_update().unwrap_or(ExitCode::FAILURE);
             }
-        }
+        };
 
-        // Try to join a connection task opportunistically.
-        if let Some(result) = connections.try_join_next() {
-            joined!(result);
+        let mut acceptor = acceptor.clone();
+        let app_service = app_service.clone();
+        let mut shutdown_rx = shutdown_rx.clone();
+
+        // Spawn a task to serve the connection.
+        connections.spawn(async move {
+            // Accept the TCP stream from the acceptor.
+            let io = match acceptor.accept(tcp_stream).await {
+                Ok(accepted) => IoWithPermit::new(permit, accepted),
+                Err(error) => {
+                    handle_error(ServerError::Io(&error));
+                    return;
+                }
+            };
+
+            // Create a new HTTP/2 connection.
+            #[cfg(feature = "http2")]
+            let mut connection = Box::pin(
+                conn::http2::Builder::new(TokioExecutor::new())
+                    .timer(TokioTimer::new())
+                    .serve_connection(io, app_service),
+            );
+
+            // Create a new HTTP/1.1 connection.
+            #[cfg(all(feature = "http1", not(feature = "http2")))]
+            let mut connection = Box::pin(
+                conn::http1::Builder::new()
+                    .timer(TokioTimer::new())
+                    .serve_connection(io, app_service)
+                    .with_upgrades(),
+            );
+
+            // Serve the connection.
+            let result = tokio::select! {
+                result = connection.as_mut() => result,
+                _ = shutdown_rx.changed() => {
+                    connection.as_mut().graceful_shutdown();
+                    connection.as_mut().await
+                }
+            };
+
+            if let Err(error) = &result {
+                handle_error(ServerError::Hyper(error));
+            }
+        });
+
+        // Reap up to 2 finished connection tasks. This keeps the length of
+        // connections roughly around `server_config.max_connections` in the
+        // worst case scenario.
+        'try_join: for _ in 0..2 {
+            match connections.try_join_next() {
+                Some(Err(error)) => handle_error(ServerError::Join(&error)),
+                Some(Ok(_)) => {}
+                None => break 'try_join,
+            }
         }
     };
 
     let drain_all = time::timeout(
-        Duration::from_secs(shutdown_timeout),
+        Duration::from_secs(server_config.shutdown_timeout),
         drain_connections(&mut connections),
     );
 
@@ -156,7 +147,7 @@ where
     }
 }
 
-fn handle_error(error: &ServerError) {
+fn handle_error(error: ServerError) {
     match error {
         ServerError::Io(io_error) => log!("error(task): {}", io_error),
         ServerError::Join(join_error) => {
@@ -180,61 +171,15 @@ fn handle_error(error: &ServerError) {
     }
 }
 
-async fn handle_connection<A, T>(
-    permit: OwnedSemaphorePermit,
-    tcp_stream: TcpStream,
-    mut acceptor: A,
-    mut shutdown_rx: watch::Receiver<Option<ExitCode>>,
-    app: Arc<App<T>>,
-    max_body_size: usize,
-) -> Result<(), ServerError>
-where
-    A: Acceptor + 'static,
-    T: Send + Sync,
-{
-    // Accept the TCP stream from the acceptor.
-    let maybe_tls_stream = acceptor.accept(tcp_stream).await?;
-
-    // Create a new HTTP/2 connection.
-    #[cfg(feature = "http2")]
-    let mut connection = Box::pin(
-        conn::http2::Builder::new(TokioExecutor::new())
-            .timer(TokioTimer::new())
-            .serve_connection(
-                IoWithPermit::new(permit, maybe_tls_stream),
-                AppService::new(app, max_body_size),
-            ),
-    );
-
-    // Create a new HTTP/1.1 connection.
-    #[cfg(all(feature = "http1", not(feature = "http2")))]
-    let mut connection = Box::pin(
-        conn::http1::Builder::new()
-            .timer(TokioTimer::new())
-            .serve_connection(
-                IoWithPermit::new(permit, maybe_tls_stream),
-                AppService::new(app, max_body_size),
-            )
-            .with_upgrades(),
-    );
-
-    // Serve the connection.
-    tokio::select! {
-        result = connection.as_mut() => result.map_err(ServerError::from),
-        _ = shutdown_rx.changed() => {
-            connection.as_mut().graceful_shutdown();
-            connection.as_mut().await.map_err(ServerError::from)
-        }
-    }
-}
-
-async fn drain_connections(connections: &mut JoinSet<Result<(), ServerError>>) {
+async fn drain_connections(connections: &mut JoinSet<()>) {
     if cfg!(debug_assertions) {
         println!("draining {} inflight connections...", connections.len());
     }
 
     while let Some(result) = connections.join_next().await {
-        joined!(result);
+        if let Err(error) = &result {
+            handle_error(ServerError::Join(error));
+        }
     }
 }
 

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use tokio::net::{TcpListener, ToSocketAddrs};
 
 use super::accept::accept;
-#[allow(unused_imports)]
 use crate::app::{App, AppService};
 use crate::error::BoxError;
 
@@ -155,8 +154,6 @@ impl<T: Send + Sync + 'static> Server<T> {
     ///
     #[cfg(feature = "rustls")]
     pub async fn listen<A: ToSocketAddrs>(self, address: A) -> Result<ExitCode, BoxError> {
-        use crate::app::AppService;
-
         let rustls_config = match self.rustls_config {
             Some(config) => Arc::new(config),
             None => panic!("rustls_config is required when the 'rustls' feature is enabled."),


### PR DESCRIPTION
While the timeout on accept is an interesting idea. In practice it results in nearly double the latency of writing the accept loop the traditional way. This PR finalizes the join strategy for Via. Incremental improvement can be made as we go.

The idea is to use a per-connection semaphore permit that lives with the I/O struct that contains the `TcpStream`. While a semaphore per-request has less latency, it's less ideal for applications that use websockets or SSE. Especially if the websockets are used alongside traditional, transactional HTTP requests.

Since hyper is responsible for driving the connection futures to completion, we only really keep a `JoinSet` for the sake of draining connections within the `shutdown_timeout` when a graceful shutdown signal is received. The only gains that are made in joining a connection in the `JoinSet` is free-ing the memory used to store the output of the connection task and preventing additional dynamic allocations from occurring in the accept loop in the event that the `JoinSet` has to grow.

Therefore, it's best that we don't anything fancy when it comes to joining connection tasks and instead prefer a reaping strategy that allows for predictable memory usage. The simplest approach is to `try_join_next` twice for every connection we receive. This keeps the number of connection tasks in the `JoinSet` roughly the value of `server.max_connections` which is really the maximum number of concurrent connection tasks.

This change should bring reduced latency with no functional changes.