### PR TITLE
fix(via): BufferBody never yields more than a single frame

### DIFF
--- a/src/response/body.rs
+++ b/src/response/body.rs
@@ -10,7 +10,7 @@ use crate::error::BoxError;
 
 pub(super) const MAX_FRAME_SIZE: usize = 16 * 1024; // 16KB
 
-/// A buffered `impl Body` that is written in `16KB..=32KB` chunks.
+/// A buffered `impl Body` that is written in `16 KB` chunks.
 ///
 #[derive(Default)]
 pub struct BufferBody {

--- a/src/response/file.rs
+++ b/src/response/file.rs
@@ -14,10 +14,10 @@ use tokio::fs::File as TokioFile;
 use tokio::io::{AsyncRead, ReadBuf};
 use tokio::{task, time};
 
-use super::body::adapt_frame_size;
 use super::{Response, ResponseBuilder};
 use crate::error::{BoxError, Error};
 use crate::pipe::Pipe;
+use crate::response::body::MAX_FRAME_SIZE;
 
 /// The base amount of time that the server will wait before
 /// attempting to open a file after an error has occurred.
@@ -85,7 +85,7 @@ async fn open(path: &Path, max_alloc_size: usize) -> Result<Open, Error> {
             if required_cap > max_alloc_size {
                 let mut file = TokioFile::from_std(std);
 
-                file.set_max_buf_size(adapt_frame_size(required_cap));
+                file.set_max_buf_size(MAX_FRAME_SIZE);
                 Ok(Open::Stream(required_cap, metadata, file))
             } else {
                 let mut data = Vec::with_capacity(required_cap);
@@ -210,7 +210,7 @@ impl FileStream {
     fn new(remaining: usize, file: TokioFile) -> Self {
         Self {
             remaining,
-            buffer: vec![MaybeUninit::uninit(); adapt_frame_size(remaining)],
+            buffer: vec![MaybeUninit::uninit(); MAX_FRAME_SIZE],
             file,
         }
     }

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -92,9 +92,12 @@ where
     F: Fn(Channel, Context<State>) -> R + Send + Sync + 'static,
     R: Future<Output = Result<(), Error>> + Send + Sync + 'static,
 {
+    // 16 KB the max size of an HTTP/2 data frame.
+    let frame_size = DEFAULT_FRAME_SIZE * 4;
+
     Upgrade {
-        flush_threshold: DEFAULT_FRAME_SIZE * 2, // 8 KB same as tokio_websockets.
-        frame_size: DEFAULT_FRAME_SIZE * 4,      // 16 KB the max size of an HTTP/2 data frame.
+        frame_size,
+        flush_threshold: frame_size,
         max_payload_size: None,
         on_upgrade: Arc::new(move |socket, request| Box::pin(upgraded(socket, request))),
     }

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -23,7 +23,6 @@ use crate::middleware::{BoxFuture, Middleware};
 use crate::next::Next;
 use crate::request::{OwnedPathParams, PathParam, QueryParam, Request};
 use crate::response::Response;
-use crate::response::body::STANDARD_FRAME_LEN;
 
 pub use tokio_websockets::CloseCode;
 
@@ -93,10 +92,12 @@ where
     F: Fn(Channel, Context<State>) -> R + Send + Sync + 'static,
     R: Future<Output = Result<(), Error>> + Send + Sync + 'static,
 {
+    let flush_threshold = DEFAULT_FRAME_SIZE * 4;
+
     Upgrade {
-        flush_threshold: STANDARD_FRAME_LEN,
+        flush_threshold,
         frame_size: DEFAULT_FRAME_SIZE,
-        max_payload_size: Some(STANDARD_FRAME_LEN),
+        max_payload_size: Some(flush_threshold),
         on_upgrade: Arc::new(move |socket, request| Box::pin(upgraded(socket, request))),
     }
 }

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -23,7 +23,6 @@ use crate::middleware::{BoxFuture, Middleware};
 use crate::next::Next;
 use crate::request::{OwnedPathParams, PathParam, QueryParam, Request};
 use crate::response::Response;
-use crate::response::body::MAX_FRAME_SIZE;
 
 pub use tokio_websockets::CloseCode;
 


### PR DESCRIPTION
Caps the frame size at the maximum size of a data frame as defined by the HTTP/2 spec.