### PR TITLE
chore(via): bump version to 2.0.0-rc.44

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ percent-encoding = "2"
 serde = { version = "1", features = ["derive"]  }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal"] }
-via-router = { path = "./via-router" }
+via-router = { version = "3.0.0-beta.27" }
 
 [dependencies.aws-lc-rs]
 version = "1"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following to dependencies section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-via = "2.0.0-rc.43"
+via = "2.0.0-rc.44"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 ```
 


### PR DESCRIPTION
Bumps via to `2.0.0-rc.44`.

---

### Changelog

- #241 