### PR TITLE
fix(via): tls 1.2 is the min for all http versions

### DIFF
--- a/src/server/tls/native.rs
+++ b/src/server/tls/native.rs
@@ -9,11 +9,7 @@ use super::super::server::ServerConfig;
 use crate::app::AppService;
 use crate::error::BoxError;
 
-#[cfg(feature = "http2")]
 const MIN_PROTOCOL_VERSION: Protocol = Protocol::Tlsv12;
-
-#[cfg(not(feature = "http2"))]
-const MIN_PROTOCOL_VERSION: Protocol = Protocol::Tlsv10;
 
 pub fn listen_native_tls<State, A>(
     config: ServerConfig,


### PR DESCRIPTION
TLS v1.2 is the minimum version supported for all HTTP versions when the `native-tls` flag is enabled. This is the default Rustls config.