### PR TITLE
fix(via): prefer Bytes::{advance,slice} for BufferBody

### DIFF
--- a/src/response/builder.rs
+++ b/src/response/builder.rs
@@ -8,10 +8,9 @@ use http_body_util::StreamBody;
 use http_body_util::combinators::BoxBody;
 use serde::Serialize;
 
-use super::BufferBody;
+use super::body::{BufferBody, ResponseBody};
 use super::response::Response;
 use crate::error::{BoxError, Error};
-use crate::response::ResponseBody;
 
 /// Define how a type can finalize a [`ResponseBuilder`].
 ///

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -9,7 +9,7 @@ mod file;
 #[cfg(feature = "fs")]
 pub use file::File;
 
-pub use body::{BufferBody, ResponseBody};
+pub use body::ResponseBody;
 pub use builder::{Pipe, ResponseBuilder};
 pub use redirect::Redirect;
 pub use response::Response;


### PR DESCRIPTION
Recomputes the adaptive frame length and prefers slice + advance when working with bytes in `BufferBody`. `Bytes::slice` and `Buf::advance` are both O(1) operations that leave `self` in tact, something we want even if `BufferBody` is `Unpin`.