### PR TITLE
fix(via): docs.rs still uses fs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ features = ["aws_lc_rs", "server"]
 optional = true
 
 [package.metadata.docs.rs]
-features = ["fs", "ws"]
+features = ["file", "ws"]
 
 [workspace]
 members = ["via-router", "examples/*"]


### PR DESCRIPTION
Docs.rs is failing to build because it's using the old fs feature flag instead of file.