### PR TITLE
feat(via): simple batch joins in accept

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -34,10 +34,10 @@ pub struct ErrorMessage<'a> {
 }
 
 #[derive(Debug)]
-pub(crate) enum ServerError<'a> {
-    Io(&'a io::Error),
-    Join(&'a JoinError),
-    Hyper(&'a hyper::Error),
+pub(crate) enum ServerError {
+    Io(io::Error),
+    Join(JoinError),
+    Hyper(hyper::Error),
 }
 
 #[macro_export]
@@ -926,22 +926,22 @@ impl Display for ErrorMessage<'_> {
     }
 }
 
-impl StdError for ServerError<'_> {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        match self {
-            Self::Io(error) => error.source(),
-            Self::Join(error) => error.source(),
-            Self::Hyper(error) => error.source(),
-        }
-    }
-}
-
-impl Display for ServerError<'_> {
+impl Display for ServerError {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
             Self::Io(error) => Display::fmt(error, f),
             Self::Join(error) => Display::fmt(error, f),
             Self::Hyper(error) => Display::fmt(error, f),
+        }
+    }
+}
+
+impl StdError for ServerError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            Self::Io(error) => error.source(),
+            Self::Join(error) => error.source(),
+            Self::Hyper(error) => error.source(),
         }
     }
 }

--- a/src/server/acceptor/http.rs
+++ b/src/server/acceptor/http.rs
@@ -7,11 +7,14 @@ use super::Acceptor;
 /// Accepts a TCP stream and returns it as-is.
 ///
 #[derive(Clone)]
-pub struct HttpAcceptor;
+pub struct HttpAcceptor(
+    // Pad HttpAcceptor with usize to avoid passing a ZST to accept.
+    #[allow(dead_code)] usize,
+);
 
 impl HttpAcceptor {
     pub fn new() -> Self {
-        Self
+        Self(0)
     }
 }
 

--- a/src/server/acceptor/http.rs
+++ b/src/server/acceptor/http.rs
@@ -7,14 +7,11 @@ use super::Acceptor;
 /// Accepts a TCP stream and returns it as-is.
 ///
 #[derive(Clone)]
-pub struct HttpAcceptor(
-    // Pad HttpAcceptor with usize to avoid passing a ZST to accept.
-    #[allow(dead_code)] usize,
-);
+pub struct HttpAcceptor;
 
 impl HttpAcceptor {
     pub fn new() -> Self {
-        Self(0)
+        Self
     }
 }
 


### PR DESCRIPTION
Avoids doing work on the main thread of accept by joining connections in the background every 1024 connections.