### PR TITLE
refactor(via): ws::RequestContext ~> Context

### DIFF
--- a/examples/chat/src/room.rs
+++ b/examples/chat/src/room.rs
@@ -1,5 +1,5 @@
 use serde_json::json;
-use via::builtin::ws::{Message, RequestContext, WebSocket};
+use via::builtin::ws::{Context, Message, WebSocket};
 use via::{Next, Request, Response};
 
 use crate::chat::Chat;
@@ -26,7 +26,7 @@ pub async fn show(request: Request<Chat>, _: Next<Chat>) -> via::Result {
     }
 }
 
-pub async fn join(mut socket: WebSocket, request: RequestContext<Chat>) -> via::Result<()> {
+pub async fn join(mut socket: WebSocket, request: Context<Chat>) -> via::Result<()> {
     let slug = request.param("room").into_result()?;
     let chat = request.state();
 


### PR DESCRIPTION
Renames `RequestContext` to `Context`. It's a bit overloaded in the rust community but we're pretty much all using rust-analyzer or something equivalent. This keeps fn signatures on a single line. If necessary, we can always change the name before the official 2.0 release.