### PR TITLE
fix(via): parts is pub(crate) in RequestHead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ hyper-util = { version = "0.1", features = ["tokio"] }
 percent-encoding = "2"
 serde = { version = "1", features = ["derive"]  }
 serde_json = "1"
-smallvec = "1.15.1"
+smallvec = "1"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal"] }
 via-router = { version = "3.0.0-beta.28" }
 

--- a/src/request/request.rs
+++ b/src/request/request.rs
@@ -23,7 +23,7 @@ pub struct Request<State = ()> {
 ///
 #[derive(Debug)]
 pub struct RequestHead<State> {
-    pub parts: Parts,
+    pub(crate) parts: Parts,
 
     /// The request's path parameters.
     ///


### PR DESCRIPTION
Changes the visibility of the parts field in RequestHead to `pub(crate)`. We'll likely introduce another method on request like `into_inner` or impl `From<RequestHead> for Parts` or the equivalent `From` impl for `http::Request`. These are no breaking changes that can take place when I return from vacation.