### PR TITLE
style(via): prefer impl Trait in App and Route

### DIFF
--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -3,28 +3,28 @@ use std::sync::Arc;
 use super::router::{Route, Router};
 use crate::middleware::Middleware;
 
-pub struct App<T> {
-    pub(super) state: Arc<T>,
-    pub(super) router: Router<T>,
+pub struct App<State> {
+    pub(super) state: Arc<State>,
+    pub(super) router: Router<State>,
 }
 
 /// Constructs a new [`App`] with the provided `state` argument.
 ///
-pub fn app<T>(state: T) -> App<T> {
+pub fn app<State>(state: State) -> App<State> {
     App {
         state: Arc::new(state),
         router: Router::new(),
     }
 }
 
-impl<T> App<T> {
-    pub fn at(&mut self, path: &'static str) -> Route<'_, T> {
+impl<State> App<State> {
+    pub fn at(&mut self, path: &'static str) -> Route<'_, State> {
         Route {
             inner: self.router.at(path),
         }
     }
 
-    pub fn include(&mut self, middleware: impl Middleware<T> + 'static) {
+    pub fn include(&mut self, middleware: impl Middleware<State> + 'static) {
         self.at("/").include(middleware);
     }
 }

--- a/src/app/router.rs
+++ b/src/app/router.rs
@@ -2,34 +2,28 @@ use std::sync::Arc;
 
 use crate::middleware::Middleware;
 
-pub type Router<T> = via_router::Router<Arc<dyn Middleware<T>>>;
+pub type Router<State> = via_router::Router<Arc<dyn Middleware<State>>>;
 
-pub struct Route<'a, T> {
-    pub(super) inner: via_router::RouteMut<'a, Arc<dyn Middleware<T>>>,
+pub struct Route<'a, State> {
+    pub(super) inner: via_router::RouteMut<'a, Arc<dyn Middleware<State>>>,
 }
 
-impl<T> Route<'_, T> {
-    pub fn at(&mut self, path: &'static str) -> Route<'_, T> {
+impl<State> Route<'_, State> {
+    pub fn at(&mut self, path: &'static str) -> Route<'_, State> {
         Route {
             inner: self.inner.at(path),
         }
     }
 
-    pub fn scope(&mut self, scope: impl FnOnce(&mut Self)) {
-        scope(self);
+    pub fn scope(mut self, scope: impl FnOnce(&mut Self)) {
+        scope(&mut self);
     }
 
-    pub fn include<M>(&mut self, middleware: M)
-    where
-        M: Middleware<T> + 'static,
-    {
+    pub fn include(&mut self, middleware: impl Middleware<State> + 'static) {
         self.inner.include(Arc::new(middleware));
     }
 
-    pub fn respond<M>(&mut self, middleware: M)
-    where
-        M: Middleware<T> + 'static,
-    {
+    pub fn respond(&mut self, middleware: impl Middleware<State> + 'static) {
         self.inner.respond(Arc::new(middleware));
     }
 }


### PR DESCRIPTION
Prefers impl Trait in `App` and `Route`.

Since middleware is converted to a trait object, we aren't missing out on edge case monomorphization that wouldn't work with `impl Middleware`.