### PR TITLE
docs(via): update readme and hello world example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Below is a basic example to demonstrate how to use Via to create a simple web se
 
 ```rust
 use std::process::ExitCode;
-use via::builtin::rescue;
 use via::{App, BoxError, Next, Request, Response};
 
 async fn hello(request: Request, _: Next) -> via::Result {
@@ -40,28 +39,12 @@ async fn hello(request: Request, _: Next) -> via::Result {
 async fn main() -> Result<ExitCode, BoxError> {
     let mut app = App::new(());
 
-    // Capture errors from downstream, log them, and map them into responses.
-    // Upstream middleware remains unaffected and continues execution.
-    app.include(rescue::inspect(|error| eprintln!("error: {}", error)));
-
     // Define a route that listens on /hello/:name.
     app.at("/hello/:name").respond(via::get(hello));
 
     via::serve(app).listen(("127.0.0.1", 8080)).await
 }
 ```
-
-### How It Works
-
-1. **Define a Handler**: The `hello` function is an asynchronous handler that receives a `Request` and a `Next` middleware chain. It extracts the `name` parameter from the URL and returns a `Response` with a personalized greeting.
-
-2. **Create the Application**: Using `via::app(())`, you can create a new instance of the application. This function can also accept shared state.
-
-3. **Define an ErrorBoundary**: Define an `ErrorBoundary` middleware to catch errors that occur downstream and convert them to a response. Middleware can be added at any depth of the route tree with the `.include(middleware)` method.
-
-4. **Define Routes**: The `app.at("/hello/:name").respond(via::get(hello))` line adds a route that listens for GET requests on `/hello/:name`. The colon (`:`) indicates a dynamic segment in the path, which will match any value and make it available as a parameter.
-
-5. **Start the Server**: Calling `via::start(app).listen(("127.0.0.1", 8080)).await` starts the server and listens for connections on the specified address.
 
 ### Running the Example
 

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -1,5 +1,4 @@
 use std::process::ExitCode;
-use via::builtin::rescue;
 use via::{App, BoxError, Next, Request, Response};
 
 async fn hello(request: Request, _: Next) -> via::Result {
@@ -13,10 +12,6 @@ async fn hello(request: Request, _: Next) -> via::Result {
 #[tokio::main]
 async fn main() -> Result<ExitCode, BoxError> {
     let mut app = App::new(());
-
-    // Capture errors from downstream, log them, and map them into responses.
-    // Upstream middleware remains unaffected and continues execution.
-    app.include(rescue::inspect(|error| eprintln!("error: {}", error)));
 
     // Define a route that listens on /hello/:name.
     app.at("/hello/:name").respond(via::get(hello));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,6 @@
 //!
 //! ```no_run
 //! use std::process::ExitCode;
-//! use via::builtin::rescue;
 //! use via::{App, BoxError, Next, Request, Response};
 //!
 //! async fn hello(request: Request, _: Next) -> via::Result {
@@ -30,10 +29,6 @@
 //! #[tokio::main]
 //! async fn main() -> Result<ExitCode, BoxError> {
 //!     let mut app = App::new(());
-//!
-//!     // Capture errors from downstream, log them, and map them into responses.
-//!     // Upstream middleware remains unaffected and continues execution.
-//!     app.include(rescue::inspect(|error| eprintln!("error: {}", error)));
 //!
 //!     // Define a route that listens on /hello/:name.
 //!     app.at("/hello/:name").respond(via::get(hello));


### PR DESCRIPTION
Prefers keeping the readme as simple as possible for now as we approach a stable public API. Since we are for the most part feature complete, we can wrap up any breaking changes that we want to make before calling it a stable release. We can always improve internals as we go.

The remaining breaking changes are mostly additive. I'd like to explore what error looks like if we come up with a statically composable API similar to iterators on top of an error kind that has a `Other(Box<dyn Error>)` variant. Hopefully, we'll be able to impl std::error::Error for it as well so it can be boxed if need be.

I'd also like to see what a ResultExt trait looks like as the entry point to building errors. I think we'll probably come up with a generalized trait for reading web socket payloads and request bodies. Consistency between the two APIs makes sense. I also think it's imperative that we provide a trait that is passed to the ws fn so we can have state scoped to the route or explicit callbacks for each message type and default impls.