### PR TITLE
chore(via): bump version to 2.0.0-rc.46

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "via"
-version = "2.0.0-rc.45"
+version = "2.0.0-rc.46"
 authors = ["Zachary Golba <zachary.golba@postlight.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -44,7 +44,7 @@ percent-encoding = "2"
 serde = { version = "1", features = ["derive"]  }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal"] }
-via-router = { version = "3.0.0-beta.27" }
+via-router = { version = "3.0.0-beta.28" }
 
 [dependencies.aws-lc-rs]
 version = "1"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following to dependencies section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-via = "2.0.0-rc.45"
+via = "2.0.0-rc.46"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 ```
 


### PR DESCRIPTION
Bumps via to `v2.0.0-rc.46`.

---

### Changelog

- #258 
- #257
- #255 
- #254
- #253
- #252
- #251
- #250
- #249
- #248
- #247
- #246