### PR TITLE
refactor(via): fs ~> file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ default = ["http1"]
 
 aws-lc-rs = ["dep:aws-lc-rs", "tokio-rustls/aws-lc-rs", "tokio-websockets/aws_lc_rs"]
 
-fs = ["dep:httpdate", "tokio/fs"]
+file = ["dep:httpdate", "tokio/fs"]
 
 http1 = ["hyper/http1"]
 http2 = ["hyper/http2"]

--- a/examples/chat/Cargo.toml
+++ b/examples/chat/Cargo.toml
@@ -8,7 +8,7 @@ http = "1"
 serde = "1"
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-via = { path = "../..", features = ["aws-lc-rs", "fs", "ws"] }
+via = { path = "../..", features = ["aws-lc-rs", "ws"] }
 
 [dependencies.bytestring]
 features = ["serde"]

--- a/examples/file-server/Cargo.toml
+++ b/examples/file-server/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2021"
 http = "1"
 mime_guess = "2"
 tokio = "1"
-via = { path = "../..", features = ["fs"] }
+via = { path = "../..", features = ["file"] }

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -3,10 +3,10 @@ mod builder;
 mod redirect;
 mod response;
 
-#[cfg(feature = "fs")]
+#[cfg(feature = "file")]
 mod file;
 
-#[cfg(feature = "fs")]
+#[cfg(feature = "file")]
 pub use file::File;
 
 pub use body::ResponseBody;


### PR DESCRIPTION
Renames the `fs` flag to `file` because it's more descriptive and `fs` and `ws` creates a pattern of 2 letter feature flag names that I'd prefer to avoid.